### PR TITLE
Sort imports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,6 @@ install:
 script:
     - make validate_translations
     - make validate
-    - make pii_check
     - make static
-    - make validate_api_committed
 after_success:
     - codecov

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ pii_check: ## check for PII annotations on all Django models
 	DJANGO_SETTINGS_MODULE=registrar.settings.test \
 	code_annotations django_find_annotations --config_file .pii_annotations.yml --lint --report --coverage
 
-validate: coverage quality pii_check ## run tests and quality checks 
+validate: validate_isort coverage quality pii_check validate_api_committed  ## run all tests and quality checks
 
 migrate: ## apply database migrations
 	python manage.py migrate
@@ -121,3 +121,9 @@ api_generated: ## generates an expanded verison of api.yaml for consuming tools 
 
 validate_api_committed: ## check to make sure any api.yaml changes have been committed to the expanded document
 	bash -c "diff .api-generated.yaml <(python scripts/yaml_merge.py api.yaml -)"
+
+isort: ## run isort to sort imports in all Python files
+	isort --recursive --atomic registrar scripts
+
+validate_isort: ## return 1 iff isort needs to be run
+	isort --check-only -rc registrar/ scripts/

--- a/registrar/api_renderer.py
+++ b/registrar/api_renderer.py
@@ -4,6 +4,7 @@ Renders a yaml API spec to an HTML/JavaScript view
 import copy
 import json
 import os
+
 import yaml
 from django.conf import settings
 from django.shortcuts import render

--- a/registrar/apps/api/exceptions.py
+++ b/registrar/apps/api/exceptions.py
@@ -1,8 +1,9 @@
 """
 Custom exceptions extending those definined by DRF.
 """
-from rest_framework.exceptions import APIException
 from rest_framework import status
+from rest_framework.exceptions import APIException
+
 from registrar.apps.api.constants import ENROLLMENT_WRITE_MAX_SIZE
 
 

--- a/registrar/apps/api/internal/tests/test_views.py
+++ b/registrar/apps/api/internal/tests/test_views.py
@@ -1,6 +1,5 @@
 """ Tests for internal API views """
 import ddt
-
 from django.core.cache import cache
 
 from registrar.apps.api.tests.mixins import AuthRequestMixin

--- a/registrar/apps/api/internal/urls.py
+++ b/registrar/apps/api/internal/urls.py
@@ -3,9 +3,8 @@
 from django.conf.urls import url
 
 from registrar.apps.api.internal import views
-from registrar.apps.core.constants import (
-    PROGRAM_KEY_PATTERN,
-)
+from registrar.apps.core.constants import PROGRAM_KEY_PATTERN
+
 
 app_name = 'internal'
 

--- a/registrar/apps/api/internal/views.py
+++ b/registrar/apps/api/internal/views.py
@@ -1,11 +1,13 @@
 """ Internal utility API views """
 from django.core.cache import cache
 from django.shortcuts import get_object_or_404
-from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
+from edx_rest_framework_extensions.auth.jwt.authentication import (
+    JwtAuthentication,
+)
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.response import Response
-from rest_framework.views import APIView
 from rest_framework.status import HTTP_204_NO_CONTENT
+from rest_framework.views import APIView
 
 from registrar.apps.api.v1.mixins import AuthMixin
 from registrar.apps.enrollments.constants import PROGRAM_CACHE_KEY_TPL

--- a/registrar/apps/api/segment.py
+++ b/registrar/apps/api/segment.py
@@ -2,11 +2,13 @@
 Convenience functions for working with the segment.io analytics library
 """
 import logging
+
 import analytics
 from django.conf import settings
 
 from registrar.apps.api.constants import TRACKING_CATEGORY
 from registrar.apps.core.utils import get_user_organizations
+
 
 logger = logging.getLogger(__name__)
 

--- a/registrar/apps/api/tests/mixins.py
+++ b/registrar/apps/api/tests/mixins.py
@@ -1,13 +1,13 @@
 """
 Mixins for Registrar API tests.
 """
-from contextlib import contextmanager
 import json
+from contextlib import contextmanager
 from time import time
 
-from django.conf import settings
 import jwt
 import mock
+from django.conf import settings
 
 from registrar.apps.api.constants import TRACKING_CATEGORY
 from registrar.apps.core.utils import get_user_organizations

--- a/registrar/apps/api/tests/test_views.py
+++ b/registrar/apps/api/tests/test_views.py
@@ -6,10 +6,10 @@ from rest_framework.test import APITestCase
 
 from registrar.apps.core import permissions as perms
 from registrar.apps.core.tests.factories import (
+    USER_PASSWORD,
     OrganizationFactory,
     OrganizationGroupFactory,
     UserFactory,
-    USER_PASSWORD
 )
 from registrar.apps.enrollments.tests.factories import ProgramFactory
 

--- a/registrar/apps/api/urls.py
+++ b/registrar/apps/api/urls.py
@@ -4,11 +4,12 @@ Root API URLs.
 All API URLs should be versioned, so urlpatterns should only
 contain namespaces for the active versions of the API.
 """
-from django.conf.urls import url, include
+from django.conf.urls import include, url
 
 from registrar.apps.api.internal import urls as internal_urls
-from registrar.apps.api.v1_mock import urls as v1_mock_urls
 from registrar.apps.api.v1 import urls as v1_urls
