### PR TITLE
Remove public_url_root, which is introducing login errors

### DIFF
--- a/registrar/settings/base.py
+++ b/registrar/settings/base.py
@@ -177,7 +177,6 @@ SOCIAL_AUTH_EDX_OAUTH2_KEY = 'replace-me'
 SOCIAL_AUTH_EDX_OAUTH2_SECRET = 'replace-me'
 SOCIAL_AUTH_EDX_OAUTH2_ENDPOINT = 'replace-me'
 SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT = 'replace-me'
-SOCIAL_AUTH_EDX_OAUTH2_PUBLIC_URL_ROOT = 'replace-me'
 SOCIAL_AUTH_EDX_OAUTH2_LOGOUT_URL = 'replace-me'
 
 # These values are used to make server to server rest api call. Should be fed into edx_rest_api_client

--- a/registrar/settings/local.py
+++ b/registrar/settings/local.py
@@ -54,10 +54,6 @@ SOCIAL_AUTH_REDIRECT_IS_HTTPS = False
 # Set these to the correct values for your OAuth2/OpenID Connect provider (e.g., devstack)
 SOCIAL_AUTH_EDX_OAUTH2_KEY = 'registrar-sso-key'
 SOCIAL_AUTH_EDX_OAUTH2_SECRET = 'registrar-sso-secret'
-SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT = 'http://edx.devstack.lms:18000'
-SOCIAL_AUTH_EDX_OAUTH2_PUBLIC_URL_ROOT = 'http://localhost:18000'
-SOCIAL_AUTH_EDX_OAUTH2_LOGOUT_URL = 'http://localhost:18000/logout'
-SOCIAL_AUTH_EDX_OAUTH2_ISSUER = SOCIAL_AUTH_EDX_OAUTH2_PUBLIC_URL_ROOT
 
 # OAuth2 variables specific to backend service API calls.
 BACKEND_SERVICE_EDX_OAUTH2_KEY = 'registrar-backend-service-key'
@@ -65,8 +61,6 @@ BACKEND_SERVICE_EDX_OAUTH2_SECRET = 'registrar-backend-service-secret'
 
 ENABLE_AUTO_AUTH = True
 
-LMS_BASE_URL = 'http://edx.devstack.lms:18000'
-DISCOVERY_BASE_URL = 'http://edx.devstack.discovery:18381'
 
 # LOGGING
 LOGGING = get_logger_config(debug=DEBUG, dev_env=True, local_loglevel='DEBUG')


### PR DESCRIPTION
## Description

According to the conversation in slack channel #hackathon_depr_dop, my change to configuration (https://github.com/edx/configuration/pull/5054) is reverted, and we need this on registrar to make oauth2 work. 