### PR TITLE
Enable line-length check in pycodestyle

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [pycodestyle]
-ignore=E501,W504
+ignore=W504
 max-line-length = 120
 exclude=.git,settings,migrations,registrar/static,bower_components,registrar/wsgi.py
 


### PR DESCRIPTION
Right now, pycodestyle doesn't check line length, but pylint does. This is confusing because we specify a pycodestyle max-line-length but don't enforce it. Also, pycodestyle runs much more quickly, so it's less annoying to get failures from pycodestyle than pylint.