### PR TITLE
Implement V1 course enrollment GET

### DIFF
--- a/registrar/apps/api/v1/mixins.py
+++ b/registrar/apps/api/v1/mixins.py
@@ -1,0 +1,189 @@
+"""
+Mixins for the public REST API.
+"""
+from collections.abc import Iterable
+
+from django.core.exceptions import (
+    ImproperlyConfigured,
+    PermissionDenied,
+)
+from django.http import Http404
+from django.shortcuts import get_object_or_404
+from django.urls import resolve
+from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
+from guardian.shortcuts import get_objects_for_user
+from rest_framework.authentication import SessionAuthentication
+from rest_framework.exceptions import NotAuthenticated
+from rest_framework.response import Response
+from rest_framework.status import HTTP_202_ACCEPTED
+
+from registrar.apps.api.serializers import JobAcceptanceSerializer
+from registrar.apps.api.utils import build_absolute_api_url
+from registrar.apps.enrollments.models import Program
+from registrar.apps.core.jobs import start_job
+from registrar.apps.enrollments.data import DiscoveryProgram
+
+
+class AuthMixin(object):
+    """
+    Mixin providing AuthN/AuthZ functionality for all our views to use.
+
+    This mixin overrides `APIView.check_permissions` to use Django Guardian.
+    It replicates, to the extent that we require, the functionality of
+    Django Guardian's `PermissionRequiredMixin`, which unfortunately doesn't
+    play nicely with Django REST Framework.
+    """
+    authentication_classes = (JwtAuthentication, SessionAuthentication)
+    permission_required = []
+    raise_404_if_unauthorized = False
+
+    def get_permission_object(self):
+        """
+        Get an object against which required permissions will be checked.
+
+        If None, permissions will be checked globally.
+        """
+        return None
+
+    def get_permission_required(self, _request):
+        """
+        Gets permission(s) to be checked.
+
+        Must return a string or an iterable of strings.
+        Can be overridden in subclass.
+        Default to class-level `permission_required` attribute.
+        """
+        return self.permission_required
+
+    def check_permissions(self, request):
+        """
+        Check that the authenticated user can access this view.
+
+        Ensure that the user has all of the permissions specified in
+        `permission_required` granted on the object returned by
+        `get_permission_object`. If not, an HTTP 403 (or, HTTP 404 if
+        `raise_404_if_unauthorized` is True) is raised.
+
+        Overrides APIView.check_permissions.
+        """
+        if resolve(request.path_info).url_name == 'api-docs':
+            self.check_doc_permissions(request)
+            return
+
+        if not request.user.is_authenticated:
+            raise NotAuthenticated()
+
+        required = self.get_permission_required(request)
+        if isinstance(required, str):
+            required = [required]
+        elif isinstance(required, Iterable):
+            required = list(required)
+        else:
+            raise ImproperlyConfigured(
+                'get_permission_required must return string or iterable; ' +
+                'returned {}'.format(required)
+            )
+
+        if all(request.user.has_perm(perm) for perm in required):
+            return
+        obj = self.get_permission_object()
+        if obj and all(request.user.has_perm(perm, obj) for perm in required):
+            return
+        if self.raise_404_if_unauthorized:
+            raise Http404()
+        else:
+            raise PermissionDenied()
+
+    def check_doc_permissions(self, request):
+        """
+        Check whether the endpoint being requested should show up in the
+        Swagger UI.
+
+        When loading /api-docs/, Swagger does `check_permissions` on all
+        API endpoints in order to decide which ones to show to the user.
+        However, we assign permissions on a per-Oranization-instance
+        basis using Guardian, whereas /api-docs/ is Organization-agnostic.
+
+        To compensate for this, we handle permission checks coming from
+        /api-docs/ differently: we simply check if the user has the appropriate
+        permission on *any* Organization instance.
+        """
+        if not get_objects_for_user(request.user, self.permission_required):
+            raise PermissionDenied()
+
+
+class ProgramSpecificViewMixin(AuthMixin):
+    """
+    A mixin for views that operate on or within a specific program.
+
+    Provides a `program` property. On first access, the property is loaded
+    based on the `program_key` URL parameter, and cached for subsequent
+    calls. This avoids redundant database queries between `get_object/queryset`
+    and `get_permission_object`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._program = None
+
+    @property
+    def program(self):
+        """
+        The program specified by the `program_key` URL parameter.
+        """
+        if not self._program:
+            program_key = self.kwargs['program_key']
+            self._program = get_object_or_404(Program, key=program_key)
+        return self._program
+
+    def get_permission_object(self):
+        """
+        Returns an organization object against which permissions should be checked.
+        """
+        return self.program.managing_organization
+
+
+class CourseSpecificViewMixin(ProgramSpecificViewMixin):
+    """
+    A mixin for views that operate on or within a specific program course run.
+
+    In addition to the functionality provided in `ProgramSpecificViewMixin`,
+    this mixin provides a `validate_course_id` function, which confirms
+    that the course ID (provided in the `course_id` path parameter)
+    exists within a program. If it does not, a 404 is raised.
+    """
+
+    def validate_course_id(self):
+        """
+        Raises a 404 if the course run identified by the `course_id` path
+        parameter is not part of self.program.
+        """
+        course_id = self.kwargs['course_id']
+        program_uuid = self.program.discovery_uuid
+        discovery_program = DiscoveryProgram.get(program_uuid)
+        program_course_run_ids = {
+            run.key for run in discovery_program.course_runs
+        }
+        if course_id not in program_course_run_ids:
+            raise Http404()
+
+
+class JobInvokerMixin(object):
+    """
+    A mixin for views that invoke jobs and return ID and status URL.
+    """
+
+    def invoke_job(self, task_fn, *args, **kwargs):
+        """
+        Invoke a job with task_fn, and a return a 202 with job_id and job_url.
+
+        *args and **kwargs are passed to task_fn *in addition* to
+        job_id, user_id, and file_format.
+        """
+        file_format = self.request.query_params.get('fmt', 'json')
+        if file_format not in {'json', 'csv'}:
+            raise Http404()
+        job_id = start_job(self.request.user, task_fn, file_format, *args, **kwargs)
+        job_url = build_absolute_api_url('api:v1:job-status', job_id=job_id)
+        data = {'job_id': job_id, 'job_url': job_url}
+        return Response(JobAcceptanceSerializer(data).data, HTTP_202_ACCEPTED)

--- a/registrar/apps/api/v1/urls.py
+++ b/registrar/apps/api/v1/urls.py
@@ -2,11 +2,12 @@
 
 from django.conf.urls import url
 
-from registrar.apps.core.constants import (
-    PROGRAM_KEY_PATTERN,
-    JOB_ID_PATTERN,
-)
 from registrar.apps.api.v1 import views
+from registrar.apps.core.constants import (
+    COURSE_ID_PATTERN,
+    JOB_ID_PATTERN,
+    PROGRAM_KEY_PATTERN,
+)
 
 
 app_name = 'v1'
@@ -36,6 +37,11 @@ urlpatterns = [
         r'programs/{}/enrollments/$'.format(PROGRAM_KEY_PATTERN),
         views.ProgramEnrollmentView.as_view(),
         name="program-enrollment",
+    ),
+    url(
+        r'programs/{}/courses/{}/enrollments/$'.format(PROGRAM_KEY_PATTERN, COURSE_ID_PATTERN),
+        views.CourseEnrollmentView.as_view(),
+        name="program-course-enrollment",
     ),
     url(
         r'jobs/{}/$'.format(JOB_ID_PATTERN),

--- a/registrar/apps/api/v1/views.py
+++ b/registrar/apps/api/v1/views.py
@@ -1,30 +1,30 @@
 """
 The public-facing REST API.
 """
-from collections.abc import Iterable
 import logging
 
 from django.core.exceptions import (
-    ImproperlyConfigured,
     ObjectDoesNotExist,
     PermissionDenied,
 )
 from django.http import Http404
 from django.shortcuts import get_object_or_404
-from django.urls import resolve
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
-from guardian.shortcuts import get_objects_for_user
-from requests.exceptions import HTTPError
 from rest_framework.authentication import SessionAuthentication
-from rest_framework.exceptions import NotAuthenticated, ValidationError
+from rest_framework.exceptions import ValidationError
 from rest_framework.generics import ListAPIView, RetrieveAPIView
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
-from rest_framework.status import HTTP_202_ACCEPTED
 from rest_framework.views import APIView
 
 from registrar.apps.api import exceptions
 from registrar.apps.api.constants import ENROLLMENT_WRITE_MAX_SIZE
+from registrar.apps.api.v1.mixins import (
+    AuthMixin,
+    CourseSpecificViewMixin,
+    JobInvokerMixin,
+    ProgramSpecificViewMixin,
+)
 import registrar.apps.api.segment as segment
 from registrar.apps.api.serializers import (
     CourseRunSerializer,
@@ -33,103 +33,21 @@ from registrar.apps.api.serializers import (
     ProgramEnrollmentRequestSerializer,
     ProgramSerializer,
 )
-from registrar.apps.api.utils import build_absolute_api_url
 from registrar.apps.enrollments.models import Program
 from registrar.apps.core import permissions as perms
-from registrar.apps.core.jobs import get_job_status, start_job
+from registrar.apps.core.jobs import get_job_status
 from registrar.apps.core.models import Organization
-from registrar.apps.enrollments.data import get_discovery_program, write_program_enrollments
-from registrar.apps.enrollments.tasks import list_program_enrollments
+from registrar.apps.enrollments.data import (
+    DiscoveryProgram,
+    write_program_enrollments,
+)
+from registrar.apps.enrollments.tasks import (
+    list_course_run_enrollments,
+    list_program_enrollments,
+)
+
 
 logger = logging.getLogger(__name__)
-
-
-class AuthMixin(object):
-    """
-    Mixin providing AuthN/AuthZ functionality for all our views to use.
-
-    This mixin overrides `APIView.check_permissions` to use Django Guardian.
-    It replicates, to the extent that we require, the functionality of
-    Django Guardian's `PermissionRequiredMixin`, which unfortunately doesn't
-    play nicely with Django REST Framework.
-    """
-    authentication_classes = (JwtAuthentication, SessionAuthentication)
-    permission_required = []
-    raise_404_if_unauthorized = False
-
-    def get_permission_object(self):
-        """
-        Get an object against which required permissions will be checked.
-
-        If None, permissions will be checked globally.
-        """
-        return None
-
-    def get_permission_required(self, _request):
-        """
-        Gets permission(s) to be checked.
-
-        Must return a string or an iterable of strings.
-        Can be overridden in subclass.
-        Default to class-level `permission_required` attribute.
-        """
-        return self.permission_required
-
-    def check_permissions(self, request):
-        """
-        Check that the authenticated user can access this view.
-
-        Ensure that the user has all of the permissions specified in
-        `permission_required` granted on the object returned by
-        `get_permission_object`. If not, an HTTP 403 (or, HTTP 404 if
-        `raise_404_if_unauthorized` is True) is raised.
-
-        Overrides APIView.check_permissions.
-        """
-        if resolve(request.path_info).url_name == 'api-docs':
-            self.check_doc_permissions(request)
-            return
-
-        if not request.user.is_authenticated:
-            raise NotAuthenticated()
-
-        required = self.get_permission_required(request)
-        if isinstance(required, str):
-            required = [required]
-        elif isinstance(required, Iterable):
-            required = list(required)
-        else:
-            raise ImproperlyConfigured(
-                'get_permission_required must return string or iterable; ' +
-                'returned {}'.format(required)
-            )
-
-        if all(request.user.has_perm(perm) for perm in required):
-            return
-        obj = self.get_permission_object()
-        if obj and all(request.user.has_perm(perm, obj) for perm in required):
-            return
-        if self.raise_404_if_unauthorized:
-            raise Http404()
-        else:
-            raise PermissionDenied()
-
-    def check_doc_permissions(self, request):
-        """
-        Check whether the endpoint being requested should show up in the
-        Swagger UI.
-
-        When loading /api-docs/, Swagger does `check_permissions` on all
-        API endpoints in order to decide which ones to show to the user.
-        However, we assign permissions on a per-Oranization-instance
-        basis using Guardian, whereas /api-docs/ is Organization-agnostic.
-
-        To compensate for this, we handle permission checks coming from
-        /api-docs/ differently: we simply check if the user has the appropriate
-        permission on *any* Organization instance.
-        """
-        if not get_objects_for_user(request.user, self.permission_required):
-            raise PermissionDenied()
 
 
 class ProgramListView(AuthMixin, ListAPIView):
@@ -180,37 +98,6 @@ class ProgramListView(AuthMixin, ListAPIView):
             return None
 
 
-class ProgramSpecificViewMixin(AuthMixin):
-    """
-    A mixin for views that operate on or within a specific program.
-
-    Provides a `program` property. On first access, the property is loaded
-    based on the `program_key` URL parameter, and cached for subsequent
-    calls. This avoids redundant database queries between `get_object/queryset`
-    and `get_permission_object`.
-    """
-
-    def __init__(self, *args, **kwargs):
-        super(ProgramSpecificViewMixin, self).__init__(*args, **kwargs)
-        self._program = None
-
-    @property
-    def program(self):
-        """
-        The program specified by the `program_key` URL parameter.
-        """
-        if not self._program:
-            program_key = self.kwargs['program_key']
-            self._program = get_object_or_404(Program, key=program_key)
-        return self._program
-
-    def get_permission_object(self):
-        """
-        Returns an organization object against which permissions should be checked.
-        """
-        return self.program.managing_organization
-
-
 class ProgramRetrieveView(ProgramSpecificViewMixin, RetrieveAPIView):
     """
     A view for retrieving a single program object.
