### PR TITLE
Use new API_ROOT setting to build absolute URLs

### DIFF
--- a/registrar/apps/api/tests/test_utils.py
+++ b/registrar/apps/api/tests/test_utils.py
@@ -1,0 +1,43 @@
+"""
+Tests for api/utils.py
+"""
+import uuid
+
+import ddt
+from django.test import TestCase
+
+from registrar.apps.api.utils import build_absolute_api_url, to_absolute_api_url
+
+
+@ddt.ddt
+class AbsoluteUrlTestCase(TestCase):
+    """ Tests for build_absolute_api_url and to_absolute_api_url """
+
+    @ddt.data(
+        (
+            ('/api/v1', 'programs', 'abcd/enrollments/'),
+            'http://localhost/api/v1/programs/abcd/enrollments/',
+        ),
+        (
+            ('/api/', '/v1/programs/', '/123'),
+            'http://localhost/api/v1/programs/123',
+        ),
+        (
+            ('/api/v1/programs/', '/', '', '456', '', '/'),
+            'http://localhost/api/v1/programs/456/',
+        ),
+    )
+    @ddt.unpack
+    def test_to_absolute_api_url(self, inputs, expected_output):
+        self.assertEqual(to_absolute_api_url(*inputs), expected_output)
+
+    def test_to_absolute_api_url_bad_input(self):
+        with self.assertRaises(ValueError):
+            to_absolute_api_url('abc/def', 'g')
+
+    def test_build_absolute_api_url(self):
+        job_id = uuid.uuid4()
+        self.assertEqual(
+            build_absolute_api_url('api:v1:job-status', job_id=job_id),
+            'http://localhost/api/v1/jobs/{}/'.format(job_id),
+        )

--- a/registrar/apps/api/utils.py
+++ b/registrar/apps/api/utils.py
@@ -1,0 +1,50 @@
+""" Miscellaneous utilities for API. """
+
+from django.conf import settings
+from django.urls import reverse
+
+
+def build_absolute_api_url(url_name, **kwargs):
+    """
+    Build a path to a Registrar API endpoint, and then make it into an
+    absolute, externally-accessible API URL.
+
+    Convenience wrapper around to_absolute_api_url.
+
+    Arguments:
+        url_name (str): name of URL as configured in urls.py.
+        kwargs (dict): URL kwargs for call to `reverse`.
+
+    Returns: str
+    """
+    return to_absolute_api_url(reverse(url_name, kwargs=kwargs))
+
+
+def to_absolute_api_url(path, *more_paths):
+    """
+    Make a path into an absolute, externally-accessible API URL.
+
+    Attempts to gracefully handle missing/duplicate forward slashes,
+    while preserving whether or not there is a trailing slash.
+
+    Arguments:
+        path (str): Path root. Must begin with /api/
+        more_paths (list[str]): Paths to be appended to `path`, in order.
+
+    Example:
+        to_absolute_api_url('api/v1', 'programs', 'abcd/enrollments/')
+            => 'https://{API_ROOT}/v1/programs/abcd/enrollments/'
+        to_absolute_api_url('api/', '/v1/programs/', '/123')
+            => 'https://{API_ROOT}/v1/programs/123'
+
+    Returns: str
+    """
+    PREFIX = '/api/'
+    if not path.startswith(PREFIX):
+        raise ValueError(
+            'Cannot make API URL for raw URL that does not begin with ' + PREFIX
+        )
+    path_parts = [settings.API_ROOT, path[len(PREFIX):]] + list(more_paths)
+    stripped_path_parts = [part.strip('/') for part in path_parts]
+    result = '/'.join(part for part in stripped_path_parts if part)
+    return result + ('/' if path_parts[-1].endswith('/') else '')

--- a/registrar/apps/api/v1/views.py
+++ b/registrar/apps/api/v1/views.py
@@ -11,7 +11,7 @@ from django.core.exceptions import (
 )
 from django.http import Http404
 from django.shortcuts import get_object_or_404
-from django.urls import resolve, reverse
+from django.urls import resolve
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from guardian.shortcuts import get_objects_for_user
 from requests.exceptions import HTTPError
@@ -33,6 +33,7 @@ from registrar.apps.api.serializers import (
     ProgramEnrollmentRequestSerializer,
     ProgramSerializer,
 )
+from registrar.apps.api.utils import build_absolute_api_url
 from registrar.apps.enrollments.models import Program
 from registrar.apps.core import permissions as perms
 from registrar.apps.core.jobs import get_job_status, start_job
@@ -341,9 +342,7 @@ class ProgramEnrollmentView(ProgramSpecificViewMixin, APIView):
             self.program.key,
             file_format,
         )
-        job_url = self.request.build_absolute_uri(
-            reverse('api:v1:job-status', kwargs={'job_id': job_id})
-        )
+        job_url = build_absolute_api_url('api:v1:job-status', job_id=job_id)
         data = {'job_id': job_id, 'job_url': job_url}
         return Response(JobAcceptanceSerializer(data).data, HTTP_202_ACCEPTED)
 

