### PR TITLE
EDUCATOR-4207 | Update JWT_AUTH setting instead of overwriting.

### DIFF
--- a/registrar/settings/production.py
+++ b/registrar/settings/production.py
@@ -12,9 +12,22 @@ ALLOWED_HOSTS = ['*']
 
 LOGGING = get_logger_config()
 
+# Keep track of the names of settings that represent dicts. Instead of overriding the values in base.py,
+# the values read from disk should UPDATE the pre-configured dicts.
+DICT_UPDATE_KEYS = ('JWT_AUTH',)
+
 CONFIG_FILE = get_env_setting('REGISTRAR_CFG')
 with open(CONFIG_FILE, encoding='utf-8') as f:
     config_from_yaml = yaml.load(f)
+
+    # Remove the items that should be used to update dicts, and apply them separately rather
+    # than pumping them into the local vars.
+    dict_updates = {key: config_from_yaml.pop(key, None) for key in DICT_UPDATE_KEYS}
+
+    for key, value in dict_updates.items():
+        if value:
+            vars()[key].update(value)
+
     vars().update(config_from_yaml)
 
 DB_OVERRIDES = dict(


### PR DESCRIPTION
Fixes https://openedx.atlassian.net/browse/EDUCATOR-4207

Thanks to Doug, who noticed that we don't do the same thing that course-discovery does in its `production.py`, which is to ensure that we only update the keys of the `JWT_AUTH` dict, instead of overwriting it completely from the yaml config.