@@ -222,7 +109,6 @@ class ProgramRetrieveView(ProgramSpecificViewMixin, RetrieveAPIView):
      * 403: User lacks read access organization of specified program.
      * 404: Program does not exist.
     """
-
     serializer_class = ProgramSerializer
     permission_required = perms.ORGANIZATION_READ_METADATA
 
@@ -241,42 +127,16 @@ class ProgramCourseListView(ProgramSpecificViewMixin, ListAPIView):
      * 403: User lacks read access organization of specified program.
      * 404: Program does not exist.
     """
-
     serializer_class = CourseRunSerializer
     permission_required = perms.ORGANIZATION_READ_METADATA
 
     def get_queryset(self):
         uuid = self.program.discovery_uuid
-        try:
-            discovery_program = get_discovery_program(uuid)
-        except HTTPError as error:
-            error_string = (
-                'Failed to retrieve program data from course-discovery ' +
-                '(key = {}, uuid = {}, http status = {})'.format(
-                    self.program.key, uuid, error.response.status_code,
-                )
-            )
-            logger.exception(error_string)
-            raise Exception(error_string)
-
-        curricula = discovery_program.get('curricula')
-
-        # this make two temporary assumptions (zwh 03/19)
-        #  1. one *active* curriculum per program
-        #  2. no programs are nested within a curriculum
-        course_runs = []
-        if curricula:
-            try:
-                curriculum = next(c for c in curricula if c['is_active'])
-                for course in curriculum.get('courses') or []:
-                    course_runs = course_runs + course.get('course_runs')
-            except StopIteration:
-                pass
-
-        return course_runs
+        discovery_program = DiscoveryProgram.get(uuid)
+        return discovery_program.course_runs
 
 
-class ProgramEnrollmentView(ProgramSpecificViewMixin, APIView):
+class ProgramEnrollmentView(ProgramSpecificViewMixin, JobInvokerMixin, APIView):
     """
     A view for enrolling students in a program, or retrieving/modifying program enrollment data.
 
@@ -319,13 +179,12 @@ class ProgramEnrollmentView(ProgramSpecificViewMixin, APIView):
      * 413: Payload too large, over 25 students supplied.
      * 422: Invalid request, unable to enroll students.
     """
