### PR TITLE
Add logging of URLs for successful jobs

### DIFF
--- a/registrar/apps/core/jobs.py
+++ b/registrar/apps/core/jobs.py
@@ -126,6 +126,8 @@ def post_job_success(job_id, results, file_extension):
     result_url = _RESULT_STORAGE.store(job_id, results, file_extension)
     task_status = UserTaskStatus.objects.get(task_id=job_id)
     _affirm_job_in_progress(job_id, task_status)
+    log_message = "Job {} succeeded with result URL {}".format(job_id, result_url)
+    logger.info(log_message)
     UserTaskArtifact.objects.create(
         status=task_status, name=_RESULT_ARTIFACT_NAME, url=result_url
     )


### PR DESCRIPTION
[EDUCATOR-4379](https://openedx.atlassian.net/browse/EDUCATOR-4379)
@edx/masters-neem 

Added in order to diagnose issue with UserTaskArtifacts failing to save with Amazon S3 signed URLs.

https://splunk.edx.org/en-US/app/search/search?q=search%20index%3Dstage-edx%20list_program_enrollments&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=%40d&latest=now&sid=1559149092.2190919

Note: This will write the job result URLs to Splunk, but I don't think that's an issue, because they become unusable after an hour.