### PR TITLE
Add 201 as a valid LMS response status when writing enrollments

### DIFF
--- a/registrar/apps/enrollments/data.py
+++ b/registrar/apps/enrollments/data.py
@@ -14,6 +14,7 @@ from edx_rest_api_client import client as rest_client
 from requests.exceptions import HTTPError
 from rest_framework.status import (
     HTTP_200_OK,
+    HTTP_201_CREATED,
     HTTP_207_MULTI_STATUS,
     HTTP_422_UNPROCESSABLE_ENTITY,
 )
@@ -307,11 +308,12 @@ def _write_enrollments(method, url, enrollments, client=None):
     })
     expected_codes = {
         HTTP_200_OK,
+        HTTP_201_CREATED,
         HTTP_207_MULTI_STATUS,
         HTTP_422_UNPROCESSABLE_ENTITY,
     }
     for response in responses:
-        if response.status_code == HTTP_200_OK:
+        if response.status_code in (HTTP_200_OK, HTTP_201_CREATED):
             good = True
         elif response.status_code == HTTP_207_MULTI_STATUS:
             good = True

--- a/registrar/apps/enrollments/tests/test_data.py
+++ b/registrar/apps/enrollments/tests/test_data.py
@@ -233,6 +233,7 @@ class WriteEnrollmentsTestMixin(object):
         (25, [200], True),
         (25, [422], False),
         (4, [200, 200], True),
+        (4, [201, 201], True),
         (4, [207, 207], True),
         (3, [200, 207, 422], True),
         (3, [422, 200, 422], True),


### PR DESCRIPTION
## Description
This is a simple fix to make sure we handle 201_created HTTP status from LMS when creating new enrollments
@edx/masters-neem Please review