-    # pylint: disable=unused-argument
 
     def get_serializer_class(self):
         if self.request.method == 'GET':
             return JobAcceptanceSerializer
         if self.request.method == 'POST' or self.request.method == 'PATCH':
-            return ProgramEnrollmentRequestSerializer(multiple=True)
+            return ProgramEnrollmentRequestSerializer(many=True)
 
     def get_permission_required(self, request):
         if request.method == 'GET':
@@ -338,18 +197,7 @@ class ProgramEnrollmentView(ProgramSpecificViewMixin, APIView):
         """
         Submit a user task that retrieves program enrollment data.
         """
-        file_format = request.query_params.get('fmt', 'json')
-        if file_format not in {'json', 'csv'}:
-            raise Http404()
-        job_id = start_job(
-            self.request.user,
-            list_program_enrollments,
-            self.program.key,
-            file_format,
-        )
-        job_url = build_absolute_api_url('api:v1:job-status', job_id=job_id)
-        data = {'job_id': job_id, 'job_url': job_url}
-        return Response(JobAcceptanceSerializer(data).data, HTTP_202_ACCEPTED)
+        return self.invoke_job(list_program_enrollments, self.program.key)
 
     def validate_enrollment_data(self, enrollments):
         """
@@ -367,20 +215,16 @@ class ProgramEnrollmentView(ProgramSpecificViewMixin, APIView):
         """
         self.validate_enrollment_data(request.data)
         program_uuid = self.program.discovery_uuid
