### PR TITLE
add test

### DIFF
--- a/registrar/apps/enrollments/admin.py
+++ b/registrar/apps/enrollments/admin.py
@@ -4,4 +4,11 @@ from django.contrib import admin
 from registrar.apps.enrollments import models
 
 
-admin.site.register(models.Program)
+class ProgramAdmin(admin.ModelAdmin):
+    """
+    Admin tool for the ProgramEnrollment model
+    """
+    list_display = ("key", "discovery_uuid", "managing_organization")
+
+
+admin.site.register(models.Program, ProgramAdmin)


### PR DESCRIPTION
I found this while looking into EDUCATOR-4390. If we don't provide a student_key or status to the registrar, it will insert the fields as None when it makes its request to the LMS. I'm not sure that we really need to do anything here, since EDUCATOR-4390 is fixed by making the LMS endpoint resilient to this behavior. I could see us adding checks against this, so I just thought I'd add the test for completeness' sake.

Also I modified the Program django admin in the course of debugging and I think it's better this way.
 