### PR TITLE
Make path regexes match only beginning of URL fragment

### DIFF
--- a/registrar/apps/api/tests/mixins.py
+++ b/registrar/apps/api/tests/mixins.py
@@ -121,6 +121,11 @@ class AuthRequestMixin(JwtMixin):
         if data:
             kwargs['data'] = json.dumps(data)
             kwargs['content_type'] = 'application/json'
-        if not (path.startswith('http://') or path.startswith('https://')):
+        path_is_absolute = (
+            path.startswith('http://') or
+            path.startswith('https://') or
+            path.startswith('/')
+        )
+        if not path_is_absolute:
             path = self.api_root + path
         return getattr(self.client, method.lower())(path, **kwargs)

--- a/registrar/apps/api/v1/urls.py
+++ b/registrar/apps/api/v1/urls.py
@@ -14,37 +14,37 @@ app_name = 'v1'
 
 urlpatterns = [
     url(
-        r'programs/$',
+        r'^programs/$',
         views.ProgramListView.as_view(),
         name="program-list",
     ),
     url(
-        r'programs/{}/$'.format(PROGRAM_KEY_PATTERN),
+        r'^programs/{}/$'.format(PROGRAM_KEY_PATTERN),
         views.ProgramRetrieveView.as_view(),
         name="program",
     ),
     url(
-        r'programs/{}/enrollments/$'.format(PROGRAM_KEY_PATTERN),
+        r'^programs/{}/enrollments/$'.format(PROGRAM_KEY_PATTERN),
         views.ProgramEnrollmentView.as_view(),
         name="program-enrollments",
     ),
     url(
-        r'programs/{}/courses/$'.format(PROGRAM_KEY_PATTERN),
+        r'^programs/{}/courses/$'.format(PROGRAM_KEY_PATTERN),
         views.ProgramCourseListView.as_view(),
         name="program-course-list",
     ),
     url(
-        r'programs/{}/enrollments/$'.format(PROGRAM_KEY_PATTERN),
+        r'^programs/{}/enrollments/$'.format(PROGRAM_KEY_PATTERN),
         views.ProgramEnrollmentView.as_view(),
         name="program-enrollment",
     ),
     url(
-        r'programs/{}/courses/{}/enrollments/$'.format(PROGRAM_KEY_PATTERN, COURSE_ID_PATTERN),
+        r'^programs/{}/courses/{}/enrollments/$'.format(PROGRAM_KEY_PATTERN, COURSE_ID_PATTERN),
         views.CourseEnrollmentView.as_view(),
         name="program-course-enrollment",
     ),
     url(
-        r'jobs/{}/$'.format(JOB_ID_PATTERN),
+        r'^jobs/{}/$'.format(JOB_ID_PATTERN),
         views.JobStatusRetrieveView.as_view(),
         name="job-status",
     ),

--- a/registrar/apps/api/v1_mock/urls.py
+++ b/registrar/apps/api/v1_mock/urls.py
@@ -14,32 +14,32 @@ app_name = 'v1-mock'
 
 urlpatterns = [
     url(
-        r'programs/$',
+        r'^programs/$',
         views.MockProgramListView.as_view(),
         name="program-list",
     ),
     url(
-        r'programs/{}/$'.format(PROGRAM_KEY_PATTERN),
+        r'^programs/{}/$'.format(PROGRAM_KEY_PATTERN),
         views.MockProgramRetrieveView.as_view(),
         name="program",
     ),
     url(
-        r'programs/{}/courses/$'.format(PROGRAM_KEY_PATTERN),
+        r'^programs/{}/courses/$'.format(PROGRAM_KEY_PATTERN),
         views.MockProgramCourseListView.as_view(),
         name="program-course-list",
     ),
     url(
-        r'programs/{}/enrollments/$'.format(PROGRAM_KEY_PATTERN),
+        r'^programs/{}/enrollments/$'.format(PROGRAM_KEY_PATTERN),
         views.MockProgramEnrollmentView.as_view(),
         name="program-enrollment",
     ),
     url(
-        r'programs/{}/courses/{}/enrollments/$'.format(PROGRAM_KEY_PATTERN, COURSE_ID_PATTERN),
+        r'^programs/{}/courses/{}/enrollments/$'.format(PROGRAM_KEY_PATTERN, COURSE_ID_PATTERN),
         views.MockCourseEnrollmentView.as_view(),
         name="program-course-enrollment",
     ),
     url(
-        r'jobs/{}/$'.format(JOB_ID_PATTERN),
+        r'^jobs/{}/$'.format(JOB_ID_PATTERN),
         views.MockJobStatusRetrieveView.as_view(),
         name="job-status",
     ),


### PR DESCRIPTION
@edx/masters-neem 

@jansenk noticed that Registrar has some weird URL behavior.. http://localhost:18734/api/v1//api/v1/programs/ is a valid Registrar URL!

It's because some of our URL regex didn't begin with carets (^), meaning that the regex matches *anywhere* in the URL fragment, not just the beginning.

This URL fixes that, as well as a few tests that relied on that bug.... oops.