+        discovery_program = DiscoveryProgram.get(program_uuid)
 
-        program = get_discovery_program(program_uuid)
-
-        try:
-            curriculum = next(c for c in program['curricula'] if c['is_active'])
-        except StopIteration:
-            logger.exception('No active curriculum found for program: {}'.format(program_uuid))
-            raise Exception('Program configuration error. No curriculum found.')
-
-        enrollments = [{
-            'student_key': enrollment.get('student_key'),
-            'status': enrollment.get('status'),
-            'curriculum_uuid': curriculum.get('uuid')
-        } for enrollment in request.data]
+        enrollments = [
+            {
+                'student_key': enrollment.get('student_key'),
+                'status': enrollment.get('status'),
+                'curriculum_uuid': discovery_program.active_curriculum_uuid
+            }
+            for enrollment in request.data
+        ]
 
         if request.method == 'POST':
             response = write_program_enrollments(program_uuid, enrollments)
@@ -395,9 +239,58 @@ class ProgramEnrollmentView(ProgramSpecificViewMixin, APIView):
         """ POST handler """
         return self.write_program_enrollments(request)
 
-    def patch(self, request, program_key):
+    def patch(self, request, program_key):  # pylint: disable=unused-argument
         """ PATCH handler """
         return self.write_program_enrollments(request)
+
+
+class CourseEnrollmentView(CourseSpecificViewMixin, JobInvokerMixin, APIView):
+    """
+    A view for enrolling students in a program course run.
+
+    Path: /api/v1/programs/{program_key}/courses/{course_id}/enrollments
+
+    Accepts: [GET]
+
+    ------------------------------------------------------------------------------------
+    GET
+    ------------------------------------------------------------------------------------
+
+    Invokes a Django User Task that retrieves student enrollment
+    data for a given program course run.
+
+    Returns:
+     * 202: Accepted, an asynchronous job was successfully started.
+     * 401: User is not authenticated
+     * 403: User lacks enrollment read access to organization of specified course run.
+     * 404: Course run does not exist within specified program.
+
+    Example Response:
+    {
+        "job_id": "3b985cec-dcf4-4d38-9498-8545ebcf5d0f",
+        "job_url": "http://localhost/api/v1/jobs/3b985cec-dcf4-4d38-9498-8545ebcf5d0f"
+    }
+    """
+
+    def get_serializer_class(self):
+        if self.request.method == 'GET':
+            return JobAcceptanceSerializer
+
+    def get_permission_required(self, request):
+        if request.method == 'GET':
+            return perms.ORGANIZATION_READ_ENROLLMENTS
+        return []
+
+    def get(self, request, *args, **kwargs):
+        """
+        Submit a user task that retrieves course run enrollment data.
+        """
+        self.validate_course_id()
+        return self.invoke_job(
+            list_course_run_enrollments,
+            self.program.key,
+            self.kwargs['course_id'],
+        )
 
 
 class JobStatusRetrieveView(RetrieveAPIView):

