### PR TITLE
Jkantor/handle 404

### DIFF
--- a/registrar/apps/api/v1/tests/test_views.py
+++ b/registrar/apps/api/v1/tests/test_views.py
@@ -858,6 +858,21 @@ class ProgramEnrollmentWriteMixin(object):
             with mock.patch.object(DiscoveryProgram, 'get', return_value=self.disco_program):
                 self.request(self.method, 'programs/masters-in-cs/enrollments/', self.stem_admin, req_data)
 
+    @mock_oauth_login
+    @responses.activate
+    def test_backend_404(self):
+        self.mock_enrollments_response(self.method, 'Not Found', response_code=404)
+
+        req_data = [
+            self.student_enrollment('active', '001'),
+            self.student_enrollment('active', '002'),
+            self.student_enrollment('inactive', '003'),
+        ]
+        with mock.patch.object(DiscoveryProgram, 'get', return_value=self.disco_program):
+            response = self.request(self.method, 'programs/masters-in-cs/enrollments/', self.stem_admin, req_data)
+
+        self.assertEqual(404, response.status_code)
+
     def test_write_enrollment_payload_limit(self):
         req_data = [self.student_enrollment('enrolled')] * (ENROLLMENT_WRITE_MAX_SIZE + 1)
 

--- a/registrar/apps/enrollments/data.py
+++ b/registrar/apps/enrollments/data.py
@@ -154,7 +154,7 @@ def write_program_enrollments(program_uuid, enrollments, update=False, client=No
         return _make_request(method, url, client, json=enrollments)
     except HTTPError as e:
         response = e.response
-        if response.status_code == 422:
+        if response.status_code in [404, 422]:
             return response
         raise
 
@@ -219,7 +219,7 @@ def write_program_course_enrollments(program_uuid, course_key, enrollments, upda
         return _make_request(method, url, client, json=enrollments)
     except HTTPError as e:
         response = e.response
-        if response.status_code == 422:
+        if response.status_code in [404, 422]:
             return response
         raise
 


### PR DESCRIPTION
_make_request will still raise an exception on a 404 from LMS, but it will now be caught by write_program_course_enrollments and write_program_enrollments

I added test cases to make the behavior more explicit