### PR TITLE
 Fix API doc permission-checking

### DIFF
--- a/registrar/settings/base.py
+++ b/registrar/settings/base.py
@@ -224,7 +224,7 @@ JWT_AUTH = {
 EXTRA_SCOPE = ['permissions']
 
 # TODO Set this to another (non-staff, ideally) path.
-LOGIN_REDIRECT_URL = '/admin/'
+LOGIN_REDIRECT_URL = '/api-docs/'
 # END AUTHENTICATION CONFIGURATION
 
 

--- a/registrar/urls.py
+++ b/registrar/urls.py
@@ -31,7 +31,7 @@ app_name = 'registrar'
 urlpatterns = oauth2_urlpatterns + [
     url(r'^admin/', admin.site.urls),
     url(r'^api/', include(api_urls)),
-    url(r'^api-docs/', get_swagger_view(title='registrar API')),
+    url(r'^api-docs/', get_swagger_view(title='registrar API'), name='api-docs'),
     # Use the same auth views for all logins, including those originating from the browseable API.
     url(r'^api-auth/', include(oauth2_urlpatterns)),
     url(r'^auto_auth/$', core_views.AutoAuth.as_view(), name='auto_auth'),


### PR DESCRIPTION
Swagger API docs broke when I implemented permissions. This PR fixes that.

Also, it makes `/login` by default redirect to `/api-docs/` instead of `/admin`, because most users who go straight to `/login` would rather see documentation than a 403.

@edx/masters-neem 