### PR TITLE
Jkantor/external course key

### DIFF
--- a/registrar/apps/api/serializers.py
+++ b/registrar/apps/api/serializers.py
@@ -66,6 +66,7 @@ class CourseRunSerializer(serializers.Serializer):
     Course Discovery Service
     """
     course_id = serializers.CharField(source='key')
+    external_course_key = serializers.CharField(source='external_key')
     course_title = serializers.CharField(source='title')
     course_url = serializers.URLField(source='marketing_url')
 

--- a/registrar/apps/api/v1/mixins.py
+++ b/registrar/apps/api/v1/mixins.py
@@ -21,7 +21,6 @@ from registrar.apps.api.serializers import JobAcceptanceSerializer
 from registrar.apps.api.utils import build_absolute_api_url
 from registrar.apps.core import permissions as perms
 from registrar.apps.core.jobs import start_job
-from registrar.apps.enrollments.data import DiscoveryProgram
 from registrar.apps.enrollments.models import Program
 
 
@@ -151,12 +150,7 @@ class CourseSpecificViewMixin(ProgramSpecificViewMixin):
         parameter is not part of self.program.
         """
         course_id = self.kwargs['course_id']
-        program_uuid = self.program.discovery_uuid
-        discovery_program = DiscoveryProgram.get(program_uuid)
-        program_course_run_ids = {
-            run.key for run in discovery_program.course_runs
-        }
-        if course_id not in program_course_run_ids:
+        if not self.program.discovery_program.find_course_run(course_id):
             self.add_tracking_data(failure='course_not_found')
             raise Http404()
 

--- a/registrar/apps/api/v1/views.py
+++ b/registrar/apps/api/v1/views.py
@@ -352,7 +352,7 @@ class CourseEnrollmentView(CourseSpecificViewMixin, JobInvokerMixin, EnrollmentM
         return self.invoke_job(
             list_course_run_enrollments,
             self.program.key,
-            self.kwargs['course_id'],
+            self.program.discovery_program.get_course_key(self.kwargs['course_id']),
         )
 
     def handle_program_course_enrollments(self, request, course_id):
@@ -361,13 +361,15 @@ class CourseEnrollmentView(CourseSpecificViewMixin, JobInvokerMixin, EnrollmentM
         """
         self.validate_enrollment_data(request.data)
         program_uuid = self.program.discovery_uuid
+        self.validate_course_id()
+        course_key = self.program.discovery_program.get_course_key(course_id)
 
         enrollments = request.data
 
         if request.method == 'POST':
-            response = write_program_course_enrollments(program_uuid, course_id, enrollments)
+            response = write_program_course_enrollments(program_uuid, course_key, enrollments)
         elif request.method == 'PATCH':
-            response = write_program_course_enrollments(program_uuid, course_id, enrollments, update=True)
+            response = write_program_course_enrollments(program_uuid, course_key, enrollments, update=True)
         else:
             raise Exception('unexpected request method.  Expected [POST, PATCH]')  # pragma: no cover
 

--- a/registrar/apps/api/v1_mock/data.py
+++ b/registrar/apps/api/v1_mock/data.py
@@ -30,6 +30,7 @@ FakeProgram = namedtuple('FakeProgram', [
 
 FakeCourseRun = namedtuple('FakeCourseRun', [
     'key',
+    'external_key',
     'title',
     'marketing_url',
 ])
@@ -72,6 +73,7 @@ def _course_run(title, org, course, run="Spring2050"):
     """
     return FakeCourseRun(
         'course-v1:{}+{}+{}'.format(org, course, run),
+        None,
         title,
         'https://www.edx.org/fake-course/{}'.format(name_to_key(title)),
     )

--- a/registrar/apps/core/constants.py
+++ b/registrar/apps/core/constants.py
@@ -9,7 +9,14 @@ class Status(object):
 
 # Pulled from edx-platform. Will correctly capture both old- and new-style
 # course ID strings.
-COURSE_ID_PATTERN = r'(?P<course_id>[^/+]+(/|\+)[^/+]+(/|\+)[^/?]+)'
+INTERNAL_COURSE_KEY_PATTERN = r'([^/+]+(/|\+)[^/+]+(/|\+)[^/?]+)'
+
+EXTERNAL_COURSE_KEY_PATTERN = r'([A-Za-z0-9-_:]+)'
+
+COURSE_ID_PATTERN = r'(?P<course_id>({}|{}))'.format(
+    INTERNAL_COURSE_KEY_PATTERN,
+    EXTERNAL_COURSE_KEY_PATTERN
+)
 
 # Captures strings composed of alphanumeric characters, dashes, and underscores.
 PROGRAM_KEY_PATTERN = r'(?P<program_key>[A-Za-z0-9-_]+)'

--- a/registrar/apps/enrollments/models.py
+++ b/registrar/apps/enrollments/models.py
@@ -22,6 +22,10 @@ class Program(TimeStampedModel):
     managing_organization = models.ForeignKey(Organization, related_name='programs')
 
     @property
+    def discovery_program(self):
+        return DiscoveryProgram.get(self.discovery_uuid)
+
+    @property
     def title(self):
         return self._get_cached_field('title')
 

--- a/registrar/apps/enrollments/tasks.py
+++ b/registrar/apps/enrollments/tasks.py
@@ -64,7 +64,7 @@ def list_program_enrollments(self, job_id, user_id, file_format, program_key):  
 
 @shared_task(base=UserTask, bind=True)
 def list_course_run_enrollments(
-        self, job_id, user_id, file_format, program_key, course_id   # pylint: disable=unused-argument
+        self, job_id, user_id, file_format, program_key, course_key   # pylint: disable=unused-argument
 ):
     """
     A user task for retrieving program course run enrollments from LMS.
@@ -76,7 +76,7 @@ def list_course_run_enrollments(
         return
 
     try:
-        enrollments = get_course_run_enrollments(program.discovery_uuid, course_id)
+        enrollments = get_course_run_enrollments(program.discovery_uuid, course_key)
     except HTTPError as err:
         post_job_failure(
             job_id,


### PR DESCRIPTION
- Added methods on DiscoveryProgram for getting internal course key and external course key
- For course-related endpoints, do conversion to internal course key right away.


The ticket mentions that conversion internal -> external was needed for user tasks, but I don't actually see anywhere where we include the key in task results. The functionality is there and tested, but not used yet 