### PR TITLE
patch course enrollments

### DIFF
--- a/registrar/apps/api/serializers.py
+++ b/registrar/apps/api/serializers.py
@@ -74,6 +74,16 @@ class CourseEnrollmentRequestSerializer(serializers.Serializer):
     status = serializers.ChoiceField(allow_blank=False, choices=STATUS_CHOICES)
 
 
+class CourseEnrollmentModificationRequestSerializer(serializers.Serializer):
+    """
+    Serializer for a request to modify a LearnerCourseEnrollment
+    """
+    STATUS_CHOICES = ['pending', 'enrolled', 'withdrawn']
+
+    student_key = serializers.CharField(allow_blank=False)
+    status = serializers.ChoiceField(allow_blank=False, choices=STATUS_CHOICES)
+
+
 class CourseRunSerializer(serializers.Serializer):
     """
     Serializer for a course run returned from the

--- a/registrar/apps/api/v0/tests/test_views.py
+++ b/registrar/apps/api/v0/tests/test_views.py
@@ -487,3 +487,93 @@ class MockCourseEnrollmentViewTests(MockAPITestBase, MockAPICommonTests):
         response = self.post(self.path, post_data, self.user)
         self.assertEqual(response.status_code, 422)
         self.assertIn('invalid enrollment record', response.data)
+
+
+@ddt.ddt
+class MockCourseEnrollmentModificationViewTests(MockAPITestBase, MockAPICommonTests):
+    """ Tests for mock modify course enrollment """
+
+    path_suffix = 'programs/hhp-masters-ce/courses/course-v1:HHPx+MA-102+Fall2050/enrollments/'
+
+    def learner_modification(self, student_key, status):
+        return {"student_key": student_key, "status": status}
+
+    def test_200_ok(self):
+        patch_data = [
+            self.learner_modification("A", "enrolled"),
+            self.learner_modification("B", "pending"),
+            self.learner_modification("C", "withdrawn")
+        ]
+        response = self.patch(self.path, patch_data, self.user)
+        self.assertEqual(200, response.status_code)
+        self.assertDictEqual(
+            {
+                "A": "enrolled",
+                "B": "pending",
+                "C": "withdrawn",
+            },
+            response.data
+        )
+
+    def test_207_multi_status(self):
+        """ Also tests duplicates """
+        patch_data = [
+            self.learner_modification("A", "enrolled"),
+            self.learner_modification("A", "enrolled"),
+            self.learner_modification("B", "not-a-status"),
+            self.learner_modification("C", "enrolled"),
+        ]
+        response = self.patch(self.path, patch_data, self.user)
+        self.assertEqual(207, response.status_code)
+        self.assertDictEqual(
+            {
+                'A': 'duplicated',
+                'B': 'invalid-status',
+                'C': 'enrolled',
+            },
+            response.data
+        )
+
+    def test_403_forbidden(self):
+        path_403 = 'programs/dvi-masters-polysci/courses/course-v1:DVIx+GOV-200+Spring2050/enrollments/'
+        patch_data = [self.learner_modification("A", "enrolled")]
+        response = self.patch(path_403, patch_data, self.user)
+        self.assertEqual(403, response.status_code)
+
+    def test_413_payload_too_large(self):
+        patch_data = [self.learner_modification(str(i), "enrolled") for i in range(30)]
+        response = self.patch(self.path, patch_data, self.user)
+        self.assertEqual(413, response.status_code)
+
+    def test_404_not_found_program(self):
+        path_404 = 'programs/nonexistant-program/courses/course-v1:HHPx+MA-102+Fall2050/enrollments/'
+        patch_data = [self.learner_modification("A", "enrolled")]
+        response = self.patch(path_404, patch_data, self.user)
+        self.assertEqual(404, response.status_code)
+
+    @ddt.data(
+        "course-v1:HHPx+FAKE-3333+Spring1776",  # nonexistant
+        "course-v1:HHPx+PHYS-260+Spring2050"  # not in this program
+    )
+    def test_404_not_found_course(self, course):
+        path_404 = 'programs/hhp-masters-ce/courses/{}/enrollments/'.format(course)
+        patch_data = [self.learner_modification("A", "enrolled")]
+        response = self.patch(path_404, patch_data, self.user)
+        self.assertEqual(404, response.status_code)
+
+    def test_422_unprocessable_entity(self):
+        patch_data = [self.learner_modification('A', 'this-is-not-a-status')]
+        response = self.patch(self.path, patch_data, self.user)
+        self.assertEqual(422, response.status_code)
+        self.assertDictEqual({'A': 'invalid-status'}, response.data)
+
+    @ddt.data(
+        [{'status': 'enrolled'}],
+        [{'student_key': '000'}],
+        ["this isn't even a dict!"],
+        [{'student_key': '000', 'status': 'enrolled'}, "bad_data"],
+    )
+    def test_422_unprocessable_entity_bad_data(self, patch_data):
+        response = self.patch(self.path, patch_data, self.user)
+        self.assertEqual(response.status_code, 422)
+        self.assertIn('invalid enrollment record', response.data)

--- a/registrar/apps/api/v0/views.py
+++ b/registrar/apps/api/v0/views.py
@@ -26,6 +26,7 @@ from registrar.apps.api.serializers import (
     ProgramEnrollmentRequestSerializer,
     ProgramEnrollmentModificationRequestSerializer,
     CourseEnrollmentRequestSerializer,
+    CourseEnrollmentModificationRequestSerializer,
 )
 from registrar.apps.api.v0.data import (
     FAKE_ORG_DICT,
@@ -153,7 +154,10 @@ class MockProgramCourseListView(MockProgramSpecificViewMixin, ListAPIView):
 
 
 class EchoStatusesMixin(object):
-    """ Provides the validate_and_echo_statuses function """
+    """
+    Provides the validate_and_echo_statuses function
+    Classes that inherit from EchoStatusesMixin must implement get_serializer_class
+    """
 
     def validate_and_echo_statuses(self, request):
         """ Enroll up to 25 students in program/course """
@@ -304,7 +308,13 @@ class MockCourseEnrollmentView(APIView, MockProgramCourseSpecificViewMixin, Echo
     def get_serializer_class(self):
         if self.request.method == 'POST':
             return CourseEnrollmentRequestSerializer
+        elif self.request.method == 'PATCH':
+            return CourseEnrollmentModificationRequestSerializer
 
     def post(self, request, *args, **kwargs):
+        self.course  # trigger 404  # pylint: disable=pointless-statement
+        return self.validate_and_echo_statuses(request)
+
+    def patch(self, request, *args, **kwargs):  # pylint: disable=unused-argument
         self.course  # trigger 404  # pylint: disable=pointless-statement
         return self.validate_and_echo_statuses(request)


### PR DESCRIPTION
pointing at my previous branch for the sake of the diff

added an optional dict argument to validate_and_echo_statuses to allow us to return enrolled-processing as a status since enrolled is not a valid status to return from this endpoint