### PR TITLE
Bump to Django>=1.11.19

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,5 +1,5 @@
 celery
-django==1.11.18
+django==1.11.20
 django-extensions
 django-model-utils
 django-mysql

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -32,7 +32,7 @@ django-mysql==3.0.0.post1
 django-rest-swagger==2.2.0
 django-simple-history==2.7.0
 django-waffle==0.15.1
-django==1.11.18
+django==1.11.20
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.9.2
 docker-compose==1.23.2
@@ -44,7 +44,7 @@ docutils==0.14            # via sphinx
 edx-auth-backends==1.2.2
 edx-django-release-util==0.3.1
 edx-django-utils==1.0.3   # via edx-drf-extensions
-edx-drf-extensions==2.0.1
+edx-drf-extensions==2.1.0
 edx-i18n-tools==0.4.8
 edx-lint==1.1.1
 edx-opaque-keys==0.4.4    # via edx-drf-extensions
@@ -117,7 +117,7 @@ transifex-client==0.13.6
 unidecode==1.0.23         # via python-slugify
 uritemplate==3.0.0        # via coreapi
 urllib3==1.23             # via requests, transifex-client
-vine==1.2.0               # via amqp
+vine==1.3.0               # via amqp
 websocket-client==0.55.0  # via docker, docker-compose
 wrapt==1.11.1             # via astroid
 zipp==0.3.3               # via importlib-metadata

--- a/requirements/monitoring/requirements.txt
+++ b/requirements/monitoring/requirements.txt
@@ -32,7 +32,7 @@ django-mysql==3.0.0.post1
 django-rest-swagger==2.2.0
 django-simple-history==2.7.0
 django-waffle==0.15.1
-django==1.11.18
+django==1.11.20
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.9.2
 docker-compose==1.23.2
@@ -44,7 +44,7 @@ docutils==0.14            # via sphinx
 edx-auth-backends==1.2.2
 edx-django-release-util==0.3.1
 edx-django-utils==1.0.3   # via edx-drf-extensions
-edx-drf-extensions==2.0.1
+edx-drf-extensions==2.1.0
 edx-i18n-tools==0.4.8
 edx-lint==1.1.1
 edx-opaque-keys==0.4.4    # via edx-drf-extensions
@@ -120,7 +120,7 @@ transifex-client==0.13.6
 unidecode==1.0.23         # via python-slugify
 uritemplate==3.0.0        # via coreapi
 urllib3==1.23             # via requests, transifex-client
-vine==1.2.0               # via amqp
+vine==1.3.0               # via amqp
 websocket-client==0.55.0  # via docker, docker-compose
 wrapt==1.11.1             # via astroid
 zipp==0.3.3               # via importlib-metadata

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -19,13 +19,13 @@ django-mysql==3.0.0.post1
 django-rest-swagger==2.2.0
 django-simple-history==2.7.0
 django-waffle==0.15.1
-django==1.11.18
+django==1.11.20
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.9.2
 edx-auth-backends==1.2.2
 edx-django-release-util==0.3.1
 edx-django-utils==1.0.3   # via edx-drf-extensions
-edx-drf-extensions==2.0.1
+edx-drf-extensions==2.1.0
 edx-opaque-keys==0.4.4    # via edx-drf-extensions
 edx-rest-api-client==1.9.2
 future==0.17.1            # via pyjwkest
@@ -64,4 +64,4 @@ social-auth-core[openidconnect]==1.7.0  # via edx-auth-backends, social-auth-app
 stevedore==1.30.1         # via edx-opaque-keys
 uritemplate==3.0.0        # via coreapi
 urllib3==1.24.1           # via requests
-vine==1.2.0               # via amqp
+vine==1.3.0               # via amqp

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -28,13 +28,13 @@ django-mysql==3.0.0.post1
 django-rest-swagger==2.2.0
 django-simple-history==2.7.0
 django-waffle==0.15.1
-django==1.11.18
+django==1.11.20
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.9.2
 edx-auth-backends==1.2.2
 edx-django-release-util==0.3.1
 edx-django-utils==1.0.3   # via edx-drf-extensions
-edx-drf-extensions==2.0.1
+edx-drf-extensions==2.1.0
 edx-lint==1.1.1
 edx-opaque-keys==0.4.4    # via edx-drf-extensions
 edx-rest-api-client==1.9.2
@@ -92,5 +92,5 @@ stevedore==1.30.1         # via code-annotations, edx-opaque-keys
 text-unidecode==1.2       # via faker, python-slugify
 uritemplate==3.0.0        # via coreapi
 urllib3==1.24.1           # via requests
-vine==1.2.0               # via amqp
+vine==1.3.0               # via amqp
 wrapt==1.11.1             # via astroid


### PR DESCRIPTION
This will address the Django-related security alerts on this repo.
