### PR TITLE
Jkantor/external key csv download

### DIFF
--- a/registrar/apps/api/v1/mixins.py
+++ b/registrar/apps/api/v1/mixins.py
@@ -154,14 +154,14 @@ class CourseSpecificViewMixin(ProgramSpecificViewMixin):
     A mixin for views that operate on or within a specific program course run.
 
     In addition to the functionality provided in `ProgramSpecificViewMixin`,
-    this mixin provides a `internal_course_key` property, which returns the
-    edX course key of the course referred to in the URL (either by the
+    this mixin provides the `internal_course_key` and `external_course_key` properties,
+    which return the edX course key of the course referred to in the URL (either by the
     edX course key itself or by an external course key). It also validates
-    that they course key exists within the program, raising 404 if not.
+    that the course key exists within the program, raising 404 if not.
     """
 
     @cached_property
-    def internal_course_key(self):
+    def course_run(self):
         """
         Raises a 404 if the course run identified by the `course_id` path
         parameter is not part of self.program.
@@ -173,7 +173,15 @@ class CourseSpecificViewMixin(ProgramSpecificViewMixin):
         if not real_course_run:
             self.add_tracking_data(failure='course_not_found')
             raise Http404()
-        return real_course_run.key
+        return real_course_run
+
+    @property
+    def internal_course_key(self):
+        return self.course_run.key
+
+    @property
+    def external_course_key(self):
+        return self.course_run.external_key
 
 
 class JobInvokerMixin(object):

--- a/registrar/apps/api/v1/tests/test_views.py
+++ b/registrar/apps/api/v1/tests/test_views.py
@@ -1041,6 +1041,7 @@ class ProgramCourseEnrollmentGetTests(S3MockMixin, RegistrarAPITestCase, AuthReq
             'courses': [{
                 'course_runs': [{
                     'key': 'HUMx+English-550+Spring',
+                    'external_key': 'ENG55-S19',
                     'title': "English 550",
                     'marketing_url': 'https://example.com/english-550',
                 }]
@@ -1050,11 +1051,13 @@ class ProgramCourseEnrollmentGetTests(S3MockMixin, RegistrarAPITestCase, AuthReq
 
     enrollments = [
         {
+            'course_key': 'ENG55-S19',
             'student_key': 'abcd',
             'status': 'enrolled',
             'account_exists': True,
         },
         {
+            'course_key': 'ENG55-S19',
             'student_key': 'efgh',
             'status': 'pending',
             'account_exists': False,
@@ -1062,8 +1065,8 @@ class ProgramCourseEnrollmentGetTests(S3MockMixin, RegistrarAPITestCase, AuthReq
     ]
     enrollments_json = json.dumps(enrollments, indent=4)
     enrollments_csv = (
-        "abcd,enrolled,True\r\n"
-        "efgh,pending,False\r\n"
+        "ENG55-S19,abcd,enrolled,True\r\n"
+        "ENG55-S19,efgh,pending,False\r\n"
     )
 
     @mock.patch.object(DiscoveryProgram, 'get', return_value=disco_program)

--- a/registrar/apps/api/v1/views.py
+++ b/registrar/apps/api/v1/views.py
@@ -337,6 +337,7 @@ class CourseEnrollmentView(CourseSpecificViewMixin, JobInvokerMixin, EnrollmentM
             list_course_run_enrollments,
             self.program.key,
             self.internal_course_key,
+            self.external_course_key,
         )
 
     def post(self, request, program_key, course_id):

--- a/registrar/apps/enrollments/data.py
+++ b/registrar/apps/enrollments/data.py
@@ -200,13 +200,14 @@ def get_program_enrollments(program_uuid, client=None):
     return serializer.validated_data
 
 
-def get_course_run_enrollments(program_uuid, course_key, client=None):
+def get_course_run_enrollments(program_uuid, internal_course_key, external_course_key=None, client=None):
     """
     Fetches program course run enrollments from the LMS.
 
     Arguments:
         program_uuid (str): UUID-4 string
-        course_key (str): edX course key identifying course run
+        internal_course_key (str): edX course key identifying course run
+        external_course_key (str): optional external course key
 
     Returns: list[dict]
         A list of enrollment dictionaries, validated by
@@ -216,11 +217,12 @@ def get_course_run_enrollments(program_uuid, course_key, client=None):
         - HTTPError if there is an issue communicating with LMS
         - ValidationError if enrollment data from LMS is invalid
     """
-    url = _lms_course_run_enrollment_url(program_uuid, course_key)
+    url = _lms_course_run_enrollment_url(program_uuid, internal_course_key)
     enrollments = _get_all_paginated_results(url, client)
-    serializer = CourseEnrollmentSerializer(data=enrollments, many=True)
+    context = {'course_key': external_course_key or internal_course_key}
+    serializer = CourseEnrollmentSerializer(data=enrollments, many=True, context=context)
     serializer.is_valid(raise_exception=True)
-    return serializer.validated_data
+    return serializer.data
 
 
 def write_program_enrollments(method, program_uuid, enrollments, client=None):

--- a/registrar/apps/enrollments/serializers.py
+++ b/registrar/apps/enrollments/serializers.py
@@ -39,9 +39,14 @@ class CourseEnrollmentSerializer(serializers.Serializer):
     """
     Serializer for program enrollment API response.
     """
+    course_key = serializers.SerializerMethodField()
     student_key = serializers.CharField()
     status = serializers.ChoiceField(choices=COURSE_ENROLLMENT_STATUSES)
     account_exists = serializers.BooleanField()
+
+    # pylint: disable=unused-argument
+    def get_course_key(self, obj):
+        return self.context.get('course_key')
 
 
 def serialize_course_run_enrollments_to_csv(enrollments):
@@ -54,7 +59,7 @@ def serialize_course_run_enrollments_to_csv(enrollments):
     Returns: str
     """
     return serialize_to_csv(
-        enrollments, ('student_key', 'status', 'account_exists')
+        enrollments, ('course_key', 'student_key', 'status', 'account_exists')
     )
 
 

--- a/registrar/apps/enrollments/tasks.py
+++ b/registrar/apps/enrollments/tasks.py
@@ -28,8 +28,6 @@ uploads_filestore = get_filestore(UPLOADS_PATH_PREFIX)
 
 
 # pylint: disable=unused-argument
-
-
 @shared_task(base=UserTask, bind=True)
 def list_program_enrollments(self, job_id, user_id, file_format, program_key):
     """
@@ -67,7 +65,13 @@ def list_program_enrollments(self, job_id, user_id, file_format, program_key):
 
 @shared_task(base=UserTask, bind=True)
 def list_course_run_enrollments(
-        self, job_id, user_id, file_format, program_key, course_key   # pylint: disable=unused-argument
+        self,
+        job_id,
+        user_id,
+        file_format,
+        program_key,
+        internal_course_key,
+        external_course_key,
 ):
     """
     A user task for retrieving program course run enrollments from LMS.
@@ -78,7 +82,9 @@ def list_course_run_enrollments(
 
     try:
         enrollments = data.get_course_run_enrollments(
-            program.discovery_uuid, course_key
+            program.discovery_uuid,
+            internal_course_key,
+            external_course_key,
         )
     except HTTPError as err:
         post_job_failure(

--- a/registrar/apps/enrollments/tests/test_tasks.py
+++ b/registrar/apps/enrollments/tests/test_tasks.py
@@ -172,6 +172,14 @@ class ListCourseRunEnrollmentTaskTests(ListEnrollmentTaskTestMixin, TestCase):
         COURSE_ENROLLMENT_INACTIVE,
     )
     mocked_get_enrollments_method = 'get_course_run_enrollments'
+    internal_course_key = 'course-1'
+    external_course_key = 'external_course_key'
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        for enrollment in cls.enrollment_data:
+            enrollment['course_key'] = cls.external_course_key
 
     def spawn_task(self, program_key=None, **kwargs):
         return tasks.list_course_run_enrollments.apply_async(
@@ -180,7 +188,8 @@ class ListCourseRunEnrollmentTaskTests(ListEnrollmentTaskTestMixin, TestCase):
                 self.user.id,
                 kwargs.get('file_format', 'json'),
                 program_key or self.program.key,
-                'course-1'
+                self.internal_course_key,
+                self.external_course_key,
             ),
             task_id=self.job_id
         )


### PR DESCRIPTION
Add displayed_course_key optional arg to data. get_course_run_enrollments where it or
course_key are passed into the serializer context and inserted into the enrollment data returned by the LMS

