### PR TITLE
EDUCATOR-4175 | Program enrollment v0 GET resource.

### DIFF
--- a/registrar/apps/api/serializers.py
+++ b/registrar/apps/api/serializers.py
@@ -62,3 +62,12 @@ class CourseRunSerializer(serializers.Serializer):
     course_id = serializers.CharField(source='key')
     course_title = serializers.CharField(source='title')
     course_url = serializers.CharField(source='marketing_url')
+
+
+class AcceptedJobSerializer(serializers.Serializer):
+    """
+    Serializer for data about the invocation of a
+    Django User Task.
+    """
+    job_id = serializers.UUIDField()
+    job_url = serializers.CharField()

--- a/registrar/apps/api/v0/data.py
+++ b/registrar/apps/api/v0/data.py
@@ -28,6 +28,11 @@ FakeCourseRun = namedtuple('FakeCourseRun', [
     'marketing_url',
 ])
 
+FakeTask = namedtuple('FakeTask', [
+    'job_id',
+    'job_url'
+])
+
 
 def _program(org, program_key, title):
     """
@@ -152,4 +157,15 @@ FAKE_PROGRAM_COURSE_RUNS = {
     ]
     for program_key, course_run_keys
     in _FAKE_PROGRAM_COURSE_RUN_KEY_BODIES.items()
+}
+
+
+def _fake_job_id(index):
+    return 'aaaaaaaa-bbbb-cccc-dddd-{}'.format(str(index).zfill(12))
+
+
+FAKE_TASK_IDS_BY_PROGRAM = {
+    program.key: _fake_job_id(index)
+    for index, program in enumerate(FAKE_PROGRAMS)
+    if program.managing_organization.enrollments_readable
 }

--- a/registrar/apps/api/v0/tests/test_views.py
+++ b/registrar/apps/api/v0/tests/test_views.py
@@ -266,3 +266,38 @@ class MockProgramEnrollmentViewTests(MockAPITestBase, MockAPICommonTests):
         )
 
         self.assertEqual(response.status_code, 413)
+
+
+class MockProgramEnrollmentRetrievalTest(MockAPITestBase, MockAPICommonTests):
+    """
+    Tests for the mock retrieval of program enrollments data via fake async jobs.
+    """
+    READABLE_ENROLLMENT_PROGRAM_KEYS = [
+        'dvi-masters-polysci',
+        'dvi-mba',
+        'hhp-masters-ce',
+        'hhp-masters-theo-physics',
+        'hhp-masters-enviro',
+    ]
+    UNREADABLE_ENROLLMENT_PROGRAM_KEYS = [
+        'upz-masters-ancient-history',
+        'bcc-masters-english-lit',
+    ]
+
+    def test_unauthenticated(self):
+        response = self.get('programs/upz-masters-ancient-history/enrollments/', None)
+        self.assertEqual(401, response.status_code)
+
+    def test_program_unauthorized(self):
+        for program_key in self.UNREADABLE_ENROLLMENT_PROGRAM_KEYS:
+            response = self.get('programs/{}/enrollments/'.format(program_key), self.user)
+            self.assertEqual(403, response.status_code)
+
+    def test_program_not_found(self):
+        response = self.get('programs/not-a-program/enrollments/', self.user)
+        self.assertEqual(404, response.status_code, 404)
+
+    def test_program_retrieval_success(self):
+        for program_key in self.READABLE_ENROLLMENT_PROGRAM_KEYS:
+            response = self.get('programs/{}/enrollments/'.format(program_key), self.user)
+            self.assertEqual(202, response.status_code)

--- a/registrar/apps/api/v1/tests/test_views.py
+++ b/registrar/apps/api/v1/tests/test_views.py
@@ -16,7 +16,7 @@ from registrar.apps.core.tests.factories import (
     OrganizationGroupFactory,
     UserFactory,
 )
-from registrar.apps.enrollments.tests.factories import ProgramFactory  # pylint: disable=no-name-in-module
+from registrar.apps.enrollments.tests.factories import ProgramFactory
 
 
 def mock_oauth_login(fn):

--- a/registrar/apps/enrollments/tests.py
+++ b/registrar/apps/enrollments/tests.py
@@ -1,3 +1,0 @@
-"""
-Tests for the enrollments app.
-"""


### PR DESCRIPTION
https://openedx.atlassian.net/browse/EDUCATOR-4175

* Introduces a `FakeTask` class.
* Associates fake task ids with any fake program with readable enrollments data.
* Exposes GET method in the `MockProgramEnrollmentView`