--- a/registrar/apps/api/v1_mock/urls.py
+++ b/registrar/apps/api/v1_mock/urls.py
@@ -3,7 +3,11 @@
 from django.conf.urls import url
 
 from registrar.apps.api.v1_mock import views
-from registrar.apps.core.constants import PROGRAM_KEY_PATTERN, COURSE_ID_PATTERN
+from registrar.apps.core.constants import (
+    COURSE_ID_PATTERN,
+    JOB_ID_PATTERN,
+    PROGRAM_KEY_PATTERN,
+)
 
 
 app_name = 'v1-mock'
@@ -32,10 +36,10 @@ urlpatterns = [
     url(
         r'programs/{}/courses/{}/enrollments/$'.format(PROGRAM_KEY_PATTERN, COURSE_ID_PATTERN),
         views.MockCourseEnrollmentView.as_view(),
-        name="program-enrollment",
+        name="program-course-enrollment",
     ),
     url(
-        r'jobs/(?P<job_id>[0-9a-f-]+)/$',
+        r'jobs/{}/$'.format(JOB_ID_PATTERN),
         views.MockJobStatusRetrieveView.as_view(),
         name="job-status",
     ),

--- a/registrar/apps/core/utils.py
+++ b/registrar/apps/core/utils.py
@@ -1,4 +1,6 @@
 """ Miscellaneous utilities not specific to any app. """
+import csv
+from io import StringIO
 import re
 
 from registrar.apps.core.models import OrganizationGroup
@@ -30,3 +32,27 @@ def get_user_organizations(user):
         except OrganizationGroup.DoesNotExist:
             pass
     return user_organizations
+
+
+def serialize_to_csv(items, field_names, include_headers=False):
+    """
+    Serialize items into a CSV-formatted string. Column headers optional.
+
+    Booleans are serialized as True and False
+    Uses Windows-style line endings ('\r\n').
+    Trailing newline is included.
+
+    Arguments:
+        items (list[dict])
+        field_names (tuple[str])
+        include_headers (bool)
+
+    Returns: str
+    """
+    outfile = StringIO()
+    writer = csv.DictWriter(outfile, fieldnames=field_names)
+    if include_headers:
+        writer.writeheader()
+    for item in items:
+        writer.writerow(item)
+    return outfile.getvalue()

--- a/registrar/apps/enrollments/constants.py
+++ b/registrar/apps/enrollments/constants.py
@@ -1,6 +1,6 @@
 """ Constants for enrollments app """
 
-PROGRAM_CACHE_KEY_TPL = 'program-{uuid}'
+PROGRAM_CACHE_KEY_TPL = 'program:{uuid}'
 
 PROGRAM_ENROLLMENT_ENROLLED = 'enrolled'
 PROGRAM_ENROLLMENT_PENDING = 'pending'

--- a/registrar/apps/enrollments/serializers.py
+++ b/registrar/apps/enrollments/serializers.py
@@ -1,8 +1,10 @@
 """ Serializers for communicating enrollment data with LMS """
 
 from rest_framework import serializers
+from registrar.apps.core.utils import serialize_to_csv
 from registrar.apps.enrollments.constants import (
     PROGRAM_ENROLLMENT_STATUSES,
+    COURSE_ENROLLMENT_STATUSES,
 )
 
 
@@ -20,20 +22,36 @@ class ProgramEnrollmentSerializer(serializers.Serializer):
 
 def serialize_program_enrollments_to_csv(enrollments):
     """
-    Serialize enrollments into a CSV-formatted string.
-
-    Headers are not included.
+    Serialize program enrollments into a CSV-formatted string.
 
     Arguments:
         enrollments: list[dict]
 
     Returns: str
     """
-    return '\n'.join(
-        '{},{},{}'.format(
-            enrollment['student_key'],
-            enrollment['status'],
-            str(enrollment['account_exists']).lower(),
-        )
-        for enrollment in enrollments
+    return serialize_to_csv(
+        enrollments, ('student_key', 'status', 'account_exists')
+    )
+
+
+class CourseEnrollmentSerializer(serializers.Serializer):
+    """
+    Serializer for program enrollment API response.
+    """
+    student_key = serializers.CharField()
+    status = serializers.ChoiceField(choices=COURSE_ENROLLMENT_STATUSES)
+    account_exists = serializers.BooleanField()
+
+
+def serialize_course_run_enrollments_to_csv(enrollments):
+    """
+    Serialize course run enrollments into a CSV-formatted string.
+
+    Arguments:
+        enrollments: list[dict]
+
+    Returns: str
+    """
+    return serialize_to_csv(
+        enrollments, ('student_key', 'status', 'account_exists')
     )

--- a/registrar/apps/enrollments/tasks.py
+++ b/registrar/apps/enrollments/tasks.py
@@ -12,18 +12,24 @@ from user_tasks.tasks import UserTask
 
 
 from registrar.apps.core.jobs import post_job_failure, post_job_success
-from registrar.apps.enrollments.data import get_program_enrollments
+from registrar.apps.enrollments.data import (
+    get_course_run_enrollments,
+    get_program_enrollments,
+)
 from registrar.apps.enrollments.models import Program
-from registrar.apps.enrollments.serializers import serialize_program_enrollments_to_csv
+from registrar.apps.enrollments.serializers import (
+    serialize_course_run_enrollments_to_csv,
+    serialize_program_enrollments_to_csv,
+)
 
 
 log = get_task_logger(__name__)
 
 
 @shared_task(base=UserTask, bind=True)
-def list_program_enrollments(self, job_id, user_id, program_key, file_format):  # pylint: disable=unused-argument
+def list_program_enrollments(self, job_id, user_id, file_format, program_key):  # pylint: disable=unused-argument
     """
-    A user task for debugging.  Creates user artifact containing given text.
+    A user task for retrieving program enrollments from LMS.
     """
     try:
         program = Program.objects.get(key=program_key)
@@ -36,7 +42,7 @@ def list_program_enrollments(self, job_id, user_id, program_key, file_format):  
     except HTTPError as err:
         post_job_failure(
             job_id,
-            "HTTP error {} on when getting enrollments at {}".format(
+            "HTTP error {} when getting enrollments at {}".format(
                 err.response.status_code, err.request.url
             ),
         )
@@ -54,7 +60,46 @@ def list_program_enrollments(self, job_id, user_id, program_key, file_format):  
         serialized = serialize_program_enrollments_to_csv(enrollments)
     else:
         raise ValueError('Invalid file_format: {}'.format(file_format))
-    post_job_success(self.request.id, serialized, file_format)
+    post_job_success(job_id, serialized, file_format)
+
+
+@shared_task(base=UserTask, bind=True)
+def list_course_run_enrollments(
+        self, job_id, user_id, file_format, program_key, course_id   # pylint: disable=unused-argument
+):
+    """
+    A user task for retrieving program course run enrollments from LMS.
+    """
+    try:
+        program = Program.objects.get(key=program_key)
+    except Program.DoesNotExist:
+        post_job_failure(job_id, "Bad program key: {}".format(program_key))
+        return
+
+    try:
+        enrollments = get_course_run_enrollments(program.discovery_uuid, course_id)
+    except HTTPError as err:
+        post_job_failure(
+            job_id,
+            "HTTP error {} when getting enrollments at {}".format(
+                err.response.status_code, err.request.url
+            ),
+        )
+        return
+    except ValidationError as err:
+        post_job_failure(
+            job_id,
+            "Invalid enrollment data from LMS: {}".format(err),
+        )
+        return
+
+    if file_format == 'json':
+        serialized = json.dumps(enrollments, indent=4)
+    elif file_format == 'csv':
+        serialized = serialize_course_run_enrollments_to_csv(enrollments)
+    else:
+        raise ValueError('Invalid file_format: {}'.format(file_format))
+    post_job_success(job_id, serialized, file_format)
 
 
 @shared_task(bind=True)

--- a/registrar/apps/enrollments/tests/test_data.py
+++ b/registrar/apps/enrollments/tests/test_data.py
@@ -4,124 +4,184 @@ Tests for enrollments/data.py
 Much of data.py is not tested in this file because it is already implicitly
 tested by our view tests.
 """
-import uuid
+from datetime import datetime
 from posixpath import join as urljoin
+import uuid
+
 from django.conf import settings
 from django.core.cache import cache
 from django.test import TestCase
+import mock
 from requests.exceptions import HTTPError
 import responses
 from rest_framework.exceptions import ValidationError
 
 from registrar.apps.core.tests.utils import mock_oauth_login
-from registrar.apps.enrollments.data import get_program_enrollments, get_discovery_program
+from registrar.apps.enrollments.data import (
+    DiscoveryCourseRun,
+    DiscoveryProgram,
+    get_course_run_enrollments,
+    get_program_enrollments,
+)
 
 
-class GetProgramEnrollmentsTestCase(TestCase):
-    """ Tests for data.get_program_enrollments """
+class GetEnrollmentsTestMixin(object):
+    """ Common tests for enrollment-getting functions """
 
-    uuid = '7fbefaa4-c0e8-431b-af69-8d3ddde543a2'
-    url = '{}/api/program_enrollments/v1/programs/{}/enrollments'.format(
-        settings.LMS_BASE_URL, uuid
-    )
+    lms_url = None  # Override in subclass
+    status_choices = None  # Override in subclass
 
-    good_data_1 = [
-        {
-            'student_key': 'abcd',
-            'account_exists': True,
-            'status': 'enrolled',
-        },
-        {
-            'student_key': 'efgh',
-            'account_exists': False,
-            'status': 'canceled',
-        },
-    ]
-    good_data_2 = [
-        {
-            'student_key': 'ijkl',
-            'account_exists': False,
-            'status': 'pending',
-        },
-        {
-            'student_key': 'mnop',
-            'account_exists': True,
-            'status': 'suspended',
-        },
-    ]
-    bad_data = [
-        {
-            'student_key': 'qrst',
-            'account_exists': True,
-            'status': 'this-is-not-a-status',
-        },
-    ]
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.good_data_1 = [
+            {
+                'student_key': 'abcd',
+                'account_exists': True,
+                'status': cls.status(0),
+            },
+            {
+                'student_key': 'efgh',
+                'account_exists': False,
+                'status': cls.status(4),
+            },
+        ]
+        cls.good_data_2 = [
+            {
+                'student_key': 'ijkl',
+                'account_exists': False,
+                'status': cls.status(2),
+            },
+            {
+                'student_key': 'mnop',
+                'account_exists': True,
+                'status': cls.status(3),
+            },
+        ]
+        cls.bad_data = [
+            {
+                'student_key': 'qrst',
+                'account_exists': True,
+                'status': 'this-is-not-a-status',
+            },
+        ]
+
+    @classmethod
+    def status(cls, i):
+        return cls.status_choices[i % len(cls.status_choices)]
+
+    def get_enrollments(self):
+        """ Override in subclass """
+        raise NotImplementedError
 
     @mock_oauth_login
     @responses.activate
-    def test_get_program_enrollments(self):
+    def test_get_enrollments(self):
         responses.add(
             responses.GET,
-            self.url,
+            self.lms_url,
             status=200,
-            json={'next': self.url + "?cursor=xxx", 'results': self.good_data_1},
+            json={'next': self.lms_url + "?cursor=xxx", 'results': self.good_data_1},
         )
         responses.add(
             responses.GET,
-            self.url,
+            self.lms_url,
             status=200,
             json={'next': None, 'results': self.good_data_2},
         )
-        enrolls = get_program_enrollments(self.uuid)
+        enrolls = self.get_enrollments()
         self.assertCountEqual(enrolls, self.good_data_1 + self.good_data_2)
 
     @mock_oauth_login
     @responses.activate
-    def test_get_program_enrollments_bad_data(self):
+    def test_get_enrollments_bad_data(self):
         responses.add(
             responses.GET,
-            self.url,
+            self.lms_url,
             status=200,
             json={'next': None, 'results': self.good_data_1 + self.bad_data},
         )
         with self.assertRaises(ValidationError):
-            get_program_enrollments(self.uuid)
+            self.get_enrollments()
 
     @mock_oauth_login
     @responses.activate
-    def test_get_program_enrollments_500(self):
-        responses.add(responses.GET, self.url, status=500)
+    def test_get_enrollments_500(self):
+        responses.add(responses.GET, self.lms_url, status=500)
         with self.assertRaises(HTTPError):
-            get_program_enrollments(self.uuid)
+            self.get_enrollments()
+
+
+class GetProgramEnrollmentsTestCase(GetEnrollmentsTestMixin, TestCase):
+    """ Tests for data.get_program_enrollments """
+
+    program_uuid = '7fbefaa4-c0e8-431b-af69-8d3ddde543a2'
+    lms_url = '{}/api/program_enrollments/v1/programs/{}/enrollments'.format(
+        settings.LMS_BASE_URL, program_uuid
+    )
+    status_choices = ['enrolled', 'pending', 'suspended', 'canceled']
+
+    def get_enrollments(self):
+        return get_program_enrollments(self.program_uuid)
+
+
+class GetCourseRunEnrollmentsTestCase(GetEnrollmentsTestMixin, TestCase):
+    """ Tests for data.get_course_run_enrollments """
+
+    program_uuid = 'ce5ea4c8-666e-429c-9d2c-a5698f86f6fb'
+    course_id = 'course-v1:ABCx+Subject-101+Term'
+    lms_url = '{}/api/program_enrollments/v1/programs/{}/courses/{}/enrollments'.format(
+        settings.LMS_BASE_URL, program_uuid, course_id
+    )
+    status_choices = ['active', 'inactive']
+
+    def get_enrollments(self):
+        return get_course_run_enrollments(self.program_uuid, self.course_id)
 
 
 class GetDiscoveryProgramTestCase(TestCase):
     """ Test get_discovery_program function """
 
-    program_uuid = uuid.uuid4()
+    program_uuid = str(uuid.uuid4())
+    curriculum_uuid = str(uuid.uuid4())
     discovery_url = urljoin(settings.DISCOVERY_BASE_URL, 'api/v1/programs/{}/').format(program_uuid)
+    course_run_1 = {
+        'key': '0001',
+        'uuid': '0000-0001',
+        'title': 'Test Course 1',
+        'marketing_url': 'https://stem-institute.edx.org/masters-in-cs/test-course-1',
+    }
     programs_response = {
         'curricula': [{
-            'uuid': uuid.uuid4().hex[0:10],
+            'uuid': curriculum_uuid,
             'is_active': True,
-            'courses': [
-                {
-                    'course_runs': [
-                        {
-                            'key': '0001',
-                            'uuid': '0000-0001',
-                            'title': 'Test Course 1',
-                            'marketing_url': 'https://stem-institute.edx.org/masters-in-cs/test-course-1',
-                        },
-                    ],
-                }
-            ],
+            'courses': [{'course_runs': [course_run_1]}],
         }],
     }
+    expected_program = DiscoveryProgram(
+        version=0,
+        loaded=datetime.now(),
+        uuid=program_uuid,
+        active_curriculum_uuid=curriculum_uuid,
+        course_runs=[
+            DiscoveryCourseRun(
+                course_run_1['key'],
+                course_run_1['title'],
+                course_run_1['marketing_url'],
+            ),
+        ],
+    )
 
     def setUp(self):
-        super(GetDiscoveryProgramTestCase, self).setUp()
+        super().setUp()
         cache.clear()
+
+    def assert_discovery_programs_equal(self, this_program, that_program):
+        """ Asserts DiscoveryProgram equality, ignoring `loaded` field. """
+        self.assertEqual(this_program.version, 1)
+        self.assertEqual(this_program.uuid, that_program.uuid)
+        self.assertEqual(this_program.active_curriculum_uuid, that_program.active_curriculum_uuid)
+        self.assertEqual(this_program.course_runs, that_program.course_runs)
 
     @mock_oauth_login
     @responses.activate
@@ -133,20 +193,19 @@ class GetDiscoveryProgramTestCase(TestCase):
         Note: TWO calls are initially made to discovery in order to obtain an auth token and then
         request data.
         """
-
         responses.add(
             responses.GET,
             self.discovery_url,
             json=self.programs_response,
             status=200
         )
-        response = get_discovery_program(self.program_uuid)
-        self.assertEqual(response, self.programs_response)
+        loaded_program = DiscoveryProgram.get(self.program_uuid)
+        self.assert_discovery_programs_equal(loaded_program, self.expected_program)
         self.assertEqual(len(responses.calls), 2)
 
         # this should return the same object from cache
-        response = get_discovery_program(self.program_uuid)
-        self.assertEqual(response, self.programs_response)
+        loaded_program = DiscoveryProgram.get(self.program_uuid)
+        self.assert_discovery_programs_equal(loaded_program, self.expected_program)
         self.assertEqual(len(responses.calls), 2)
 
     @mock_oauth_login
@@ -164,7 +223,7 @@ class GetDiscoveryProgramTestCase(TestCase):
         )
 
         with self.assertRaises(HTTPError):
-            get_discovery_program(self.program_uuid)
+            DiscoveryProgram.get(self.program_uuid)
 
         responses.replace(
             responses.GET,
@@ -172,5 +231,25 @@ class GetDiscoveryProgramTestCase(TestCase):
             json=self.programs_response,
             status=200
         )
-        response = get_discovery_program(self.program_uuid)
-        self.assertEqual(response, self.programs_response)
+        loaded_program = DiscoveryProgram.get(self.program_uuid)
+        self.assert_discovery_programs_equal(loaded_program, self.expected_program)
+
+    @mock_oauth_login
+    @responses.activate
+    def test_get_discovery_cache_versioning(self):
+        """
+        Verify that bumping the version of the cache invalidates old
+        entries.
+        """
+        responses.add(
+            responses.GET,
+            self.discovery_url,
+            json=self.programs_response,
+            status=200
+        )
+        DiscoveryProgram.get(self.program_uuid)
+        self.assertEqual(len(responses.calls), 2)
+        bumped_version = DiscoveryProgram.class_version + 1
+        with mock.patch.object(DiscoveryProgram, 'class_version', bumped_version):
+            DiscoveryProgram.get(self.program_uuid)
+        self.assertEqual(len(responses.calls), 4)


### PR DESCRIPTION
[EDUCATOR-4110](https://openedx.atlassian.net/browse/EDUCATOR-4110)
@edx/masters-neem 

This PR adds the asynchronous course-enrollment GET endpoint to the Registrar V1 API.

Currently, we cache Discovery program data as it comes: a JSON blob. Then, we extract necessary data and do validation on it per-request. In this PR, I propose extracting and validating that data *before* caching it. That logic is abstracted by the new `DiscoveryProgram` class in data.py. My reasoning is that we will eventually use the Discovery data in every V1 endpoint, so for the purposes of DRY, we should validate it all in one place. Additionally, by having a class with definite attributes, future developers will know what data to expect in the cache (instead of having to trawl through Discovery). Happy to hear any thoughts on this.