### PR TITLE
Switch to pytest for running unittests.  Clean up some warnings.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ create_superuser:
 	docker exec -t registrar-app bash -c 'echo "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser(\"edx\", \"edx@example.com\",\"edx\")" | python manage.py shell'
 
 
-# The followeing targets must be build from within the Docker container,
+# The followeing targets must be built from within the Docker container,
 # which can be accessed using `make shell` after running `make up`.
 
 upgrade: piptools
@@ -97,9 +97,12 @@ requirements:
 prod-requirements:
 	pip-sync -q requirements.txt
 
+coverage: clean
+	pytest --cov-report html
+	$(BROWSER) htmlcov/index.html
+
 test: clean
-	coverage run ./manage.py test registrar --settings=registrar.settings.test
-	coverage report
+	pytest
 
 quality:
 	pycodestyle registrar *.py
@@ -109,7 +112,7 @@ pii_check:
 	DJANGO_SETTINGS_MODULE=registrar.settings.test \
 	code_annotations django_find_annotations --config_file .pii_annotations.yml --lint --report --coverage
 
-validate: test quality pii_check
+validate: coverage quality pii_check
 
 migrate:
 	python manage.py migrate

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = registrar.settings.test
+addopts = --cov registrar --cov-report term-missing --cov-report xml
+norecursedirs = .* docs requirements

