### PR TITLE
Change non-ASCII quote mark to ASCII apostrophe

### DIFF
--- a/.api-generated.yaml
+++ b/.api-generated.yaml
@@ -465,7 +465,7 @@ models:
       student_key:
         description: "Key that uniquely identifies student within organization. For\
           \ data privacy reasons, this cannot be, or include, sensitive personal information\
-          \ like a student’s official university ID number, social security number,\
+          \ like a student's official university ID number, social security number,\
           \ or some other government-issued ID number.\n"
         type: string
     type: object
@@ -537,7 +537,7 @@ models:
       student_key:
         description: "Key that uniquely identifies student within organization. For\
           \ data privacy reasons, this cannot be, or include, sensitive personal information\
-          \ like a student’s official university ID number, social security number,\
+          \ like a student's official university ID number, social security number,\
           \ or some other government-issued ID number.\n"
         type: string
     type: object
@@ -1508,7 +1508,7 @@ program_path_param:
 student_key:
   description: "Key that uniquely identifies student within organization. For data\
     \ privacy reasons, this cannot be, or include, sensitive personal information\
-    \ like a student’s official university ID number, social security number, or some\
+    \ like a student's official university ID number, social security number, or some\
     \ other government-issued ID number.\n"
   type: string
 swagger: '2.0'

--- a/api.yaml
+++ b/api.yaml
@@ -74,7 +74,7 @@ student_key: &student_key
   description: >
     Key that uniquely identifies student within organization.
     For data privacy reasons, this cannot be, or include,
-    sensitive personal information like a student’s official university ID
+    sensitive personal information like a student's official university ID
     number, social security number, or some other government-issued ID number.
 program_input_status: &program_input_status
   type: string


### PR DESCRIPTION
@edx/masters-neem 

My Registrar sandbox was giving a 500 with:
```
Traceback (most recent call last):
  File "/edx/app/registrar/venvs/registrar/lib/python3.5/site-packages/django/core/handlers/exception.py", line 41, in inner
    response = get_response(request)
  File "/edx/app/registrar/venvs/registrar/lib/python3.5/site-packages/django/utils/deprecation.py", line 140, in __call__
    response = self.get_response(request)
  File "/edx/app/registrar/venvs/registrar/lib/python3.5/site-packages/django/core/handlers/exception.py", line 43, in inner
    response = response_for_exception(request, exc)
  File "/edx/app/registrar/venvs/registrar/lib/python3.5/site-packages/django/core/handlers/exception.py", line 93, in response_for_exception
    response = handle_uncaught_exception(request, get_resolver(get_urlconf()), sys.exc_info())
  File "/edx/app/registrar/venvs/registrar/lib/python3.5/site-packages/django/core/handlers/exception.py", line 142, in handle_uncaught_exception
    callback, param_dict = resolver.resolve_error_handler(500)
  File "/edx/app/registrar/venvs/registrar/lib/python3.5/site-packages/django/urls/resolvers.py", line 420, in resolve_error_handler
    callback = getattr(self.urlconf_module, 'handler%s' % view_type, None)
  File "/edx/app/registrar/venvs/registrar/lib/python3.5/site-packages/django/utils/functional.py", line 35, in __get__
    res = instance.__dict__[self.name] = self.func(instance)
  File "/edx/app/registrar/venvs/registrar/lib/python3.5/site-packages/django/urls/resolvers.py", line 400, in urlconf_module
    return import_module(self.urlconf_name)
  File "/edx/app/registrar/venvs/registrar/lib/python3.5/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 986, in _gcd_import
  File "<frozen importlib._bootstrap>", line 969, in _find_and_load
  File "<frozen importlib._bootstrap>", line 958, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 673, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 665, in exec_module
  File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
  File "/edx/app/registrar/registrar/registrar/urls.py", line 24, in <module>
    from registrar import api_renderer
  File "/edx/app/registrar/registrar/registrar/api_renderer.py", line 15, in <module>
    API_SPEC = yaml.safe_load(spec_file.read())
  File "/edx/app/registrar/venvs/registrar/lib/python3.5/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 2721: ordinal not in range(128)
```

After 1+ hours of confusion, I figured out that we must have copied Legal's copytext out of a Google doc or something, because our API spec had a [non-ASCII quote mark](https://www.fileformat.info/info/unicode/char/2019/index.htm) instead of the standard ASCII apostrophe. Oops.

Future work: It'd be worth figuring out why `spec_file.read()` defaulted to `utf-8` on devstack/stage/prod but defaulted to `ascii` on a sandbox.