### PR TITLE
Allow global staff to access all programs in mock API

### DIFF
--- a/registrar/apps/api/v1/tests/test_views.py
+++ b/registrar/apps/api/v1/tests/test_views.py
@@ -61,7 +61,7 @@ class RegistrarAPITestCase(APITestCase, RequestMixin):
             organization=self.stem_org,
             role=perms.OrganizationReadMetadataRole.name
         )
-        self.stem_admin.groups.add(self.stem_admin_group)
+        self.stem_admin.groups.add(self.stem_admin_group)  # pylint: disable=no-member
 
         self.hum_org = OrganizationFactory(name='Humanities College')
         self.phil_program = ProgramFactory(
@@ -78,7 +78,7 @@ class RegistrarAPITestCase(APITestCase, RequestMixin):
             organization=self.hum_org,
             role=perms.OrganizationReadMetadataRole.name
         )
-        self.hum_admin.groups.add(self.hum_admin_group)
+        self.hum_admin.groups.add(self.hum_admin_group)  # pylint: disable=no-member
 
     def mock_api_response(self, url, response_data):
         responses.add(

--- a/registrar/apps/core/tests/test_models.py
+++ b/registrar/apps/core/tests/test_models.py
@@ -76,7 +76,7 @@ class OrganizationGroupTests(TestCase):
         )
         permissions = get_perms(self.user, self.organization)
         self.assertEqual([], permissions)
-        self.user.groups.add(org_group)
+        self.user.groups.add(org_group)  # pylint: disable=no-member
         permissions = get_perms(self.user, self.organization)
         self.assertEqual(len(role.permissions), len(permissions))
         for permission in Organization._meta.permissions:
@@ -90,7 +90,7 @@ class OrganizationGroupTests(TestCase):
             role=perm.OrganizationReadMetadataRole.name,
             organization=self.organization,
         )
-        self.user.groups.add(org_group)
+        self.user.groups.add(org_group)  # pylint: disable=no-member
         permission = perm.OrganizationReadMetadataRole.permissions[0]
         self.assertTrue(self.user.has_perm(permission, self.organization))
         self.assertFalse(self.user.has_perm(permission))
@@ -104,7 +104,7 @@ class OrganizationGroupTests(TestCase):
             role=perm.OrganizationReadMetadataRole.name,
             organization=self.organization,
         )
-        self.user.groups.add(org_group)
+        self.user.groups.add(org_group)  # pylint: disable=no-member
         self.assertTrue(self.user.has_perm(permission, self.organization))
         self.assertFalse(self.user.has_perm(permission, organization2))
 
@@ -119,7 +119,7 @@ class OrganizationGroupTests(TestCase):
             role=perm.OrganizationReadWriteEnrollmentsRole.name,
             organization=org1,
         )
-        self.user.groups.add(org_group)
+        self.user.groups.add(org_group)  # pylint: disable=no-member
         self.assertTrue(self.user.has_perm(metdata_permission, org1))
         self.assertTrue(self.user.has_perm(write_permission, org1))
         self.assertFalse(self.user.has_perm(metdata_permission, org2))


### PR DESCRIPTION
## Description

Affects only the v0/mock API: A user granted the `ORGANIZATION_READ_METADATA` permission (doing it through a group, here) can list and retrieve metadata for all programs (if excluding `org` query param), even for U. of Perezburgh.
