### PR TITLE
Fix jobs by re-qualifying Celery task names

### DIFF
--- a/registrar/apps/enrollments/task_names.py
+++ b/registrar/apps/enrollments/task_names.py
@@ -1,6 +1,0 @@
-""" Names of enrollment tasks. """
-
-LIST_PROGRAM_ENROLLMENTS = "list_program_enrollments"
-LIST_COURSE_RUN_ENROLLMENTS = "list_course_run_enrollments"
-WRITE_PROGRAM_ENROLLMENTS = "write_program_enrollments"
-WRITE_COURSE_RUN_ENROLLMENTS = "write_course_run_enrollments"

--- a/registrar/apps/enrollments/tasks.py
+++ b/registrar/apps/enrollments/tasks.py
@@ -20,11 +20,6 @@ from registrar.apps.enrollments.serializers import (
     serialize_enrollment_results_to_csv,
     serialize_program_enrollments_to_csv,
 )
-from registrar.apps.enrollments.task_names import (
-    LIST_COURSE_RUN_ENROLLMENTS,
-    LIST_PROGRAM_ENROLLMENTS,
-    WRITE_PROGRAM_ENROLLMENTS,
-)
 from registrar.apps.enrollments.utils import build_enrollment_job_status_name
 
 
@@ -35,7 +30,7 @@ uploads_filestore = get_filestore(UPLOADS_PATH_PREFIX)
 # pylint: disable=unused-argument
 
 
-@shared_task(base=UserTask, bind=True, name=LIST_PROGRAM_ENROLLMENTS)
+@shared_task(base=UserTask, bind=True)
 def list_program_enrollments(self, job_id, user_id, file_format, program_key):
     """
     A user task for retrieving program enrollments from LMS.
@@ -70,7 +65,7 @@ def list_program_enrollments(self, job_id, user_id, file_format, program_key):
     post_job_success(job_id, serialized, file_format)
 
 
-@shared_task(base=UserTask, bind=True, name=LIST_COURSE_RUN_ENROLLMENTS)
+@shared_task(base=UserTask, bind=True)
 def list_course_run_enrollments(
         self, job_id, user_id, file_format, program_key, course_key   # pylint: disable=unused-argument
 ):
@@ -132,7 +127,7 @@ class EnrollmentWriteTask(UserTask):
         )
 
 
-@shared_task(base=EnrollmentWriteTask, bind=True, name=WRITE_PROGRAM_ENROLLMENTS)
+@shared_task(base=EnrollmentWriteTask, bind=True)
 def write_program_enrollments(
         self, job_id, user_id, program_key, json_filepath
 ):


### PR DESCRIPTION
#118 tried to factor out Celery task names into a constants file. Turns out that's a not a great idea -- In order to be auto-discoverable, Celery task names need not be just the function name (`list_program_enrollments`), but have to be the fully qualified Python name (`registrar.apps.enrollments.tasks.list_program_enrollments`).

Rather then listing out the fully qualified name in a constants file, code that needs to know the task name can just do something like:
```python
from registrar.apps.enrollments.tasks import list_program_enrollments
task_name = list_program_enrollments.name
```