--- a/registrar/apps/api/v1_mock/views.py
+++ b/registrar/apps/api/v1_mock/views.py
@@ -6,7 +6,6 @@ import logging
 
 from django.core.exceptions import PermissionDenied
 from django.http import Http404
-from django.urls import reverse
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.exceptions import ValidationError
@@ -32,6 +31,7 @@ from registrar.apps.api.serializers import (
     CourseEnrollmentRequestSerializer,
     CourseEnrollmentModificationRequestSerializer,
 )
+from registrar.apps.api.utils import build_absolute_api_url
 from registrar.apps.api.v1_mock.data import (
     invoke_fake_course_enrollment_listing_job,
     invoke_fake_program_enrollment_listing_job,
@@ -426,8 +426,8 @@ class MockProgramEnrollmentView(APIView, MockProgramSpecificViewMixin, EchoStatu
         fake_job_id = invoke_fake_program_enrollment_listing_job(
             self.program.key
         )
-        fake_job_url = self.request.build_absolute_uri(
-            reverse('api:v1-mock:job-status', kwargs={'job_id': fake_job_id})
+        fake_job_url = build_absolute_api_url(
+            'api:v1-mock:job-status', job_id=fake_job_id
         )
         fake_job_acceptance = FakeJobAcceptance(fake_job_id, fake_job_url)
 
@@ -508,8 +508,8 @@ class MockCourseEnrollmentView(APIView, MockProgramCourseSpecificViewMixin, Echo
         fake_job_id = invoke_fake_course_enrollment_listing_job(
             self.program.key, self.course.key
         )
-        fake_job_url = self.request.build_absolute_uri(
-            reverse('api:v1-mock:job-status', kwargs={'job_id': fake_job_id})
+        fake_job_url = build_absolute_api_url(
+            'api:v1-mock:job-status', job_id=fake_job_id
         )
         fake_job_acceptance = FakeJobAcceptance(fake_job_id, fake_job_url)
 

--- a/registrar/apps/core/job_storage.py
+++ b/registrar/apps/core/job_storage.py
@@ -1,11 +1,10 @@
 """ Utilities for storing the results of jobs. """
-
-from urllib.parse import urljoin
-
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage, get_storage_class
+
+from registrar.apps.api.utils import to_absolute_api_url
 
 
 class JobResultStorageBase(object):
@@ -49,12 +48,8 @@ class FileSystemJobResultStorage(JobResultStorageBase):
     def _get_url(self, result_path):
         """
         Given the path of a job result, return a URL to the result.
-
-        TODO: This doesn't work, because we don't currently have a way to
-        return absolute URLs outisde the context of a request. We end up
-        just returning something along the lines of '/media/abcd.json'.
         """
-        return urljoin(settings.MEDIA_URL, result_path)
+        return to_absolute_api_url(settings.MEDIA_URL, result_path)
 
 
 class S3JobResultStorage(JobResultStorageBase):

--- a/registrar/settings/base.py
+++ b/registrar/settings/base.py
@@ -131,7 +131,7 @@ LOCALE_PATHS = (
 MEDIA_ROOT = root('media')
 
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#media-url
-MEDIA_URL = '/media/'
+MEDIA_URL = '/api/media/'
 # END MEDIA CONFIGURATION
 
 # STATIC FILE CONFIGURATION
@@ -241,3 +241,6 @@ LOGGING = get_logger_config(debug=DEBUG, dev_env=True, local_loglevel='DEBUG')
 
 # API key for segment.io event tracking
 SEGMENT_KEY = None
+
+# Publicly-exposed base URLs for service and API
+API_ROOT = 'http://replace-me/api'

--- a/registrar/settings/local.py
+++ b/registrar/settings/local.py
@@ -66,6 +66,8 @@ CELERY_ALWAYS_EAGER = True
 # Media
 DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
 
+# Publicly-exposed base URLs for service and API
+API_ROOT = 'http://localhost:18734/api'
 
 #####################################################################
 # Lastly, see if the developer has any local overrides.

--- a/registrar/settings/test.py
+++ b/registrar/settings/test.py
@@ -42,3 +42,6 @@ AWS_STORAGE_BUCKET_NAME = 'registrar-test'
 AWS_QUERYSTRING_AUTH = True
 AWS_QUERYSTRING_EXPIRE = 3600
 AWS_DEFAULT_ACL = None
+
+# Publicly-exposed base URLs for service and API, respectively
+API_ROOT = 'http://localhost/api'


### PR DESCRIPTION
@edx/masters-neem 
[EDUCATOR-4274](https://openedx.atlassian.net/browse/EDUCATOR-4274)

Configuration PR: https://github.com/edx/configuration/pull/5102
Internal configuration PR: https://github.com/edx/edx-internal/pull/849
