### PR TITLE
Include curriculum_uuid with program enrollments

### DIFF
--- a/registrar/apps/enrollments/constants.py
+++ b/registrar/apps/enrollments/constants.py
@@ -1,5 +1,7 @@
 """ Constants for enrollments app """
 
+PROGRAM_CACHE_KEY_TPL = 'program-{uuid}'
+
 PROGRAM_ENROLLMENT_ENROLLED = 'enrolled'
 PROGRAM_ENROLLMENT_PENDING = 'pending'
 PROGRAM_ENROLLMENT_SUSPENDED = 'suspended'

--- a/registrar/apps/enrollments/tests/test_data.py
+++ b/registrar/apps/enrollments/tests/test_data.py
@@ -4,15 +4,17 @@ Tests for enrollments/data.py
 Much of data.py is not tested in this file because it is already implicitly
 tested by our view tests.
 """
-
+import uuid
+from posixpath import join as urljoin
 from django.conf import settings
+from django.core.cache import cache
 from django.test import TestCase
 from requests.exceptions import HTTPError
 import responses
 from rest_framework.exceptions import ValidationError
 
 from registrar.apps.core.tests.utils import mock_oauth_login
-from registrar.apps.enrollments.data import get_program_enrollments
+from registrar.apps.enrollments.data import get_program_enrollments, get_discovery_program
 
 
 class GetProgramEnrollmentsTestCase(TestCase):
@@ -91,3 +93,84 @@ class GetProgramEnrollmentsTestCase(TestCase):
         responses.add(responses.GET, self.url, status=500)
         with self.assertRaises(HTTPError):
             get_program_enrollments(self.uuid)
+
+
+class GetDiscoveryProgramTestCase(TestCase):
+    """ Test get_discovery_program function """
+
+    program_uuid = uuid.uuid4()
+    discovery_url = urljoin(settings.DISCOVERY_BASE_URL, 'api/v1/programs/{}/').format(program_uuid)
+    programs_response = {
+        'curricula': [{
+            'uuid': uuid.uuid4().hex[0:10],
+            'is_active': True,
+            'courses': [
+                {
+                    'course_runs': [
+                        {
+                            'key': '0001',
+                            'uuid': '0000-0001',
+                            'title': 'Test Course 1',
+                            'marketing_url': 'https://stem-institute.edx.org/masters-in-cs/test-course-1',
+                        },
+                    ],
+                }
+            ],
+        }],
+    }
+
+    def setUp(self):
+        super(GetDiscoveryProgramTestCase, self).setUp()
+        cache.clear()
+
+    @mock_oauth_login
+    @responses.activate
+    def test_get_discovery_program_success(self):
+        """
+        Verify initial call returns data from the discovery service and additional function
+        calls return from cache.
+
+        Note: TWO calls are initially made to discovery in order to obtain an auth token and then
+        request data.
+        """
+
+        responses.add(
+            responses.GET,
+            self.discovery_url,
+            json=self.programs_response,
+            status=200
+        )
+        response = get_discovery_program(self.program_uuid)
+        self.assertEqual(response, self.programs_response)
+        self.assertEqual(len(responses.calls), 2)
+
+        # this should return the same object from cache
+        response = get_discovery_program(self.program_uuid)
+        self.assertEqual(response, self.programs_response)
+        self.assertEqual(len(responses.calls), 2)
+
+    @mock_oauth_login
+    @responses.activate
+    def test_get_discovery_program_error(self):
+        """
+        Verify if an error occurs when requesting discovery data an exception is
+        thown and the cache is not polluted.
+        """
+        responses.add(
+            responses.GET,
+            self.discovery_url,
+            json={'message': 'everything is broken'},
+            status=500
+        )
+
+        with self.assertRaises(HTTPError):
+            get_discovery_program(self.program_uuid)
+
+        responses.replace(
+            responses.GET,
+            self.discovery_url,
+            json=self.programs_response,
+            status=200
+        )
+        response = get_discovery_program(self.program_uuid)
+        self.assertEqual(response, self.programs_response)


### PR DESCRIPTION
### [EDUCATOR-4283](https://openedx.atlassian.net/browse/EDUCATOR-4283)

1. Send curriculum_uuid to LMS when creating or updating program enrollments
2. Added caching of discovery programs
3. Fix POST/PATCH to use base class instead of ddt

Note: It turns out discovery does not expose the created date on curricula, for now this will use the first active curriculum in a program.