### PR TITLE
Add the logging for v1_mock api endpoints

### DIFF
--- a/registrar/apps/api/constants.py
+++ b/registrar/apps/api/constants.py
@@ -2,3 +2,4 @@
 Defines constants used by the registrar api.
 """
 ENROLLMENT_WRITE_MAX_SIZE = 25
+TRACKING_CATEGORY = 'Registrar API'

--- a/registrar/apps/api/segment.py
+++ b/registrar/apps/api/segment.py
@@ -5,6 +5,7 @@ import logging
 import analytics
 from django.conf import settings
 
+from registrar.apps.api.constants import TRACKING_CATEGORY
 from registrar.apps.core.utils import get_user_organizations
 
 logger = logging.getLogger(__name__)
@@ -32,5 +33,6 @@ def get_tracking_properties(user, **kwargs):
     user_orgs = get_user_organizations(user)
     property_dict = kwargs.copy()
     property_dict['user_organizations'] = [org.name for org in user_orgs]
+    property_dict['category'] = TRACKING_CATEGORY
 
     return property_dict

--- a/registrar/apps/core/tests/factories.py
+++ b/registrar/apps/core/tests/factories.py
@@ -80,7 +80,7 @@ class OrganizationFactory(factory.DjangoModelFactory):
 
     key = factory.LazyAttribute(lambda org: name_to_key(org.name))
     discovery_uuid = factory.Faker('uuid4')
-    name = factory.Sequence(lambda n: "Test Origanization " + str(n))
+    name = factory.Sequence(lambda n: "Test Organization " + str(n))
 
 
 class OrganizationGroupFactory(factory.DjangoModelFactory):


### PR DESCRIPTION
## Description

@edx/masters-neem  Please help review
This is the change to add logging to the API endpoints for debugging from splunk. It's largely riding on the segment tracking infrastructure.