### PR TITLE
get title and url from cached discovery program

### DIFF
--- a/registrar/apps/api/serializers.py
+++ b/registrar/apps/api/serializers.py
@@ -20,10 +20,12 @@ class ProgramSerializer(serializers.ModelSerializer):
     Serializer for Programs.
     """
     program_key = serializers.CharField(source='key')
+    program_title = serializers.CharField(source='title')
+    program_url = serializers.URLField(source='url')
 
     class Meta:
         model = Program
-        fields = ('program_key',)
+        fields = ('program_key', 'program_title', 'program_url')
 
 
 class ProgramEnrollmentRequestSerializer(serializers.Serializer):

--- a/registrar/apps/enrollments/data.py
+++ b/registrar/apps/enrollments/data.py
@@ -42,6 +42,8 @@ class DiscoveryProgram(object):
         * version (int)
         * loaded (datetime): When data was loaded from Course Discovery
         * uuid (str): Program UUID-4
+        * title (str): Program title
+        * url (str): Program marketing-url
         * active_curriculum_uuid (str): UUID-4 of active curriculum.
         * course_runs (list[DiscoveryCourseRun]):
             Flattened list of all course runs in program
@@ -51,12 +53,10 @@ class DiscoveryProgram(object):
     # so that all old entries will be ignored.
     class_version = 1
 
-    def __init__(self, version, loaded, uuid, active_curriculum_uuid, course_runs):
-        self.version = version
-        self.loaded = loaded
-        self.uuid = uuid
-        self.active_curriculum_uuid = active_curriculum_uuid
-        self.course_runs = course_runs
+    def __init__(self, **kwargs):
+        self.loaded = datetime.now()
+        for key, value in kwargs.items():
+            setattr(self, key, value)
 
     @classmethod
     def get(cls, program_uuid, client=None):
@@ -96,6 +96,8 @@ class DiscoveryProgram(object):
         Builds a DiscoveryProgram instance from JSON data that has been
         returned by the Course Discovery service.
         """
+        program_title = program_data.get('title')
+        program_url = program_data.get('marketing_url')
         # this make two temporary assumptions (zwh 03/19)
         #  1. one *active* curriculum per program
         #  2. no programs are nested within a curriculum
@@ -111,11 +113,12 @@ class DiscoveryProgram(object):
                 )
             )
             return DiscoveryProgram(
-                cls.class_version,
-                datetime.now(),
-                program_uuid,
-                None,
-                [],
+                version=cls.class_version,
+                uuid=program_uuid,
+                title=program_title,
+                url=program_url,
+                active_curriculum_uuid=None,
+                course_runs=[],
             )
         active_curriculum_uuid = curriculum.get("uuid")
         course_runs = [
@@ -128,11 +131,12 @@ class DiscoveryProgram(object):
             for course_run in course.get("course_runs", [])
         ]
         return DiscoveryProgram(
-            cls.class_version,
-            datetime.now(),
-            program_uuid,
-            active_curriculum_uuid,
-            course_runs,
+            version=cls.class_version,
+            uuid=program_uuid,
+            title=program_title,
+            url=program_url,
+            active_curriculum_uuid=active_curriculum_uuid,
+            course_runs=course_runs,
         )
 
 

--- a/registrar/apps/enrollments/models.py
+++ b/registrar/apps/enrollments/models.py
@@ -5,6 +5,7 @@ from django.db import models
 from model_utils.models import TimeStampedModel
 
 from registrar.apps.core.models import Organization
+from registrar.apps.enrollments.data import DiscoveryProgram
 
 
 class Program(TimeStampedModel):
@@ -19,6 +20,23 @@ class Program(TimeStampedModel):
     key = models.CharField(unique=True, max_length=255)
     discovery_uuid = models.UUIDField(db_index=True, null=True)
     managing_organization = models.ForeignKey(Organization, related_name='programs')
+
+    @property
+    def title(self):
+        return self._get_cached_field('title')
+
+    @property
+    def url(self):
+        return self._get_cached_field('url')
+
+    def _get_cached_field(self, field):
+        """
+        Returns the specified field from a cached Discovery program.
+        If the program is not found in the cache it is loaded from discovery
+        """
+        discovery_program = DiscoveryProgram.get(self.discovery_uuid)
+        val = getattr(discovery_program, field)
+        return val
 
     def __str__(self):
         return self.key

--- a/registrar/apps/enrollments/tests/test_data.py
+++ b/registrar/apps/enrollments/tests/test_data.py
@@ -222,7 +222,11 @@ class GetDiscoveryProgramTestCase(TestCase):
         'title': 'Test Course 1',
         'marketing_url': 'https://stem-institute.edx.org/masters-in-cs/test-course-1',
     }
+    program_title = "Master's in CS"
+    program_url = 'https://stem-institute.edx.org/masters-in-cs'
     programs_response = {
+        'title': program_title,
+        'marketing_url': program_url,
         'curricula': [{
             'uuid': curriculum_uuid,
             'is_active': True,
@@ -233,6 +237,8 @@ class GetDiscoveryProgramTestCase(TestCase):
         version=0,
         loaded=datetime.now(),
         uuid=program_uuid,
+        title=program_title,
+        url=program_url,
         active_curriculum_uuid=curriculum_uuid,
         course_runs=[
             DiscoveryCourseRun(
@@ -251,6 +257,8 @@ class GetDiscoveryProgramTestCase(TestCase):
         """ Asserts DiscoveryProgram equality, ignoring `loaded` field. """
         self.assertEqual(this_program.version, 1)
         self.assertEqual(this_program.uuid, that_program.uuid)
+        self.assertEqual(this_program.title, that_program.title)
+        self.assertEqual(this_program.url, that_program.url)
         self.assertEqual(this_program.active_curriculum_uuid, that_program.active_curriculum_uuid)
         self.assertEqual(this_program.course_runs, that_program.course_runs)
 


### PR DESCRIPTION
-save title and marketing_url in dicovery_program
-change serializer for programs to get those fields from cached discovery programs
-add a FakeProgramSerializer for serializing FakePrograms from v1_mock to avoid having to change the whole data model in v1_mock