### PR TITLE
Include external service base url variable names in base settings.

### DIFF
--- a/registrar/settings/base.py
+++ b/registrar/settings/base.py
@@ -227,6 +227,10 @@ EXTRA_SCOPE = ['permissions']
 LOGIN_REDIRECT_URL = '/api-docs/'
 # END AUTHENTICATION CONFIGURATION
 
+# Other service locations
+LMS_BASE_URL = 'replace-me'
+DISCOVERY_BASE_URL = 'replace-me'
+
 
 # OPENEDX-SPECIFIC CONFIGURATION 
 PLATFORM_NAME = 'Your Platform Name Here'


### PR DESCRIPTION
## Description
https://openedx.atlassian.net/browse/EDUCATOR-4232

This change makes it really clear that `LMS_BASE_URL` and `DISCOVERY_BASE_URL` are required configuration variables in all environments (the changes from the configuration PRs linked in the ticket will cause the stage/prod environments to have the values that we want).

