### PR TITLE
Try changing the default celery queue name to 'registrar' to avoid queue name collisions

### DIFF
--- a/registrar/settings/base.py
+++ b/registrar/settings/base.py
@@ -106,6 +106,11 @@ CELERY_SEND_TASK_SENT_EVENT = True
 # let logging work as configured:
 CELERYD_HIJACK_ROOT_LOGGER = False
 
+# only registrar workers should receive registrar tasks.
+# explicitly define this to avoid name collisions with other services
+# using the same broker and the standard default queue name of "celery"
+CELERY_DEFAULT_QUEUE = 'registrar'
+
 ############################# END CELERY #################################3
 
 # Internationalization


### PR DESCRIPTION
## Description

I noticed in stage logs on splunk that celery tasks are getting routed to notifier workers.  This is no good.  I think what happened is that neither notifier or registrar explicitly declare a queue name, so they are both using the default of "celery".  This PR declares a more specific default queue name for registrar.
