### PR TITLE
Log user IDs in Splunk with tracking events

### DIFF
--- a/registrar/apps/api/mixins.py
+++ b/registrar/apps/api/mixins.py
@@ -102,7 +102,8 @@ class TrackViewMixin(object):
 
         segment.track(self.request.user.username, event_name, properties)
         logger.info(
-            '%s invoked on Registrar with properties %s',
+            '%s invoked on Registrar by user with ID=%s with properties %s',
             event_name,
+            self.request.user.id,
             json.dumps(properties, skipkeys=True, sort_keys=True),
         )

--- a/registrar/apps/api/tests/mixins.py
+++ b/registrar/apps/api/tests/mixins.py
@@ -81,8 +81,9 @@ class TrackTestMixin(object):
             properties
         )
         self.mock_logging.info.assert_called_once_with(
-            '%s invoked on Registrar with properties %s',
+            '%s invoked on Registrar by user with ID=%s with properties %s',
             event,
+            user.id,
             json.dumps(properties, skipkeys=True, sort_keys=True),
         )
 

--- a/registrar/apps/core/admin.py
+++ b/registrar/apps/core/admin.py
@@ -15,7 +15,7 @@ from registrar.apps.core.models import (
 
 class CustomUserAdmin(UserAdmin):
     """ Admin configuration for the custom User model. """
-    list_display = ('username', 'email', 'full_name', 'first_name', 'last_name', 'is_staff')
+    list_display = ('id', 'username', 'email', 'full_name', 'first_name', 'last_name', 'is_staff')
     fieldsets = (
         (None, {'fields': ('username', 'password')}),
         (_('Personal info'), {'fields': ('full_name', 'first_name', 'last_name', 'email')}),


### PR DESCRIPTION
@edx/masters-neem 

When I was looking at some tracking data for Scott, I realized that we log users in Segment, but not in Splunk. I can imagine this making our lives harder at some point.

This PR logs user ID to Splunk (data eng requested that we log IDs instead of usernames).