### PR TITLE
Load Celery settings from environment in settings/base.py

### DIFF
--- a/registrar/settings/base.py
+++ b/registrar/settings/base.py
@@ -244,3 +244,17 @@ SEGMENT_KEY = None
 
 # Publicly-exposed base URLs for service and API
 API_ROOT = 'http://replace-me/api'
+
+# Celery Broker
+CELERY_BROKER_TRANSPORT = os.environ.get("CELERY_BROKER_TRANSPORT", "")
+CELERY_BROKER_HOSTNAME = os.environ.get("CELERY_BROKER_HOSTNAME", "")
+CELERY_BROKER_VHOST = os.environ.get("CELERY_BROKER_VHOST", "")
+CELERY_BROKER_USER = os.environ.get("CELERY_BROKER_USER", "")
+CELERY_BROKER_PASSWORD = os.environ.get("CELERY_BROKER_PASSWORD", "")
+BROKER_URL = "{0}://{1}:{2}@{3}/{4}".format(
+    CELERY_BROKER_TRANSPORT,
+    CELERY_BROKER_USER,
+    CELERY_BROKER_PASSWORD,
+    CELERY_BROKER_HOSTNAME,
+    CELERY_BROKER_VHOST
+)

--- a/registrar/settings/devstack.py
+++ b/registrar/settings/devstack.py
@@ -30,26 +30,8 @@ DATABASES = {
     }
 }
 
-########################### BEGIN CELERY ###################################
-
-# Celery Broker
-CELERY_BROKER_TRANSPORT = os.environ.get("CELERY_BROKER_TRANSPORT", "")
-CELERY_BROKER_HOSTNAME = os.environ.get("CELERY_BROKER_HOSTNAME", "")
-CELERY_BROKER_VHOST = os.environ.get("CELERY_BROKER_VHOST", "")
-CELERY_BROKER_USER = os.environ.get("CELERY_BROKER_USER", "")
-CELERY_BROKER_PASSWORD = os.environ.get("CELERY_BROKER_PASSWORD", "")
-
-BROKER_URL = "{0}://{1}:{2}@{3}/{4}".format(
-    CELERY_BROKER_TRANSPORT,
-    CELERY_BROKER_USER,
-    CELERY_BROKER_PASSWORD,
-    CELERY_BROKER_HOSTNAME,
-    CELERY_BROKER_VHOST
-)
-
+# Set to true in local.py; need to override.
 CELERY_ALWAYS_EAGER = False
-
-########################### END CELERY ###################################
 
 STATICFILES_STORAGE = os.environ.get('STATICFILES_STORAGE', 'django.contrib.staticfiles.storage.StaticFilesStorage')
 STATIC_URL = os.environ.get('STATIC_URL', '/static/')


### PR DESCRIPTION
@edx/masters-neem 

This edx/configuration PR injects Celery settings into the environment: https://github.com/edx/configuration/pull/5104.

This edx/edx-internal PR overrides the settings with production values: https://github.com/edx/edx-internal/pull/851

In this PR, we grab the settings from the environment in `settings/base.py`