### PR TITLE
Set celery exchange, rename default queue

### DIFF
--- a/registrar/settings/base.py
+++ b/registrar/settings/base.py
@@ -109,8 +109,9 @@ CELERYD_HIJACK_ROOT_LOGGER = False
 # only registrar workers should receive registrar tasks.
 # explicitly define this to avoid name collisions with other services
 # using the same broker and the standard default queue name of "celery"
-CELERY_DEFAULT_QUEUE = 'registrar'
+CELERY_DEFAULT_EXCHANGE = 'registrar'
 CELERY_DEFAULT_ROUTING_KEY = 'registrar'
+CELERY_DEFAULT_QUEUE = 'registrar.default'
 
 ############################# END CELERY #################################3
 

--- a/registrar/settings/base.py
+++ b/registrar/settings/base.py
@@ -109,9 +109,9 @@ CELERYD_HIJACK_ROOT_LOGGER = False
 # only registrar workers should receive registrar tasks.
 # explicitly define this to avoid name collisions with other services
 # using the same broker and the standard default queue name of "celery"
-CELERY_DEFAULT_EXCHANGE = 'registrar'
-CELERY_DEFAULT_ROUTING_KEY = 'registrar'
-CELERY_DEFAULT_QUEUE = 'registrar.default'
+CELERY_DEFAULT_EXCHANGE = os.environ.get('CELERY_DEFAULT_EXCHANGE', 'registrar')
+CELERY_DEFAULT_ROUTING_KEY = os.environ.get('CELERY_DEFAULT_ROUTING_KEY', 'registrar')
+CELERY_DEFAULT_QUEUE = os.environ.get('CELERY_DEFAULT_QUEUE', 'registrar.default')
 
 ############################# END CELERY #################################3
 


### PR DESCRIPTION
We need to also set the celery exchange setting. I also made the default queue name 'registrar.default' in case we ever want more queues. It's fine to leave it as just registrar if we think the chance of other queues is low. I'd like the have all queues include the app name in them, so if a new queue is ever needed it should be registrar,foobar instead of just foobar so we know which IDA it goes with.