### PR TITLE
Fix media & task settings

### DIFF
--- a/registrar/settings/base.py
+++ b/registrar/settings/base.py
@@ -130,14 +130,10 @@ LOCALE_PATHS = (
     root('conf', 'locale'),
 )
 
-
 # MEDIA CONFIGURATION
-# See: https://docs.djangoproject.com/en/dev/ref/settings/#media-root
 MEDIA_ROOT = root('media')
-
-# See: https://docs.djangoproject.com/en/dev/ref/settings/#media-url
 MEDIA_URL = '/api/media/'
-# END MEDIA CONFIGURATION
+DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
 
 # STATIC FILE CONFIGURATION
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#static-root

--- a/registrar/settings/base.py
+++ b/registrar/settings/base.py
@@ -110,6 +110,7 @@ CELERYD_HIJACK_ROOT_LOGGER = False
 # explicitly define this to avoid name collisions with other services
 # using the same broker and the standard default queue name of "celery"
 CELERY_DEFAULT_QUEUE = 'registrar'
+CELERY_DEFAULT_ROUTING_KEY = 'registrar'
 
 ############################# END CELERY #################################3
 

--- a/registrar/settings/local.py
+++ b/registrar/settings/local.py
@@ -63,9 +63,6 @@ LOGGING = get_logger_config(debug=DEBUG, dev_env=True, local_loglevel='DEBUG')
 # CELERY
 CELERY_ALWAYS_EAGER = True
 
-# Media
-DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
-
 # Publicly-exposed base URLs for service and API
 API_ROOT = 'http://localhost:18734/api'
 

--- a/registrar/settings/production.py
+++ b/registrar/settings/production.py
@@ -12,13 +12,16 @@ ALLOWED_HOSTS = ['*']
 
 LOGGING = get_logger_config()
 
+# This may be overridden by the YAML in REGISTRAR_CFG, but it should be here as a default.
+MEDIA_STORAGE_BACKEND = {}
+
 # Keep track of the names of settings that represent dicts. Instead of overriding the values in base.py,
 # the values read from disk should UPDATE the pre-configured dicts.
 DICT_UPDATE_KEYS = ('JWT_AUTH',)
 
 CONFIG_FILE = get_env_setting('REGISTRAR_CFG')
 with open(CONFIG_FILE, encoding='utf-8') as f:
-    config_from_yaml = yaml.load(f)
+    config_from_yaml = yaml.safe_load(f)
 
     # Remove the items that should be used to update dicts, and apply them separately rather
     # than pumping them into the local vars.
@@ -29,6 +32,7 @@ with open(CONFIG_FILE, encoding='utf-8') as f:
             vars()[key].update(value)
 
     vars().update(config_from_yaml)
+    vars().update(MEDIA_STORAGE_BACKEND)
 
 DB_OVERRIDES = dict(
     PASSWORD=environ.get('DB_MIGRATION_PASS', DATABASES['default']['PASSWORD']),


### PR DESCRIPTION
@edx/masters-neem 
[EDUCATOR-4301](https://openedx.atlassian.net/browse/EDUCATOR-4301)

Registrar's config sets `MEDIA_STORAGE_BACKEND`, but we weren't actually loading the settings within that dict into Registrar settings. See https://github.com/edx/configuration/pull/3307#discussion_r74458655 for some historical context.

Two questions for @bderusha:
 1) Is it fine to set CELERY_DEFAULT_QUEUE and CELERY_DEFAULT_ROUTING_KEY here, or should that be done in configuration?
 2) Is it fine to switch from `yaml.load` to `yaml.safe_load`, or do we expect the YAMLs generated by our configuration pipeline to have advanced features that `safe_load` would choke on?
