### PR TITLE
Get CELERY_ALWAYS_EAGER from environment

### DIFF
--- a/registrar/settings/base.py
+++ b/registrar/settings/base.py
@@ -86,34 +86,55 @@ DATABASES = {
 ############################# BEGIN CELERY #################################3
 
 # Message configuration
-
 CELERY_TASK_SERIALIZER = 'json'
 CELERY_RESULT_SERIALIZER = 'json'
 CELERY_ACCEPT_CONTENT = ['json']
-
 CELERY_MESSAGE_COMPRESSION = 'gzip'
 
 # Results configuration
-
 CELERY_IGNORE_RESULT = False
 CELERY_STORE_ERRORS_EVEN_IF_IGNORED = True
 
 # Events configuration
-
 CELERY_TRACK_STARTED = True
-
 CELERY_SEND_EVENTS = True
 CELERY_SEND_TASK_SENT_EVENT = True
 
 # let logging work as configured:
 CELERYD_HIJACK_ROOT_LOGGER = False
 
-# only registrar workers should receive registrar tasks.
-# explicitly define this to avoid name collisions with other services
-# using the same broker and the standard default queue name of "celery"
+# Celery task routing configuration.
+# Only registrar workers should receive registrar tasks.
+# Explicitly define these to avoid name collisions with other services
+# using the same broker and the standard default queue name of "celery".
 CELERY_DEFAULT_EXCHANGE = os.environ.get('CELERY_DEFAULT_EXCHANGE', 'registrar')
 CELERY_DEFAULT_ROUTING_KEY = os.environ.get('CELERY_DEFAULT_ROUTING_KEY', 'registrar')
 CELERY_DEFAULT_QUEUE = os.environ.get('CELERY_DEFAULT_QUEUE', 'registrar.default')
+
+# Eager vs. Asynchronous
+# In Standalone we default to True.
+# Devstack overrides this in its docker-compose.yml to be False.
+# Production environments can override this to be whatever they want.
+CELERY_ALWAYS_EAGER = (
+    os.environ.get("CELERY_ALWAYS_EAGER", "True").lower() == "true"
+)
+
+# Celery Broker
+# These settings need not be set if CELERY_ALWAYS_EAGER == True, like in Standalone.
+# Devstack overrides these in its docker-compose.yml.
+# Production environments can override these to be whatever they want.
+CELERY_BROKER_TRANSPORT = os.environ.get("CELERY_BROKER_TRANSPORT", "")
+CELERY_BROKER_HOSTNAME = os.environ.get("CELERY_BROKER_HOSTNAME", "")
+CELERY_BROKER_VHOST = os.environ.get("CELERY_BROKER_VHOST", "")
+CELERY_BROKER_USER = os.environ.get("CELERY_BROKER_USER", "")
+CELERY_BROKER_PASSWORD = os.environ.get("CELERY_BROKER_PASSWORD", "")
+BROKER_URL = "{0}://{1}:{2}@{3}/{4}".format(
+    CELERY_BROKER_TRANSPORT,
+    CELERY_BROKER_USER,
+    CELERY_BROKER_PASSWORD,
+    CELERY_BROKER_HOSTNAME,
+    CELERY_BROKER_VHOST
+)
 
 ############################# END CELERY #################################3
 
@@ -250,20 +271,6 @@ SEGMENT_KEY = None
 
 # Publicly-exposed base URLs for service and API
 API_ROOT = 'http://replace-me/api'
-
-# Celery Broker
-CELERY_BROKER_TRANSPORT = os.environ.get("CELERY_BROKER_TRANSPORT", "")
-CELERY_BROKER_HOSTNAME = os.environ.get("CELERY_BROKER_HOSTNAME", "")
-CELERY_BROKER_VHOST = os.environ.get("CELERY_BROKER_VHOST", "")
-CELERY_BROKER_USER = os.environ.get("CELERY_BROKER_USER", "")
-CELERY_BROKER_PASSWORD = os.environ.get("CELERY_BROKER_PASSWORD", "")
-BROKER_URL = "{0}://{1}:{2}@{3}/{4}".format(
-    CELERY_BROKER_TRANSPORT,
-    CELERY_BROKER_USER,
-    CELERY_BROKER_PASSWORD,
-    CELERY_BROKER_HOSTNAME,
-    CELERY_BROKER_VHOST
-)
 
 CERTIFICATE_LANGUAGES = {
     'en': 'English',

--- a/registrar/settings/devstack.py
+++ b/registrar/settings/devstack.py
@@ -30,9 +30,6 @@ DATABASES = {
     }
 }
 
-# Set to true in local.py; need to override.
-CELERY_ALWAYS_EAGER = False
-
 STATICFILES_STORAGE = os.environ.get('STATICFILES_STORAGE', 'django.contrib.staticfiles.storage.StaticFilesStorage')
 STATIC_URL = os.environ.get('STATIC_URL', '/static/')
 

--- a/registrar/settings/local.py
+++ b/registrar/settings/local.py
@@ -62,9 +62,6 @@ ENABLE_AUTO_AUTH = True
 # LOGGING
 LOGGING = get_logger_config(debug=DEBUG, dev_env=True, local_loglevel='DEBUG')
 
-# CELERY
-CELERY_ALWAYS_EAGER = True
-
 # Publicly-exposed base URLs for service and API
 API_ROOT = 'http://localhost:8000/api'
 


### PR DESCRIPTION
@edx/masters-neem 
For part of [EDUCATOR-4444](https://openedx.atlassian.net/browse/EDUCATOR-4444)

This also cleans up some formatting and comments. The important changes are the `CELERY_ALWAYS_EAGER` lines.

Related PRs:
https://github.com/edx/configuration/pull/5206
https://github.com/edx/devstack/pull/427

Note: when this merges, tell Neem team members to do a git-pull on devstack, else tasks will all run eagerly.