### PR TITLE
Fix browsable API page for GET program enrollments

### DIFF
--- a/registrar/apps/api/v0/views.py
+++ b/registrar/apps/api/v0/views.py
@@ -133,7 +133,7 @@ class MockProgramCourseListView(MockProgramSpecificViewMixin, ListAPIView):
             raise PermissionDenied()
 
 
-class MockProgramEnrollmentView(RetrieveAPIView, APIView, MockProgramSpecificViewMixin):
+class MockProgramEnrollmentView(APIView, MockProgramSpecificViewMixin):
     """
     A view for enrolling students in a program, or retrieving/modifying program enrollment data.
 
@@ -175,7 +175,6 @@ class MockProgramEnrollmentView(RetrieveAPIView, APIView, MockProgramSpecificVie
     """
     authentication_classes = (JwtAuthentication, SessionAuthentication)
     permission_classes = (IsAuthenticated,)
-    serializer_class = ProgramEnrollmentRequestSerializer
 
     def post(self, request, *args, **kwargs):
         return self.validate_and_echo_statuses(request, ProgramEnrollmentRequestSerializer)
@@ -231,7 +230,7 @@ class MockProgramEnrollmentView(RetrieveAPIView, APIView, MockProgramSpecificVie
         else:
             return Response(response)
 
-    def retrieve(self, request, *args, **kwargs):
+    def get(self, request, *args, **kwargs):
         """
         Submit a user task that retrieves program enrollment data.
         """


### PR DESCRIPTION
@edx/masters-neem 

This fixes a bug where `GET https://<registrar_path>/api/v0/<readable_program_key>/enrollments` with an `Accept: text/html` header (i.e., in a browser) causes a 500.

We were abusing DRF a bit by having a `retrieve` method that returned custom serialized data instead of a model serialized by `serializer_class`. It worked fine in our tests (and probably would have though an API client) but broke in the browsable API. This PR removes the `RetrieveAPIView` superclass, changes `retrieve` to `get`, and removes `serializer_class = ProgramEnrollmentRequestSerializer`. 

Takeaways: Don't use generic DRF ModelViews unless you're accepting or returning a model that is serialized by the `serializer_class`.