### PR TITLE
Bump pyyaml to 5.1

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -16,5 +16,6 @@ edx-rest-api-client==1.9.2
 edx-auth-backends
 mysqlclient==1.3.14  # have to stay on this until Django 2
 pytz
+pyyaml==5.1
 
 python-memcached

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -12,12 +12,12 @@ attrs==19.1.0             # via pytest
 babel==2.6.0              # via sphinx
 billiard==3.5.0.5         # via celery
 cached-property==1.5.1    # via docker-compose
-celery==4.2.1
+celery==4.2.2
 certifi==2019.3.9         # via requests
 chardet==3.0.4            # via requests
 click-log==0.1.8          # via edx-lint
 click==7.0                # via click-log, code-annotations, edx-lint
-code-annotations==0.3
+code-annotations==0.3.1
 coreapi==2.3.3            # via django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
 coverage==4.5.3
@@ -37,7 +37,7 @@ djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.9.2
 docker-compose==1.23.2
 docker-pycreds==0.4.0     # via docker
-docker==3.7.0             # via docker-compose
+docker==3.7.1             # via docker-compose
 dockerpty==0.4.1          # via docker-compose
 docopt==0.6.2             # via docker-compose
 docutils==0.14            # via sphinx
@@ -60,7 +60,7 @@ isort==4.3.15             # via pylint
 itypes==1.1.0             # via coreapi
 jinja2==2.10              # via code-annotations, coreschema, sphinx
 jsonschema==2.6.0         # via docker-compose
-kombu==4.4.0              # via celery
+kombu==4.3.0              # via celery
 lazy-object-proxy==1.3.1  # via astroid
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via pylint
@@ -95,7 +95,7 @@ python-memcached==1.59
 python-slugify==1.2.6     # via code-annotations, transifex-client
 python3-openid==3.1.0     # via social-auth-core
 pytz==2018.9
-pyyaml==3.13              # via code-annotations, docker-compose, edx-django-release-util, edx-i18n-tools
+pyyaml==5.1
 requests-oauthlib==1.2.0  # via social-auth-core
 requests==2.20.1          # via coreapi, docker, docker-compose, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, responses, slumber, social-auth-core, sphinx, transifex-client
 responses==0.10.6

--- a/requirements/monitoring/requirements.txt
+++ b/requirements/monitoring/requirements.txt
@@ -12,12 +12,12 @@ attrs==19.1.0             # via pytest
 babel==2.6.0              # via sphinx
 billiard==3.5.0.5         # via celery
 cached-property==1.5.1    # via docker-compose
-celery==4.2.1
+celery==4.2.2
 certifi==2019.3.9         # via requests
 chardet==3.0.4            # via requests
 click-log==0.1.8          # via edx-lint
 click==7.0                # via click-log, code-annotations, edx-lint
-code-annotations==0.3
+code-annotations==0.3.1
 coreapi==2.3.3            # via django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
 coverage==4.5.3
@@ -37,7 +37,7 @@ djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.9.2
 docker-compose==1.23.2
 docker-pycreds==0.4.0     # via docker
-docker==3.7.0             # via docker-compose
+docker==3.7.1             # via docker-compose
 dockerpty==0.4.1          # via docker-compose
 docopt==0.6.2             # via docker-compose
 docutils==0.14            # via sphinx
@@ -63,7 +63,7 @@ isort==4.3.15             # via pylint
 itypes==1.1.0             # via coreapi
 jinja2==2.10              # via code-annotations, coreschema, sphinx
 jsonschema==2.6.0         # via docker-compose
-kombu==4.4.0              # via celery
+kombu==4.3.0              # via celery
 lazy-object-proxy==1.3.1  # via astroid
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via pylint
@@ -98,7 +98,7 @@ python-memcached==1.59
 python-slugify==1.2.6     # via code-annotations, transifex-client
 python3-openid==3.1.0     # via social-auth-core
 pytz==2018.9
-pyyaml==3.13
+pyyaml==5.1
 requests-oauthlib==1.2.0  # via social-auth-core
 requests==2.20.1          # via coreapi, docker, docker-compose, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, responses, slumber, social-auth-core, sphinx, transifex-client
 responses==0.10.6

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -6,7 +6,7 @@
 #
 amqp==2.4.2               # via kombu
 billiard==3.5.0.5         # via celery
-celery==4.2.1
+celery==4.2.2
 certifi==2019.3.9         # via requests
 chardet==3.0.4            # via requests
 coreapi==2.3.3            # via django-rest-swagger, openapi-codec
@@ -35,7 +35,7 @@ gunicorn==19.9.0
 idna==2.8                 # via requests
 itypes==1.1.0             # via coreapi
 jinja2==2.10              # via coreschema
-kombu==4.4.0              # via celery
+kombu==4.3.0              # via celery
 markupsafe==1.1.1         # via jinja2
 mysqlclient==1.3.14
 newrelic==4.14.0.115      # via edx-django-utils

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -3,7 +3,7 @@
 
 coverage
 django-dynamic-fixture
-code-annotations
+code-annotations>=0.3.1
 edx-lint
 factory_boy
 Faker

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -9,12 +9,12 @@ astroid==1.5.3            # via edx-lint, pylint, pylint-celery
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 billiard==3.5.0.5         # via celery
-celery==4.2.1
+celery==4.2.2
 certifi==2019.3.9         # via requests
 chardet==3.0.4            # via requests
 click-log==0.1.8          # via edx-lint
 click==7.0                # via click-log, code-annotations, edx-lint
-code-annotations==0.3
+code-annotations==0.3.1
 coreapi==2.3.3            # via django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
 coverage==4.5.3
@@ -45,7 +45,7 @@ idna==2.8                 # via requests
 isort==4.3.15             # via pylint
 itypes==1.1.0             # via coreapi
 jinja2==2.10              # via code-annotations, coreschema
-kombu==4.4.0              # via celery
+kombu==4.3.0              # via celery
 lazy-object-proxy==1.3.1  # via astroid
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via pylint


### PR DESCRIPTION
This will get rid of the pyyaml security alerts on this repo.

Note: I had to manually bump the `local.txt` and `monitoring/requirements.txt` versions to 5.1, since docker-compose 1.23.2 still has a pyyaml dependency pinned to version 3.12.  This shouldn't affect any production code, it would only affect running docker-compose through your local registrar directory, and I expect that would work fine, too, since the changes in pyyaml==5.1 are meant to be backward-compatible.