--- a/registrar/apps/api/urls.py
+++ b/registrar/apps/api/urls.py
@@ -6,6 +6,8 @@ contain namespaces for the active versions of the API.
 """
 from django.conf.urls import url, include
 
+
+app_name = 'api'
 urlpatterns = [
-    url(r'^v1/', include('registrar.apps.api.v1.urls', namespace='v1')),
+    url(r'^v1/', include('registrar.apps.api.v1.urls')),
 ]

--- a/registrar/apps/api/v1/urls.py
+++ b/registrar/apps/api/v1/urls.py
@@ -6,4 +6,5 @@ from rest_framework import routers
 from .views import ProgramEnrollmentView
 
 
+app_name = 'v1'
 urlpatterns = []

--- a/registrar/apps/core/tests/test_views.py
+++ b/registrar/apps/core/tests/test_views.py
@@ -3,7 +3,7 @@
 from django.db import DatabaseError
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase
 from django.test.utils import override_settings
 import mock

--- a/registrar/settings/base.py
+++ b/registrar/settings/base.py
@@ -43,7 +43,7 @@ PROJECT_APPS = (
 INSTALLED_APPS += THIRD_PARTY_APPS
 INSTALLED_APPS += PROJECT_APPS
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',

--- a/registrar/settings/test.py
+++ b/registrar/settings/test.py
@@ -3,21 +3,6 @@ import os
 from registrar.settings.base import *
 
 
-# TEST SETTINGS
-INSTALLED_APPS += (
-    'django_nose',
-)
-
-TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
-
-NOSE_ARGS = [
-    '--with-ignore-docstrings',
-    '--logging-level=DEBUG',
-]
-
-# END TEST SETTINGS
-
-
 # IN-MEMORY TEST DATABASE
 DATABASES = {
     'default': {

--- a/registrar/urls.py
+++ b/registrar/urls.py
@@ -26,7 +26,7 @@ from registrar.apps.core import views as core_views
 admin.autodiscover()
 
 urlpatterns = auth_urlpatterns + [
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^admin/', admin.site.urls),
     url(r'^api/', include('registrar.apps.api.urls', namespace='api')),
     url(r'^api-docs/', get_swagger_view(title='registrar API')),
     # Use the same auth views for all logins, including those originating from the browseable API.

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -6,6 +6,8 @@
 #
 alabaster==0.7.12         # via sphinx
 astroid==1.5.3            # via edx-lint, pylint, pylint-celery
+atomicwrites==1.3.0       # via pytest
+attrs==18.2.0             # via pytest
 babel==2.6.0              # via sphinx
 cached-property==1.5.1    # via docker-compose
 certifi==2018.11.29       # via requests
@@ -22,7 +24,6 @@ django-dynamic-fixture==2.0.0
 django-extensions==2.1.5
 django-model-utils==3.1.2
 django-mysql==2.4.1
-django-nose==1.4.6
 django-rest-swagger==2.2.0
 django-simple-history==2.7.0
 django-waffle==0.15.1
@@ -51,14 +52,15 @@ lazy-object-proxy==1.3.1  # via astroid
 markupsafe==1.1.0         # via jinja2
 mccabe==0.6.1             # via pylint
 mock==2.0.0
+more-itertools==5.0.0     # via pytest
 mysqlclient==1.3.14
-nose-ignore-docstring==0.2
-nose==1.3.7               # via django-nose
 oauthlib==3.0.1           # via requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via django-rest-swagger
 path.py==11.5.0           # via edx-i18n-tools
 pbr==5.1.2                # via mock, stevedore
+pluggy==0.8.1             # via pytest
 polib==1.1.0              # via edx-i18n-tools
+py==1.7.0                 # via pytest
 pycodestyle==2.5.0
 pycryptodomex==3.7.3      # via pyjwkest
 pygments==2.3.1           # via sphinx
@@ -68,6 +70,9 @@ pylint-celery==0.3        # via edx-lint
 pylint-django==0.7.2      # via edx-lint
 pylint-plugin-utils==0.4  # via pylint-celery, pylint-django
 pylint==1.7.6             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pytest-cov==2.6.1
+pytest-django==3.4.7
+pytest==4.2.0             # via pytest-cov, pytest-django
 python-slugify==1.2.6     # via transifex-client
 python3-openid==3.1.0     # via social-auth-core
 pytz==2018.9
@@ -75,7 +80,7 @@ pyyaml==3.13              # via code-annotations, docker-compose, edx-i18n-tools
 requests-oauthlib==1.2.0  # via social-auth-core
 requests==2.20.1          # via coreapi, docker, docker-compose, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core, sphinx, transifex-client
 simplejson==3.16.0        # via django-rest-swagger
-six==1.11.0               # via astroid, django-dynamic-fixture, django-extensions, docker, docker-compose, docker-pycreds, dockerpty, edx-auth-backends, edx-i18n-tools, edx-lint, edx-sphinx-theme, mock, pyjwkest, pylint, social-auth-app-django, social-auth-core, sphinx, stevedore, transifex-client, websocket-client
+six==1.11.0               # via astroid, django-dynamic-fixture, django-extensions, docker, docker-compose, docker-pycreds, dockerpty, edx-auth-backends, edx-i18n-tools, edx-lint, edx-sphinx-theme, mock, more-itertools, pyjwkest, pylint, pytest, social-auth-app-django, social-auth-core, sphinx, stevedore, transifex-client, websocket-client
 slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==1.2.1    # via sphinx
 social-auth-app-django==1.2.0  # via edx-auth-backends

--- a/requirements/monitoring/requirements.txt
+++ b/requirements/monitoring/requirements.txt
@@ -6,6 +6,8 @@
 #
 alabaster==0.7.12         # via sphinx
 astroid==1.5.3            # via edx-lint, pylint, pylint-celery
+atomicwrites==1.3.0       # via pytest
+attrs==18.2.0             # via pytest
 babel==2.6.0              # via sphinx
 cached-property==1.5.1    # via docker-compose
 certifi==2018.11.29       # via requests
@@ -22,7 +24,6 @@ django-dynamic-fixture==2.0.0
 django-extensions==2.1.5
 django-model-utils==3.1.2
 django-mysql==2.4.1
-django-nose==1.4.6
 django-rest-swagger==2.2.0
 django-simple-history==2.7.0
 django-waffle==0.15.1
@@ -54,15 +55,16 @@ lazy-object-proxy==1.3.1  # via astroid
 markupsafe==1.1.0         # via jinja2
 mccabe==0.6.1             # via pylint
 mock==2.0.0
+more-itertools==5.0.0     # via pytest
 mysqlclient==1.3.14
 newrelic==4.12.0.113
-nose-ignore-docstring==0.2
-nose==1.3.7               # via django-nose
 oauthlib==3.0.1           # via requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via django-rest-swagger
 path.py==11.5.0           # via edx-i18n-tools
 pbr==5.1.2                # via mock, stevedore
+pluggy==0.8.1             # via pytest
 polib==1.1.0              # via edx-i18n-tools
+py==1.7.0                 # via pytest
 pycodestyle==2.5.0
 pycryptodomex==3.7.3      # via pyjwkest
 pygments==2.3.1           # via sphinx
@@ -72,6 +74,9 @@ pylint-celery==0.3        # via edx-lint
 pylint-django==0.7.2      # via edx-lint
 pylint-plugin-utils==0.4  # via pylint-celery, pylint-django
 pylint==1.7.6             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pytest-cov==2.6.1
+pytest-django==3.4.7
+pytest==4.2.0             # via pytest-cov, pytest-django
 python-slugify==1.2.6     # via transifex-client
 python3-openid==3.1.0     # via social-auth-core
 pytz==2018.9
@@ -79,7 +84,7 @@ pyyaml==3.13
 requests-oauthlib==1.2.0  # via social-auth-core
 requests==2.20.1          # via coreapi, docker, docker-compose, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core, sphinx, transifex-client
 simplejson==3.16.0        # via django-rest-swagger
-six==1.11.0               # via astroid, django-dynamic-fixture, django-extensions, docker, docker-compose, docker-pycreds, dockerpty, edx-auth-backends, edx-i18n-tools, edx-lint, edx-sphinx-theme, mock, pyjwkest, pylint, social-auth-app-django, social-auth-core, sphinx, stevedore, transifex-client, websocket-client
+six==1.11.0               # via astroid, django-dynamic-fixture, django-extensions, docker, docker-compose, docker-pycreds, dockerpty, edx-auth-backends, edx-i18n-tools, edx-lint, edx-sphinx-theme, mock, more-itertools, pyjwkest, pylint, pytest, social-auth-app-django, social-auth-core, sphinx, stevedore, transifex-client, websocket-client
 slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==1.2.1    # via sphinx
 social-auth-app-django==1.2.0  # via edx-auth-backends

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -3,9 +3,9 @@
 
 coverage
 django-dynamic-fixture
-django-nose
 code-annotations
 edx-lint
 mock
-nose-ignore-docstring
 pycodestyle
+pytest-cov
+pytest-django

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,6 +5,8 @@
 #    pip-compile --output-file requirements/test.txt requirements/test.in
 #
 astroid==1.5.3            # via edx-lint, pylint, pylint-celery
+atomicwrites==1.3.0       # via pytest
+attrs==18.2.0             # via pytest
 certifi==2018.11.29       # via requests
 chardet==3.0.4            # via requests
 click-log==0.1.8          # via edx-lint
@@ -18,7 +20,6 @@ django-dynamic-fixture==2.0.0
 django-extensions==2.1.5
 django-model-utils==3.1.2
 django-mysql==2.4.1
-django-nose==1.4.6
 django-rest-swagger==2.2.0
 django-simple-history==2.7.0
 django-waffle==0.15.1
@@ -36,12 +37,13 @@ lazy-object-proxy==1.3.1  # via astroid
 markupsafe==1.1.0         # via jinja2
 mccabe==0.6.1             # via pylint
 mock==2.0.0
+more-itertools==5.0.0     # via pytest
 mysqlclient==1.3.14
-nose-ignore-docstring==0.2
-nose==1.3.7               # via django-nose
 oauthlib==3.0.1           # via requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via django-rest-swagger
 pbr==5.1.2                # via mock, stevedore
+pluggy==0.8.1             # via pytest
+py==1.7.0                 # via pytest
 pycodestyle==2.5.0
 pycryptodomex==3.7.3      # via pyjwkest
 pyjwkest==1.4.0           # via social-auth-core
@@ -50,13 +52,16 @@ pylint-celery==0.3        # via edx-lint
 pylint-django==0.7.2      # via edx-lint
 pylint-plugin-utils==0.4  # via pylint-celery, pylint-django
 pylint==1.7.6             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pytest-cov==2.6.1
+pytest-django==3.4.7
+pytest==4.2.0             # via pytest-cov, pytest-django
 python3-openid==3.1.0     # via social-auth-core
 pytz==2018.9
 pyyaml==3.13              # via code-annotations
 requests-oauthlib==1.2.0  # via social-auth-core
 requests==2.21.0          # via coreapi, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 simplejson==3.16.0        # via django-rest-swagger
-six==1.12.0               # via astroid, django-dynamic-fixture, django-extensions, edx-auth-backends, edx-lint, mock, pyjwkest, pylint, social-auth-app-django, social-auth-core, stevedore
+six==1.12.0               # via astroid, django-dynamic-fixture, django-extensions, edx-auth-backends, edx-lint, mock, more-itertools, pyjwkest, pylint, pytest, social-auth-app-django, social-auth-core, stevedore
 slumber==0.7.1            # via edx-rest-api-client
 social-auth-app-django==1.2.0  # via edx-auth-backends
 social-auth-core[openidconnect]==1.7.0  # via edx-auth-backends, social-auth-app-django


### PR DESCRIPTION
## Description
* Removes nose in favor of pytest.
* Cleans up some Django deprecations warnings.
* https://openedx.atlassian.net/browse/EDUCATOR-4041