+from registrar.apps.api.v1_mock import urls as v1_mock_urls
+
 
 app_name = 'api'
 urlpatterns = [

--- a/registrar/apps/api/v1/mixins.py
+++ b/registrar/apps/api/v1/mixins.py
@@ -3,12 +3,11 @@ Mixins for the public V1 REST API.
 """
 from collections.abc import Iterable
 
-from django.core.exceptions import (
-    ImproperlyConfigured,
-    PermissionDenied,
-)
+from django.core.exceptions import ImproperlyConfigured, PermissionDenied
 from django.http import Http404
-from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
+from edx_rest_framework_extensions.auth.jwt.authentication import (
+    JwtAuthentication,
+)
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.exceptions import NotAuthenticated, ValidationError
 from rest_framework.response import Response
@@ -19,10 +18,10 @@ from registrar.apps.api.constants import ENROLLMENT_WRITE_MAX_SIZE
 from registrar.apps.api.mixins import TrackViewMixin
 from registrar.apps.api.serializers import JobAcceptanceSerializer
 from registrar.apps.api.utils import build_absolute_api_url
-from registrar.apps.enrollments.models import Program
 from registrar.apps.core import permissions as perms
 from registrar.apps.core.jobs import start_job
 from registrar.apps.enrollments.data import DiscoveryProgram
+from registrar.apps.enrollments.models import Program
 
 
 class AuthMixin(TrackViewMixin):

--- a/registrar/apps/api/v1/tests/test_views.py
+++ b/registrar/apps/api/v1/tests/test_views.py
@@ -1,23 +1,22 @@
 """ Tests for API views. """
 import json
-from posixpath import join as urljoin
 import uuid
+from posixpath import join as urljoin
 
 import boto3
-from celery import shared_task
-from django.conf import settings
-from django.core.cache import cache
-from django.urls import reverse
 import ddt
-from faker import Faker
-from guardian.shortcuts import assign_perm
 import mock
 import moto
 import requests
 import responses
+from celery import shared_task
+from django.conf import settings
+from django.core.cache import cache
+from django.urls import reverse
+from faker import Faker
+from guardian.shortcuts import assign_perm
 from rest_framework.test import APITestCase
 from user_tasks.tasks import UserTask
-
 
 from registrar.apps.api.constants import ENROLLMENT_WRITE_MAX_SIZE
 from registrar.apps.api.tests.mixins import AuthRequestMixin, TrackTestMixin
@@ -35,7 +34,10 @@ from registrar.apps.core.tests.factories import (
 )
 from registrar.apps.core.tests.utils import mock_oauth_login
 from registrar.apps.enrollments.constants import PROGRAM_CACHE_KEY_TPL
-from registrar.apps.enrollments.data import DiscoveryProgram, LMS_PROGRAM_COURSE_ENROLLMENTS_API_TPL
+from registrar.apps.enrollments.data import (
+    LMS_PROGRAM_COURSE_ENROLLMENTS_API_TPL,
+    DiscoveryProgram,
+)
 from registrar.apps.enrollments.tests.factories import ProgramFactory
 
 

--- a/registrar/apps/api/v1/views.py
+++ b/registrar/apps/api/v1/views.py
@@ -3,12 +3,11 @@ The public-facing REST API.
 """
 import logging
 
-from django.core.exceptions import (
-    ObjectDoesNotExist,
-    PermissionDenied,
-)
+from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.http import Http404
-from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
+from edx_rest_framework_extensions.auth.jwt.authentication import (
+    JwtAuthentication,
+)
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.generics import ListAPIView, RetrieveAPIView
 from rest_framework.permissions import IsAuthenticated
@@ -16,6 +15,11 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from registrar.apps.api.mixins import TrackViewMixin
+from registrar.apps.api.serializers import (
+    CourseRunSerializer,
+    JobStatusSerializer,
+    ProgramSerializer,
+)
 from registrar.apps.api.v1.mixins import (
     AuthMixin,
     CourseSpecificViewMixin,
@@ -23,24 +27,20 @@ from registrar.apps.api.v1.mixins import (
     JobInvokerMixin,
     ProgramSpecificViewMixin,
 )
-from registrar.apps.api.serializers import (
-    CourseRunSerializer,
-    JobStatusSerializer,
-    ProgramSerializer,
-)
-from registrar.apps.enrollments.models import Program
 from registrar.apps.core import permissions as perms
 from registrar.apps.core.jobs import get_job_status
 from registrar.apps.core.models import Organization
 from registrar.apps.enrollments.data import (
     DiscoveryProgram,
-    write_program_enrollments,
     write_program_course_enrollments,
+    write_program_enrollments,
 )
+from registrar.apps.enrollments.models import Program
 from registrar.apps.enrollments.tasks import (
     list_course_run_enrollments,
     list_program_enrollments,
 )
+
 
 logger = logging.getLogger(__name__)
 

--- a/registrar/apps/api/v1_mock/data.py
+++ b/registrar/apps/api/v1_mock/data.py
@@ -2,10 +2,10 @@
 Fake data for the mock API.
 """
 
-from collections import namedtuple
-from datetime import datetime
 import random
 import uuid
+from collections import namedtuple
+from datetime import datetime
 
 from django.core.cache import cache
 from user_tasks.models import UserTaskStatus

--- a/registrar/apps/api/v1_mock/tests/test_views.py
+++ b/registrar/apps/api/v1_mock/tests/test_views.py
@@ -14,9 +14,9 @@ from registrar.apps.api.v1_mock.data import (
 from registrar.apps.core import permissions as perms
 from registrar.apps.core.tests.factories import (
     GroupFactory,
-    UserFactory,
     OrganizationFactory,
-    OrganizationGroupFactory
+    OrganizationGroupFactory,
+    UserFactory,
 )
 
 

--- a/registrar/apps/api/v1_mock/views.py
+++ b/registrar/apps/api/v1_mock/views.py
@@ -4,10 +4,11 @@ testing.
 """
 from django.core.exceptions import PermissionDenied
 from django.http import Http404
-from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
+from edx_rest_framework_extensions.auth.jwt.authentication import (
+    JwtAuthentication,
+)
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.exceptions import ValidationError
-from rest_framework.views import APIView
 from rest_framework.generics import ListAPIView, RetrieveAPIView
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -17,29 +18,30 @@ from rest_framework.status import (
     HTTP_413_REQUEST_ENTITY_TOO_LARGE,
     HTTP_422_UNPROCESSABLE_ENTITY,
 )
+from rest_framework.views import APIView
 
 from registrar.apps.api.mixins import TrackViewMixin
 from registrar.apps.api.serializers import (
+    CourseEnrollmentModificationRequestSerializer,
+    CourseEnrollmentRequestSerializer,
     CourseRunSerializer,
     JobAcceptanceSerializer,
     JobStatusSerializer,
-    ProgramSerializer,
-    ProgramEnrollmentRequestSerializer,
     ProgramEnrollmentModificationRequestSerializer,
-    CourseEnrollmentRequestSerializer,
-    CourseEnrollmentModificationRequestSerializer,
+    ProgramEnrollmentRequestSerializer,
+    ProgramSerializer,
 )
 from registrar.apps.api.utils import build_absolute_api_url
 from registrar.apps.api.v1_mock.data import (
-    invoke_fake_course_enrollment_listing_job,
-    invoke_fake_program_enrollment_listing_job,
     FAKE_ORG_DICT,
     FAKE_ORG_PROGRAMS,
-    FAKE_PROGRAMS,
     FAKE_PROGRAM_COURSE_RUNS,
     FAKE_PROGRAM_DICT,
+    FAKE_PROGRAMS,
     FakeJobAcceptance,
     get_fake_job_status,
+    invoke_fake_course_enrollment_listing_job,
+    invoke_fake_program_enrollment_listing_job,
 )
 from registrar.apps.core import permissions as perms
 

--- a/registrar/apps/core/admin.py
+++ b/registrar/apps/core/admin.py
@@ -3,8 +3,8 @@
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
 from django.utils.translation import ugettext_lazy as _
-
 from guardian.admin import GuardedModelAdmin
+
 from registrar.apps.core.models import (
     Organization,
     OrganizationGroup,

--- a/registrar/apps/core/apps.py
+++ b/registrar/apps/core/apps.py
@@ -7,6 +7,7 @@ from logging import getLogger
 
 from django.apps import AppConfig
 
+
 logger = getLogger(__name__)
 
 

--- a/registrar/apps/core/jobs.py
+++ b/registrar/apps/core/jobs.py
@@ -13,9 +13,9 @@ from the UserTask ID. For this reason, we attempt not to expose the relationship
 between job_ids and UserTask IDs outside of this module.
 """
 
-from collections import namedtuple
 import logging
 import uuid
+from collections import namedtuple
 
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from user_tasks.models import UserTaskArtifact, UserTaskStatus

--- a/registrar/apps/core/models.py
+++ b/registrar/apps/core/models.py
@@ -1,13 +1,14 @@
 """ Core models. """
 
-from django.contrib.auth.models import Group
-from django.contrib.auth.models import AbstractUser
+from django.contrib.auth.models import AbstractUser, Group
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 from guardian.shortcuts import remove_perm
 from model_utils.models import TimeStampedModel
+
 from registrar.apps.core import permissions as perms
+
 
 ACCESS_ADMIN = ('admin', 2)
 ACCESS_WRITE = ('write', 1)

--- a/registrar/apps/core/signals.py
+++ b/registrar/apps/core/signals.py
@@ -5,6 +5,7 @@ from logging import getLogger
 
 from registrar.apps.core.models import PendingUserOrganizationGroup
 
+
 logger = getLogger(__name__)
 
 

--- a/registrar/apps/core/tests/factories.py
+++ b/registrar/apps/core/tests/factories.py
@@ -3,16 +3,19 @@ Factories for creating core data.
 """
 
 import re
+
 import factory
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
 from guardian.shortcuts import assign_perm
-from registrar.apps.core.permissions import OrganizationReadMetadataRole
+
 from registrar.apps.core.models import (
     Organization,
     OrganizationGroup,
     PendingUserOrganizationGroup,
 )
+from registrar.apps.core.permissions import OrganizationReadMetadataRole
+
 
 # pylint: disable=missing-docstring
 

--- a/registrar/apps/core/tests/test_context_processors.py
+++ b/registrar/apps/core/tests/test_context_processors.py
@@ -1,8 +1,9 @@
 """ Context processor tests. """
 
-from django.test import TestCase, override_settings, RequestFactory
+from django.test import RequestFactory, TestCase, override_settings
 
 from registrar.apps.core.context_processors import core
+
 
 PLATFORM_NAME = 'Test Platform'
 

--- a/registrar/apps/core/tests/test_models.py
+++ b/registrar/apps/core/tests/test_models.py
@@ -6,15 +6,18 @@ from django_dynamic_fixture import G
 from guardian.shortcuts import get_perms
 from social_django.models import UserSocialAuth
 
-from registrar.apps.core.tests.factories import UserFactory
-from registrar.apps.core.models import User
-from registrar.apps.core.tests.factories import OrganizationFactory, OrganizationGroupFactory
+import registrar.apps.core.permissions as perm
 from registrar.apps.core.models import (
     Organization,
     OrganizationGroup,
     PendingUserOrganizationGroup,
+    User,
 )
-import registrar.apps.core.permissions as perm
+from registrar.apps.core.tests.factories import (
+    OrganizationFactory,
+    OrganizationGroupFactory,
+    UserFactory,
+)
 
 
 class UserTests(TestCase):

--- a/registrar/apps/core/tests/test_signals.py
+++ b/registrar/apps/core/tests/test_signals.py
@@ -2,11 +2,11 @@
 Tests for signal handlers in this app
 """
 import ddt
-from django.test import TestCase
 from django.apps import apps
+from django.test import TestCase
 
-from registrar.apps.core.models import User, PendingUserOrganizationGroup
 from registrar.apps.core import permissions as perms
+from registrar.apps.core.models import PendingUserOrganizationGroup, User
 from registrar.apps.core.tests.factories import (
     OrganizationGroupFactory,
     PendingUserOrganizationGroupFactory,

--- a/registrar/apps/core/tests/test_utils.py
+++ b/registrar/apps/core/tests/test_utils.py
@@ -9,10 +9,7 @@ from registrar.apps.core.tests.factories import (
     OrganizationGroupFactory,
     UserFactory,
 )
-from registrar.apps.core.utils import (
-    get_user_organizations,
-    serialize_to_csv,
-)
+from registrar.apps.core.utils import get_user_organizations, serialize_to_csv
 
 
 @ddt.ddt

--- a/registrar/apps/core/tests/test_views.py
+++ b/registrar/apps/core/tests/test_views.py
@@ -1,12 +1,12 @@
 """Test core.views."""
 
-from django.db import DatabaseError
+import mock
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.urls import reverse
+from django.db import DatabaseError
 from django.test import TestCase
 from django.test.utils import override_settings
-import mock
+from django.urls import reverse
 
 from registrar.apps.core.constants import Status
 

--- a/registrar/apps/core/tests/utils.py
+++ b/registrar/apps/core/tests/utils.py
@@ -1,10 +1,10 @@
 """ General utilities for unit tests. """
 
-from functools import wraps
 import json
+from functools import wraps
 
-from django.conf import settings
 import responses
+from django.conf import settings
 
 
 def mock_oauth_login(fn):

--- a/registrar/apps/core/utils.py
+++ b/registrar/apps/core/utils.py
@@ -1,7 +1,7 @@
 """ Miscellaneous utilities not specific to any app. """
 import csv
-from io import StringIO
 import re
+from io import StringIO
 
 from registrar.apps.core.models import OrganizationGroup
 

--- a/registrar/apps/core/views.py
+++ b/registrar/apps/core/views.py
@@ -2,15 +2,15 @@
 import logging
 import uuid
 
-from django.db import transaction, connection, DatabaseError
-from django.http import JsonResponse
 from django.conf import settings
-from django.contrib.auth import get_user_model, login, authenticate
-from django.http import Http404
+from django.contrib.auth import authenticate, get_user_model, login
+from django.db import DatabaseError, connection, transaction
+from django.http import Http404, JsonResponse
 from django.shortcuts import redirect
 from django.views.generic import View
 
 from registrar.apps.core.constants import Status
+
 
 logger = logging.getLogger(__name__)
 User = get_user_model()

--- a/registrar/apps/enrollments/admin.py
+++ b/registrar/apps/enrollments/admin.py
@@ -3,4 +3,5 @@ from django.contrib import admin
 
 from registrar.apps.enrollments import models
 
+
 admin.site.register(models.Program)

--- a/registrar/apps/enrollments/data.py
+++ b/registrar/apps/enrollments/data.py
@@ -1,16 +1,15 @@
 """
 Module for syncing data with external services.
 """
+import logging
 from collections import namedtuple
 from datetime import datetime
-import logging
 from posixpath import join as urljoin
 
-from django.core.cache import cache
 from django.conf import settings
-from requests.exceptions import HTTPError
-
+from django.core.cache import cache
 from edx_rest_api_client import client as rest_client
+from requests.exceptions import HTTPError
 
 from registrar.apps.enrollments.constants import PROGRAM_CACHE_KEY_TPL
 from registrar.apps.enrollments.serializers import (

--- a/registrar/apps/enrollments/serializers.py
+++ b/registrar/apps/enrollments/serializers.py
@@ -1,10 +1,11 @@
 """ Serializers for communicating enrollment data with LMS """
 
 from rest_framework import serializers
+
 from registrar.apps.core.utils import serialize_to_csv
 from registrar.apps.enrollments.constants import (
-    PROGRAM_ENROLLMENT_STATUSES,
     COURSE_ENROLLMENT_STATUSES,
+    PROGRAM_ENROLLMENT_STATUSES,
 )
 
 

--- a/registrar/apps/enrollments/tasks.py
+++ b/registrar/apps/enrollments/tasks.py
@@ -10,7 +10,6 @@ from rest_framework.exceptions import ValidationError
 from user_tasks.models import UserTaskArtifact
 from user_tasks.tasks import UserTask
 
-
 from registrar.apps.core.jobs import post_job_failure, post_job_success
 from registrar.apps.enrollments.data import (
     get_course_run_enrollments,

--- a/registrar/apps/enrollments/tests/factories.py
+++ b/registrar/apps/enrollments/tests/factories.py
@@ -3,9 +3,7 @@ Factories for creating enrollment data.
 """
 import factory
 
-from registrar.apps.enrollments.models import (
-    Program,
-)
+from registrar.apps.enrollments.models import Program
 
 
 # pylint: disable=missing-docstring

--- a/registrar/apps/enrollments/tests/test_data.py
+++ b/registrar/apps/enrollments/tests/test_data.py
@@ -5,26 +5,26 @@ Much of data.py is not tested in this file because it is already implicitly
 tested by our view tests.
 """
 
-from datetime import datetime
 import json
-from posixpath import join as urljoin
 import uuid
+from datetime import datetime
+from posixpath import join as urljoin
 
+import mock
+import responses
 from django.conf import settings
 from django.core.cache import cache
 from django.test import TestCase
-import mock
 from requests.exceptions import HTTPError
-import responses
 from rest_framework.exceptions import ValidationError
 
 from registrar.apps.core.tests.utils import mock_oauth_login
 from registrar.apps.enrollments.data import (
     DISCOVERY_PROGRAM_API_TPL,
-    DiscoveryCourseRun,
-    DiscoveryProgram,
     LMS_PROGRAM_COURSE_ENROLLMENTS_API_TPL,
     LMS_PROGRAM_ENROLLMENTS_API_TPL,
+    DiscoveryCourseRun,
+    DiscoveryProgram,
     get_course_run_enrollments,
     get_program_enrollments,
     write_program_course_enrollments,

--- a/registrar/apps/enrollments/tests/test_tasks.py
+++ b/registrar/apps/enrollments/tests/test_tasks.py
@@ -1,24 +1,25 @@
 """
 Unit tests for the enrollment.tasks module.
 """
-from collections import namedtuple
 import uuid
-import mock
+from collections import namedtuple
 
+import mock
 from django.test import TestCase
-from rest_framework.exceptions import ValidationError
 from requests.exceptions import HTTPError
+from rest_framework.exceptions import ValidationError
 from user_tasks.models import UserTaskArtifact, UserTaskStatus
 
-from registrar.apps.core.tests.factories import UserFactory, OrganizationFactory
+from registrar.apps.core.tests.factories import OrganizationFactory, UserFactory
 from registrar.apps.enrollments import tasks
-from registrar.apps.enrollments.tests.factories import ProgramFactory
 from registrar.apps.enrollments.constants import (
-    PROGRAM_ENROLLMENT_ENROLLED,
-    PROGRAM_ENROLLMENT_PENDING,
     COURSE_ENROLLMENT_ACTIVE,
     COURSE_ENROLLMENT_INACTIVE,
+    PROGRAM_ENROLLMENT_ENROLLED,
+    PROGRAM_ENROLLMENT_PENDING,
 )
+from registrar.apps.enrollments.tests.factories import ProgramFactory
+
 
 FakeRequest = namedtuple('FakeRequest', ['url'])
 FakeResponse = namedtuple('FakeResponse', ['status_code'])

--- a/registrar/urls.py
+++ b/registrar/urls.py
@@ -25,6 +25,7 @@ from registrar import api_renderer
 from registrar.apps.api import urls as api_urls
 from registrar.apps.core import views as core_views
 
+
 admin.autodiscover()
 
 app_name = 'registrar'

--- a/registrar/wsgi.py
+++ b/registrar/wsgi.py
@@ -10,11 +10,13 @@ import os
 from os.path import abspath, dirname
 from sys import path
 
+from django.core.wsgi import get_wsgi_application
+
+
 SITE_ROOT = dirname(dirname(abspath(__file__)))
 path.append(SITE_ROOT)
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "registrar.settings.local")
 
-from django.core.wsgi import get_wsgi_application
 
 application = get_wsgi_application()  # pylint: disable=invalid-name

--- a/requirements/devstack.txt
+++ b/requirements/devstack.txt
@@ -16,13 +16,13 @@ aws-sam-translator==1.11.0  # via cfn-lint
 aws-xray-sdk==2.4.2       # via moto
 babel==2.6.0              # via sphinx
 billiard==3.3.0.23        # via celery
-boto3==1.9.146            # via aws-sam-translator, moto
+boto3==1.9.152            # via aws-sam-translator, moto
 boto==2.49.0              # via moto
-botocore==1.12.146        # via aws-xray-sdk, boto3, moto, s3transfer
+botocore==1.12.152        # via aws-xray-sdk, boto3, moto, s3transfer
 celery==3.1.26.post2
 certifi==2019.3.9         # via requests
 cffi==1.12.3              # via cryptography
-cfn-lint==0.20.1          # via moto
+cfn-lint==0.20.3          # via moto
 chardet==3.0.4            # via requests
 click-log==0.3.2          # via edx-lint
 click==7.0                # via click-log, code-annotations, edx-lint
@@ -34,10 +34,10 @@ ddt==1.2.1
 defusedxml==0.6.0         # via python3-openid, social-auth-core
 django-debug-toolbar==1.11
 django-dynamic-fixture==2.0.0
-django-extensions==2.1.6
+django-extensions==2.1.7
 django-guardian==1.5.1
 django-model-utils==3.1.2
-django-mysql==3.0.0.post1
+django-mysql==3.1.0
 django-simple-history==2.7.2
 django-storages==1.7.1
 django-user-tasks==0.1.5
@@ -45,8 +45,8 @@ django-waffle==0.16.0
 django==1.11.20
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.9.4
-docker-pycreds==0.4.0     # via docker
-docker==3.7.2             # via moto
+docker==4.0.1             # via moto
+docopt==0.6.2             # via pipreqs
 docutils==0.14            # via botocore, sphinx
 ecdsa==0.13.2             # via python-jose
 edx-auth-backends==2.0.1
@@ -54,17 +54,17 @@ edx-django-release-util==0.3.1
 edx-django-utils==1.0.3   # via edx-drf-extensions
 edx-drf-extensions==2.2.1
 edx-i18n-tools==0.4.8
-edx-lint==1.1.2
+edx-lint==1.2.0
 edx-opaque-keys==0.4.4    # via edx-drf-extensions
 edx-rest-api-client==1.9.2
 edx-sphinx-theme==1.4.0
 factory-boy==2.12.0
-faker==1.0.6
+faker==1.0.7
 future==0.17.1            # via aws-xray-sdk, pyjwkest, python-jose
 idna==2.8                 # via moto, requests
 imagesize==1.1.0          # via sphinx
-importlib-metadata==0.11  # via path.py
-isort==4.3.19             # via pylint
+importlib-metadata==0.13  # via path.py
+isort[requirements]==4.3.20
 jinja2==2.10.1            # via code-annotations, moto, sphinx
 jmespath==0.9.4           # via boto3, botocore
 jsondiff==1.1.2           # via moto
@@ -82,10 +82,13 @@ moto==1.3.8
 mysqlclient==1.3.14
 newrelic==4.18.0.118      # via edx-django-utils
 oauthlib==3.0.1           # via requests-oauthlib, social-auth-core
+packaging==19.0           # via pip-api
 path.py==12.0.1           # via edx-i18n-tools
 pathlib2==2.3.3           # via pytest
 pathspec==0.5.9           # via yamllint
 pbr==5.2.0                # via stevedore
+pip-api==0.0.8            # via isort
+pipreqs==0.4.9            # via isort
 pluggy==0.11.0            # via pytest
 polib==1.1.0              # via edx-i18n-tools
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
@@ -102,6 +105,7 @@ pylint-django==0.7.2      # via edx-lint
 pylint-plugin-utils==0.5  # via pylint-celery, pylint-django
 pylint==1.7.6             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.8.0            # via edx-opaque-keys
+pyparsing==2.4.0          # via packaging
 pytest-cov==2.7.1
 pytest-django==3.4.8
 pytest==4.5.0             # via pytest-cov, pytest-django
@@ -114,23 +118,23 @@ pytz==2019.1
 pyyaml==5.1               # via cfn-lint, code-annotations, edx-django-release-util, edx-i18n-tools, moto, yamllint
 redis==2.8
 requests-oauthlib==1.2.0  # via social-auth-core
-requests==2.21.0          # via analytics-python, cfn-lint, docker, edx-drf-extensions, edx-rest-api-client, moto, pyjwkest, requests-oauthlib, responses, slumber, social-auth-core, sphinx, transifex-client
+requests==2.21.0          # via analytics-python, cfn-lint, docker, edx-drf-extensions, edx-rest-api-client, moto, pyjwkest, requests-oauthlib, responses, slumber, social-auth-core, sphinx, transifex-client, yarg
 responses==0.10.6
 rest-condition==1.0.3     # via edx-drf-extensions
 rsa==4.0                  # via python-jose
 ruamel.std.argparse==0.8.1  # via ruamel.yaml.cmd
 ruamel.yaml.cmd==0.5.3
 ruamel.yaml.convert==0.3.0  # via ruamel.yaml.cmd
-ruamel.yaml==0.15.94      # via ruamel.yaml.cmd, ruamel.yaml.convert
+ruamel.yaml==0.15.96      # via ruamel.yaml.cmd, ruamel.yaml.convert
 s3transfer==0.2.0         # via boto3
 semantic-version==2.6.0   # via edx-drf-extensions
-six==1.11.0               # via analytics-python, astroid, aws-sam-translator, cfn-lint, configobj, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, docker, docker-pycreds, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, faker, mock, moto, pathlib2, pyjwkest, pylint, pytest, python-dateutil, python-jose, python-memcached, responses, social-auth-app-django, social-auth-core, sphinx, stevedore, transifex-client, websocket-client
+six==1.11.0               # via analytics-python, astroid, aws-sam-translator, cfn-lint, configobj, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, docker, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, faker, mock, moto, packaging, pathlib2, pyjwkest, pylint, pytest, python-dateutil, python-jose, python-memcached, responses, social-auth-app-django, social-auth-core, sphinx, stevedore, transifex-client, websocket-client
 slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==1.2.1    # via sphinx
 social-auth-app-django==1.2.0  # via edx-auth-backends
 social-auth-core[openidconnect]==1.7.0  # via edx-auth-backends, social-auth-app-django
 sphinx==1.6.7
-sphinxcontrib-websupport==1.1.0  # via sphinx
+sphinxcontrib-websupport==1.1.2  # via sphinx
 sqlparse==0.3.0           # via django-debug-toolbar
 stevedore==1.30.1         # via code-annotations, edx-opaque-keys
 text-unidecode==1.2       # via faker
@@ -139,8 +143,9 @@ unidecode==1.0.23         # via python-slugify
 urllib3==1.23             # via botocore, requests, transifex-client
 wcwidth==0.1.7            # via pytest
 websocket-client==0.56.0  # via docker
-werkzeug==0.15.2          # via moto
+werkzeug==0.15.4          # via moto
 wrapt==1.11.1             # via astroid, aws-xray-sdk
 xmltodict==0.12.0         # via moto
 yamllint==1.15.0
-zipp==0.5.0               # via importlib-metadata
+yarg==0.1.9               # via pipreqs
+zipp==0.5.1               # via importlib-metadata

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -16,13 +16,13 @@ aws-sam-translator==1.11.0  # via cfn-lint
 aws-xray-sdk==2.4.2       # via moto
 babel==2.6.0              # via sphinx
 billiard==3.3.0.23        # via celery
-boto3==1.9.146            # via aws-sam-translator, moto
+boto3==1.9.152            # via aws-sam-translator, moto
 boto==2.49.0              # via moto
-botocore==1.12.146        # via aws-xray-sdk, boto3, moto, s3transfer
+botocore==1.12.152        # via aws-xray-sdk, boto3, moto, s3transfer
 celery==3.1.26.post2
 certifi==2019.3.9         # via requests
 cffi==1.12.3              # via cryptography
-cfn-lint==0.20.1          # via moto
+cfn-lint==0.20.3          # via moto
 chardet==3.0.4            # via requests
 click-log==0.3.2          # via edx-lint
 click==7.0                # via click-log, code-annotations, edx-lint
@@ -34,10 +34,10 @@ ddt==1.2.1
 defusedxml==0.6.0         # via python3-openid, social-auth-core
 django-debug-toolbar==1.11
 django-dynamic-fixture==2.0.0
-django-extensions==2.1.6
+django-extensions==2.1.7
 django-guardian==1.5.1
 django-model-utils==3.1.2
-django-mysql==3.0.0.post1
+django-mysql==3.1.0
 django-simple-history==2.7.2
 django-storages==1.7.1
 django-user-tasks==0.1.5
@@ -45,8 +45,8 @@ django-waffle==0.16.0
 django==1.11.20
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.9.4
-docker-pycreds==0.4.0     # via docker
-docker==3.7.2             # via moto
+docker==4.0.1             # via moto
+docopt==0.6.2             # via pipreqs
 docutils==0.14            # via botocore, sphinx
 ecdsa==0.13.2             # via python-jose
 edx-auth-backends==2.0.1
@@ -54,17 +54,17 @@ edx-django-release-util==0.3.1
 edx-django-utils==1.0.3   # via edx-drf-extensions
 edx-drf-extensions==2.2.1
 edx-i18n-tools==0.4.8
-edx-lint==1.1.2
+edx-lint==1.2.0
 edx-opaque-keys==0.4.4    # via edx-drf-extensions
 edx-rest-api-client==1.9.2
 edx-sphinx-theme==1.4.0
 factory-boy==2.12.0
-faker==1.0.6
+faker==1.0.7
 future==0.17.1            # via aws-xray-sdk, pyjwkest, python-jose
 idna==2.8                 # via moto, requests
 imagesize==1.1.0          # via sphinx
-importlib-metadata==0.11  # via path.py
-isort==4.3.19             # via pylint
+importlib-metadata==0.13  # via path.py
+isort[requirements]==4.3.20
 jinja2==2.10.1            # via code-annotations, moto, sphinx
 jmespath==0.9.4           # via boto3, botocore
 jsondiff==1.1.2           # via moto
@@ -81,10 +81,13 @@ more-itertools==7.0.0     # via pytest
 moto==1.3.8
 newrelic==4.18.0.118      # via edx-django-utils
 oauthlib==3.0.1           # via requests-oauthlib, social-auth-core
+packaging==19.0           # via pip-api
 path.py==12.0.1           # via edx-i18n-tools
 pathlib2==2.3.3           # via pytest
 pathspec==0.5.9           # via yamllint
 pbr==5.2.0                # via stevedore
+pip-api==0.0.8            # via isort
+pipreqs==0.4.9            # via isort
 pluggy==0.11.0            # via pytest
 polib==1.1.0              # via edx-i18n-tools
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
@@ -101,6 +104,7 @@ pylint-django==0.7.2      # via edx-lint
 pylint-plugin-utils==0.5  # via pylint-celery, pylint-django
 pylint==1.7.6             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.8.0            # via edx-opaque-keys
+pyparsing==2.4.0          # via packaging
 pytest-cov==2.7.1
 pytest-django==3.4.8
 pytest==4.5.0             # via pytest-cov, pytest-django
@@ -112,23 +116,23 @@ pytz==2019.1
 pyyaml==5.1               # via cfn-lint, code-annotations, edx-django-release-util, edx-i18n-tools, moto, yamllint
 redis==2.8
 requests-oauthlib==1.2.0  # via social-auth-core
-requests==2.21.0          # via analytics-python, cfn-lint, docker, edx-drf-extensions, edx-rest-api-client, moto, pyjwkest, requests-oauthlib, responses, slumber, social-auth-core, sphinx, transifex-client
+requests==2.21.0          # via analytics-python, cfn-lint, docker, edx-drf-extensions, edx-rest-api-client, moto, pyjwkest, requests-oauthlib, responses, slumber, social-auth-core, sphinx, transifex-client, yarg
 responses==0.10.6
 rest-condition==1.0.3     # via edx-drf-extensions
 rsa==4.0                  # via python-jose
 ruamel.std.argparse==0.8.1  # via ruamel.yaml.cmd
 ruamel.yaml.cmd==0.5.3
 ruamel.yaml.convert==0.3.0  # via ruamel.yaml.cmd
-ruamel.yaml==0.15.94      # via ruamel.yaml.cmd, ruamel.yaml.convert
+ruamel.yaml==0.15.96      # via ruamel.yaml.cmd, ruamel.yaml.convert
 s3transfer==0.2.0         # via boto3
 semantic-version==2.6.0   # via edx-drf-extensions
-six==1.11.0               # via analytics-python, astroid, aws-sam-translator, cfn-lint, configobj, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, docker, docker-pycreds, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, faker, mock, moto, pathlib2, pyjwkest, pylint, pytest, python-dateutil, python-jose, responses, social-auth-app-django, social-auth-core, sphinx, stevedore, transifex-client, websocket-client
+six==1.11.0               # via analytics-python, astroid, aws-sam-translator, cfn-lint, configobj, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, docker, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, faker, mock, moto, packaging, pathlib2, pyjwkest, pylint, pytest, python-dateutil, python-jose, responses, social-auth-app-django, social-auth-core, sphinx, stevedore, transifex-client, websocket-client
 slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==1.2.1    # via sphinx
 social-auth-app-django==1.2.0  # via edx-auth-backends
 social-auth-core[openidconnect]==1.7.0  # via edx-auth-backends, social-auth-app-django
 sphinx==1.6.7
-sphinxcontrib-websupport==1.1.0  # via sphinx
+sphinxcontrib-websupport==1.1.2  # via sphinx
 sqlparse==0.3.0           # via django-debug-toolbar
 stevedore==1.30.1         # via code-annotations, edx-opaque-keys
 text-unidecode==1.2       # via faker
@@ -137,8 +141,9 @@ unidecode==1.0.23         # via python-slugify
 urllib3==1.23             # via botocore, requests, transifex-client
 wcwidth==0.1.7            # via pytest
 websocket-client==0.56.0  # via docker
-werkzeug==0.15.2          # via moto
+werkzeug==0.15.4          # via moto
 wrapt==1.11.1             # via astroid, aws-xray-sdk
 xmltodict==0.12.0         # via moto
 yamllint==1.15.0
-zipp==0.5.0               # via importlib-metadata
+yarg==0.1.9               # via pipreqs
+zipp==0.5.1               # via importlib-metadata

--- a/requirements/monitoring/requirements.txt
+++ b/requirements/monitoring/requirements.txt
@@ -16,13 +16,13 @@ aws-sam-translator==1.11.0  # via cfn-lint
 aws-xray-sdk==2.4.2       # via moto
 babel==2.6.0              # via sphinx
 billiard==3.3.0.23        # via celery
-boto3==1.9.146
+boto3==1.9.152
 boto==2.49.0              # via moto
-botocore==1.12.146        # via aws-xray-sdk, boto3, moto, s3transfer
+botocore==1.12.152        # via aws-xray-sdk, boto3, moto, s3transfer
 celery==3.1.26.post2
 certifi==2019.3.9         # via requests
 cffi==1.12.3              # via cryptography
-cfn-lint==0.20.1          # via moto
+cfn-lint==0.20.3          # via moto
 chardet==3.0.4            # via requests
 click-log==0.3.2          # via edx-lint
 click==7.0                # via click-log, code-annotations, edx-lint
@@ -34,10 +34,10 @@ ddt==1.2.1
 defusedxml==0.6.0         # via python3-openid, social-auth-core
 django-debug-toolbar==1.11
 django-dynamic-fixture==2.0.0
-django-extensions==2.1.6
+django-extensions==2.1.7
 django-guardian==1.5.1
 django-model-utils==3.1.2
-django-mysql==3.0.0.post1
+django-mysql==3.1.0
 django-simple-history==2.7.2
 django-storages==1.7.1
 django-user-tasks==0.1.5
@@ -45,8 +45,8 @@ django-waffle==0.16.0
 django==1.11.20
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.9.4
-docker-pycreds==0.4.0     # via docker
-docker==3.7.2             # via moto
+docker==4.0.1             # via moto
+docopt==0.6.2             # via pipreqs
 docutils==0.14            # via botocore, sphinx
 ecdsa==0.13.2             # via python-jose
 edx-auth-backends==2.0.1
@@ -54,20 +54,20 @@ edx-django-release-util==0.3.1
 edx-django-utils==1.0.3   # via edx-drf-extensions
 edx-drf-extensions==2.2.1
 edx-i18n-tools==0.4.8
-edx-lint==1.1.2
+edx-lint==1.2.0
 edx-opaque-keys==0.4.4    # via edx-drf-extensions
 edx-rest-api-client==1.9.2
 edx-sphinx-theme==1.4.0
 factory-boy==2.12.0
-faker==1.0.6
+faker==1.0.7
 future==0.17.1            # via aws-xray-sdk, pyjwkest, python-jose
 gevent==1.4.0
 greenlet==0.4.15          # via gevent
 gunicorn==19.9.0
 idna==2.8                 # via moto, requests
 imagesize==1.1.0          # via sphinx
-importlib-metadata==0.11  # via path.py
-isort==4.3.19             # via pylint
+importlib-metadata==0.13  # via path.py
+isort[requirements]==4.3.20
 jinja2==2.10.1            # via code-annotations, moto, sphinx
 jmespath==0.9.4           # via boto3, botocore
 jsondiff==1.1.2           # via moto
@@ -85,10 +85,13 @@ moto==1.3.8
 mysqlclient==1.3.14
 newrelic==4.18.0.118
 oauthlib==3.0.1           # via requests-oauthlib, social-auth-core
+packaging==19.0           # via pip-api
 path.py==12.0.1           # via edx-i18n-tools
 pathlib2==2.3.3           # via pytest
 pathspec==0.5.9           # via yamllint
 pbr==5.2.0                # via stevedore
+pip-api==0.0.8            # via isort
+pipreqs==0.4.9            # via isort
 pluggy==0.11.0            # via pytest
 polib==1.1.0              # via edx-i18n-tools
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
@@ -105,6 +108,7 @@ pylint-django==0.7.2      # via edx-lint
 pylint-plugin-utils==0.5  # via pylint-celery, pylint-django
 pylint==1.7.6             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.8.0            # via edx-opaque-keys
+pyparsing==2.4.0          # via packaging
 pytest-cov==2.7.1
 pytest-django==3.4.8
 pytest==4.5.0             # via pytest-cov, pytest-django
@@ -117,23 +121,23 @@ pytz==2019.1
 pyyaml==5.1
 redis==2.8
 requests-oauthlib==1.2.0  # via social-auth-core
-requests==2.21.0          # via analytics-python, cfn-lint, docker, edx-drf-extensions, edx-rest-api-client, moto, pyjwkest, requests-oauthlib, responses, slumber, social-auth-core, sphinx, transifex-client
+requests==2.21.0          # via analytics-python, cfn-lint, docker, edx-drf-extensions, edx-rest-api-client, moto, pyjwkest, requests-oauthlib, responses, slumber, social-auth-core, sphinx, transifex-client, yarg
 responses==0.10.6
 rest-condition==1.0.3     # via edx-drf-extensions
 rsa==4.0                  # via python-jose
 ruamel.std.argparse==0.8.1  # via ruamel.yaml.cmd
 ruamel.yaml.cmd==0.5.3
 ruamel.yaml.convert==0.3.0  # via ruamel.yaml.cmd
-ruamel.yaml==0.15.94      # via ruamel.yaml.cmd, ruamel.yaml.convert
+ruamel.yaml==0.15.96      # via ruamel.yaml.cmd, ruamel.yaml.convert
 s3transfer==0.2.0         # via boto3
 semantic-version==2.6.0   # via edx-drf-extensions
-six==1.11.0               # via analytics-python, astroid, aws-sam-translator, cfn-lint, configobj, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, docker, docker-pycreds, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, faker, mock, moto, pathlib2, pyjwkest, pylint, pytest, python-dateutil, python-jose, python-memcached, responses, social-auth-app-django, social-auth-core, sphinx, stevedore, transifex-client, websocket-client
+six==1.11.0               # via analytics-python, astroid, aws-sam-translator, cfn-lint, configobj, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, docker, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, faker, mock, moto, packaging, pathlib2, pyjwkest, pylint, pytest, python-dateutil, python-jose, python-memcached, responses, social-auth-app-django, social-auth-core, sphinx, stevedore, transifex-client, websocket-client
 slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==1.2.1    # via sphinx
 social-auth-app-django==1.2.0  # via edx-auth-backends
 social-auth-core[openidconnect]==1.7.0  # via edx-auth-backends, social-auth-app-django
 sphinx==1.6.7
-sphinxcontrib-websupport==1.1.0  # via sphinx
+sphinxcontrib-websupport==1.1.2  # via sphinx
 sqlparse==0.3.0           # via django-debug-toolbar
 stevedore==1.30.1         # via code-annotations, edx-opaque-keys
 text-unidecode==1.2       # via faker
@@ -142,8 +146,9 @@ unidecode==1.0.23         # via python-slugify
 urllib3==1.23             # via botocore, requests, transifex-client
 wcwidth==0.1.7            # via pytest
 websocket-client==0.56.0  # via docker
-werkzeug==0.15.2          # via moto
+werkzeug==0.15.4          # via moto
 wrapt==1.11.1             # via astroid, aws-xray-sdk
 xmltodict==0.12.0         # via moto
 yamllint==1.15.0
-zipp==0.5.0               # via importlib-metadata
+yarg==0.1.9               # via pipreqs
+zipp==0.5.1               # via importlib-metadata

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -8,16 +8,16 @@ amqp==1.4.9               # via kombu
 analytics-python==1.2.9
 anyjson==0.3.3            # via kombu
 billiard==3.3.0.23        # via celery
-boto3==1.9.146
-botocore==1.12.146        # via boto3, s3transfer
+boto3==1.9.152
+botocore==1.12.152        # via boto3, s3transfer
 celery==3.1.26.post2
 certifi==2019.3.9         # via requests
 chardet==3.0.4            # via requests
 defusedxml==0.6.0         # via python3-openid, social-auth-core
-django-extensions==2.1.6
+django-extensions==2.1.7
 django-guardian==1.5.1
 django-model-utils==3.1.2
-django-mysql==3.0.0.post1
+django-mysql==3.1.0
 django-simple-history==2.7.2
 django-storages==1.7.1
 django-user-tasks==0.1.5
@@ -55,7 +55,7 @@ pytz==2019.1
 pyyaml==5.1
 redis==2.8
 requests-oauthlib==1.2.0  # via social-auth-core
-requests==2.21.0          # via analytics-python, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
+requests==2.22.0          # via analytics-python, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via edx-drf-extensions
 s3transfer==0.2.0         # via boto3
 semantic-version==2.6.0   # via edx-drf-extensions

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -15,3 +15,4 @@ pytest-cov
 pytest-django
 responses
 yamllint
+isort[requirements]

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -14,13 +14,13 @@ attrs==19.1.0             # via pytest
 aws-sam-translator==1.11.0  # via cfn-lint
 aws-xray-sdk==2.4.2       # via moto
 billiard==3.3.0.23        # via celery
-boto3==1.9.146            # via aws-sam-translator, moto
+boto3==1.9.152            # via aws-sam-translator, moto
 boto==2.49.0              # via moto
-botocore==1.12.146        # via aws-xray-sdk, boto3, moto, s3transfer
+botocore==1.12.152        # via aws-xray-sdk, boto3, moto, s3transfer
 celery==3.1.26.post2
 certifi==2019.3.9         # via requests
 cffi==1.12.3              # via cryptography
-cfn-lint==0.20.1          # via moto
+cfn-lint==0.20.3          # via moto
 chardet==3.0.4            # via requests
 click-log==0.3.2          # via edx-lint
 click==7.0                # via click-log, code-annotations, edx-lint
@@ -30,10 +30,10 @@ cryptography==2.6.1       # via moto
 ddt==1.2.1
 defusedxml==0.6.0         # via python3-openid, social-auth-core
 django-dynamic-fixture==2.0.0
-django-extensions==2.1.6
+django-extensions==2.1.7
 django-guardian==1.5.1
 django-model-utils==3.1.2
-django-mysql==3.0.0.post1
+django-mysql==3.1.0
 django-simple-history==2.7.2
 django-storages==1.7.1
 django-user-tasks==0.1.5
@@ -41,22 +41,22 @@ django-waffle==0.16.0
 django==1.11.20
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.9.4
-docker-pycreds==0.4.0     # via docker
-docker==3.7.2             # via moto
+docker==4.0.1             # via moto
+docopt==0.6.2             # via pipreqs
 docutils==0.14            # via botocore
 ecdsa==0.13.2             # via python-jose
 edx-auth-backends==2.0.1
 edx-django-release-util==0.3.1
 edx-django-utils==1.0.3   # via edx-drf-extensions
 edx-drf-extensions==2.2.1
-edx-lint==1.1.2
+edx-lint==1.2.0
 edx-opaque-keys==0.4.4    # via edx-drf-extensions
 edx-rest-api-client==1.9.2
 factory-boy==2.12.0
-faker==1.0.6
+faker==1.0.7
 future==0.17.1            # via aws-xray-sdk, pyjwkest, python-jose
 idna==2.8                 # via moto, requests
-isort==4.3.19             # via pylint
+isort[requirements]==4.3.20
 jinja2==2.10.1            # via code-annotations, moto
 jmespath==0.9.4           # via boto3, botocore
 jsondiff==1.1.2           # via moto
@@ -73,9 +73,12 @@ more-itertools==7.0.0     # via pytest
 moto==1.3.8
 newrelic==4.18.0.118      # via edx-django-utils
 oauthlib==3.0.1           # via requests-oauthlib, social-auth-core
+packaging==19.0           # via pip-api
 pathlib2==2.3.3           # via pytest
 pathspec==0.5.9           # via yamllint
 pbr==5.2.0                # via stevedore
+pip-api==0.0.8            # via isort
+pipreqs==0.4.9            # via isort
 pluggy==0.11.0            # via pytest
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
 py==1.8.0                 # via pytest
@@ -90,6 +93,7 @@ pylint-django==0.7.2      # via edx-lint
 pylint-plugin-utils==0.5  # via pylint-celery, pylint-django
 pylint==1.7.6             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.8.0            # via edx-opaque-keys
+pyparsing==2.4.0          # via packaging
 pytest-cov==2.7.1
 pytest-django==3.4.8
 pytest==4.5.0             # via pytest-cov, pytest-django
@@ -101,13 +105,13 @@ pytz==2019.1
 pyyaml==5.1               # via cfn-lint, code-annotations, edx-django-release-util, moto, yamllint
 redis==2.8
 requests-oauthlib==1.2.0  # via social-auth-core
-requests==2.21.0          # via analytics-python, cfn-lint, docker, edx-drf-extensions, edx-rest-api-client, moto, pyjwkest, requests-oauthlib, responses, slumber, social-auth-core
+requests==2.21.0          # via analytics-python, cfn-lint, docker, edx-drf-extensions, edx-rest-api-client, moto, pyjwkest, requests-oauthlib, responses, slumber, social-auth-core, yarg
 responses==0.10.6
 rest-condition==1.0.3     # via edx-drf-extensions
 rsa==4.0                  # via python-jose
 s3transfer==0.2.0         # via boto3
 semantic-version==2.6.0   # via edx-drf-extensions
-six==1.12.0               # via analytics-python, astroid, aws-sam-translator, cfn-lint, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, docker, docker-pycreds, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-lint, edx-opaque-keys, faker, mock, moto, pathlib2, pyjwkest, pylint, pytest, python-dateutil, python-jose, responses, social-auth-app-django, social-auth-core, stevedore, websocket-client
+six==1.12.0               # via analytics-python, astroid, aws-sam-translator, cfn-lint, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, docker, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-lint, edx-opaque-keys, faker, mock, moto, packaging, pathlib2, pyjwkest, pylint, pytest, python-dateutil, python-jose, responses, social-auth-app-django, social-auth-core, stevedore, websocket-client
 slumber==0.7.1            # via edx-rest-api-client
 social-auth-app-django==1.2.0  # via edx-auth-backends
 social-auth-core[openidconnect]==1.7.0  # via edx-auth-backends, social-auth-app-django
@@ -116,7 +120,8 @@ text-unidecode==1.2       # via faker, python-slugify
 urllib3==1.24.3           # via botocore, requests
 wcwidth==0.1.7            # via pytest
 websocket-client==0.56.0  # via docker
-werkzeug==0.15.2          # via moto
+werkzeug==0.15.4          # via moto
 wrapt==1.11.1             # via astroid, aws-xray-sdk
 xmltodict==0.12.0         # via moto
 yamllint==1.15.0
+yarg==0.1.9               # via pipreqs

--- a/scripts/fake_course_enrollments.py
+++ b/scripts/fake_course_enrollments.py
@@ -15,8 +15,8 @@ Example:
 """
 
 import json
-import sys
 import random
+import sys
 
 
 # Map from program enrollment statuses to sets of possible course

--- a/scripts/fake_program_enrollments.py
+++ b/scripts/fake_program_enrollments.py
@@ -11,8 +11,8 @@ Example:
 """
 
 import json
-import sys
 import random
+import sys
 
 
 STATUS_CHOICES = ['enrolled', 'pending', 'suspended', 'canceled']

--- a/scripts/yaml_merge.py
+++ b/scripts/yaml_merge.py
@@ -8,6 +8,7 @@ dictionary elements are expanded.
 """
 import os
 import sys
+
 import yaml
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,3 +2,13 @@
 ignore=E501,W504
 max-line-length = 120
 exclude=.git,settings,migrations,registrar/static,bower_components,registrar/wsgi.py
+
+[tool:isort]
+indent='    '
+line_length=80
+multi_line_output=3
+lines_after_imports=2
+include_trailing_comma=True
+skip=
+    settings
+    migrations


### PR DESCRIPTION
@edx/masters-neem 

This PR:
1. Installs https://github.com/timothycrosley/isort
2. Adds `make isort` and `make validate_isort` targets
3. Adds `make validate_isort` to `make validate`, which adds it to Travis build
4. Runs `isort`

Steps 1-3 and step 4 are in two separate commits in order to make reviewing easier.

Rationale:
* I like import sorting because it makes it easier to tell what's what in a giant blob of imports. 
* We already mostly do it by hand.
* Theoretically, there should be fewer merge conflicts at the top of files, because there is a single deterministic way to order imports.
* edx-platform currently does it, so it must be a good idea.
* This is kinda wack: https://github.com/edx/registrar/blob/master/registrar/apps/core/tests/test_models.py#L9-L11