### PR TITLE
Add a trivial v2 API.

### DIFF
--- a/.api-generated.yaml
+++ b/.api-generated.yaml
@@ -1325,6 +1325,400 @@ paths:
       summary: Enroll students in a program
       tags:
       - v1
+  /v2/jobs/{job_id}/:
+    get:
+      operationId: registrar_v2_get_job_status
+      parameters:
+      - description: UUID-4 job identifier
+        example: 3869c0d5-e88f-4088-bf1d-409222492869
+        format: uuid
+        in: path
+        name: job_id
+        required: true
+        type: string
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: '#/models/JobStatus'
+      summary: Get the status of a job
+      tags:
+      - v2
+  /v2/programs/:
+    get:
+      description: List all programs, requires an organization key for non-admins
+      operationId: registrar_v2_list_programs
+      parameters:
+      - description: Organization key
+        in: query
+        name: org
+        required: false
+        type: string
+      responses:
+        200:
+          description: OK
+          examples:
+            application/json:
+            - program_key: uexample-master-of-science
+              program_title: Master of Science
+              program_url: https://uexample.edx.org/uexample-master-of-science
+          schema:
+            items:
+              $ref: '#/models/Program'
+            type: array
+        403:
+          description: User is not authorized to list specified programs.
+        404:
+          description: Organization was not found.
+      summary: List programs
+      tags:
+      - v2
+  /v2/programs/{program_key}/:
+    get:
+      operationId: registrar_v2_get_program
+      parameters:
+      - description: edX program key
+        example: uexample-master-of-science
+        in: path
+        name: program_key
+        required: true
+        type: string
+      responses:
+        200:
+          description: OK
+          examples:
+            application/json:
+              program_key: uexample-master-of-science
+              program_title: Master of Science
+              program_url: https://uexample.edx.org/uexample-master-of-science
+          schema:
+            $ref: '#/models/Program'
+        403:
+          description: User is not authorized to view program.
+        404:
+          description: Program was not found.
+      summary: Get Program
+      tags:
+      - v2
+  /v2/programs/{program_key}/courses/:
+    get:
+      operationId: registrar_v2_list_courses
+      parameters:
+      - description: edX program key
+        example: uexample-master-of-science
+        in: path
+        name: program_key
+        required: true
+        type: string
+      responses:
+        200:
+          description: OK
+          examples:
+            application/json:
+            - course_id: course-v1:ExU+Science-101+Fall2050,
+              course_title: Introduction to Science,
+              course_url: https://courses.edx.org/course-v1:ExU+Science-101+Fall2050
+              external_course_key: ExU-IntroToScience50,
+          schema:
+            items:
+              $ref: '#/models/Course'
+            type: array
+        403:
+          description: User is not authorized to list courses of program.
+        404:
+          description: Program was not found.
+      summary: List program courses
+      tags:
+      - v2
+  /v2/programs/{program_key}/courses/{course_id}/enrollments/:
+    get:
+      description: Submit a job to retrieve course enrollment data
+      operationId: registrar_v2_get_course_enrollments
+      parameters:
+      - description: edX program key
+        example: uexample-master-of-science
+        in: path
+        name: program_key
+        required: true
+        type: string
+      - description: edX course run identifier, or an external course run key
+        example: course-v1:ExU+Science-101+Fall2050
+        in: path
+        name: course_id
+        required: true
+        type: string
+      - description: format of file to generate
+        enum:
+        - json
+        - csv
+        example: json
+        in: query
+        name: fmt
+        required: false
+        type: string
+      responses:
+        202:
+          description: Job submitted.
+          schema:
+            $ref: '#/models/NewJob'
+        403:
+          description: "User is not authorized to retrieve enrollments for program\
+            \ course.\n"
+        404:
+          description: "Course does not exist within program, or program was not found.\n"
+      summary: Request course enrollment data
+      tags:
+      - v2
+    patch:
+      operationId: registrar_v2_patch_course_enrollments
+      parameters:
+      - description: edX program key
+        example: uexample-master-of-science
+        in: path
+        name: program_key
+        required: true
+        type: string
+      - description: edX course run identifier, or an external course run key
+        example: course-v1:ExU+Science-101+Fall2050
+        in: path
+        name: course_id
+        required: true
+        type: string
+      - in: body
+        name: body
+        required: true
+        schema:
+          items:
+            $ref: '#/models/CourseEnrollmentRequest'
+          type: array
+      responses:
+        200:
+          description: All students' enrollments were successfully modified.
+          examples:
+            application/json:
+              student_0128fe4a: active
+              student_aae45c81: inactive
+          schema:
+            $ref: '#/models/CourseEnrollmentResult'
+        207:
+          description: "Some, but not all, students' enrollments were successfully\
+            \ modified.\n"
+          examples:
+            application/json:
+              student_0128fe4a: active
+              student_aae45c81: not-found
+          schema:
+            $ref: '#/models/CourseEnrollmentResult'
+        403:
+          description: "User is not authorized to modify enrollments for program course.\n"
+        404:
+          description: "Course does not exist within program, or program was not found.\n"
+        413:
+          description: "Payload too large; at most 25 students' enrollments may be\
+            \ modified per request.\n"
+        422:
+          description: "None of the students' enrollments were successfully modified.\n"
+          examples:
+            application/json:
+              student_0128fe4a: invalid-status
+              student_aae45c81: not-found
+          schema:
+            $ref: '#/models/CourseEnrollmentResult'
+      summary: Modify course enrollments
+      tags:
+      - v2
+    post:
+      operationId: registrar_v2_post_course_enrollments
+      parameters:
+      - description: edX program key
+        example: uexample-master-of-science
+        in: path
+        name: program_key
+        required: true
+        type: string
+      - description: edX course run identifier, or an external course run key
+        example: course-v1:ExU+Science-101+Fall2050
+        in: path
+        name: course_id
+        required: true
+        type: string
+      - in: body
+        name: body
+        required: true
+        schema:
+          items:
+            $ref: '#/models/CourseEnrollmentRequest'
+          type: array
+      responses:
+        200:
+          description: All students were successfully listed.
+          examples:
+            application/json:
+              student_0128fe4a: inactive
+              student_aae45c81: active
+          schema:
+            $ref: '#/models/CourseEnrollmentResult'
+        207:
+          description: Some, but not all, students were successfully listed.
+          examples:
+            application/json:
+              student_0128fe4a: inactive
+              student_aae45c81: conflict
+          schema:
+            $ref: '#/models/CourseEnrollmentResult'
+        403:
+          description: "User is not authorized to modify enrollments for program course.\n"
+        404:
+          description: "Course does not exist within program, or program was not found.\n"
+        413:
+          description: "Payload too large; at most 25 students may be supplied per\
+            \ request.\n"
+        422:
+          description: None of the students were successfully listed.
+          examples:
+            application/json:
+              student_0128fe4a: invalid-status
+              student_aae45c81: conflict
+          schema:
+            $ref: '#/models/CourseEnrollmentResult'
+      summary: Enroll students in a course
+      tags:
+      - v2
+  /v2/programs/{program_key}/enrollments/:
+    get:
+      description: Submit a job to retrieve program enrollment data
+      operationId: registrar_v2_get_program_enrollments
+      parameters:
+      - description: edX program key
+        example: uexample-master-of-science
+        in: path
+        name: program_key
+        required: true
+        type: string
+      - description: format of file to generate
+        enum:
+        - json
+        - csv
+        example: json
+        in: query
+        name: fmt
+        required: false
+        type: string
+      responses:
+        202:
+          description: Job submitted.
+          schema:
+            $ref: '#/models/NewJob'
+        403:
+          description: User is not authorized to retrieve enrollment of program.
+        404:
+          description: Program was not found.
+      summary: Request program enrollment data
+      tags:
+      - v2
+    patch:
+      operationId: registrar_v2_patch_program_enrollments
+      parameters:
+      - description: edX program key
+        example: uexample-master-of-science
+        in: path
+        name: program_key
+        required: true
+        type: string
+      - in: body
+        name: body
+        required: true
+        schema:
+          items:
+            $ref: '#/models/ProgramEnrollmentRequest'
+          type: array
+      responses:
+        200:
+          description: All students' enrollments were successfully modified.
+          examples:
+            application/json:
+              student_0128fe4a: enrolled
+              student_aae45c81: canceled
+          schema:
+            $ref: '#/models/ProgramEnrollmentResult'
+        207:
+          description: "Some, but not all, students' enrollments were successfully\
+            \ modified.\n"
+          examples:
+            application/json:
+              student_0128fe4a: enrolled
+              student_aae45c81: not-found
+          schema:
+            $ref: '#/models/ProgramEnrollmentResult'
+        403:
+          description: "User is not authorized to modify enrollments for program course.\n"
+        404:
+          description: "Course does not exist within program, or program was not found.\n"
+        413:
+          description: "Payload too large; at most 25 students' enrollments may be\
+            \ modified per request.\n"
+        422:
+          description: "None of the students' enrollments were successfully modified.\n"
+          examples:
+            application/json:
+              student_0128fe4a: invalid-status
+              student_aae45c81: not-found
+          schema:
+            $ref: '#/models/ProgramEnrollmentResult'
+      summary: Modify program enrollments
+      tags:
+      - v2
+    post:
+      operationId: registrar_v2_post_program_enrollments
+      parameters:
+      - description: edX program key
+        example: uexample-master-of-science
+        in: path
+        name: program_key
+        required: true
+        type: string
+      - in: body
+        name: body
+        required: true
+        schema:
+          items:
+            $ref: '#/models/ProgramEnrollmentRequest'
+          type: array
+      responses:
+        200:
+          description: All students were successfully listed.
+          examples:
+            application/json:
+              student_0128fe4a: pending
+              student_aae45c81: enrolled
+          schema:
+            $ref: '#/models/ProgramEnrollmentResult'
+        207:
+          description: Some, but not all, students were successfully listed.
+          examples:
+            application/json:
+              student_0128fe4a: pending
+              student_aae45c81: conflict
+          schema:
+            $ref: '#/models/ProgramEnrollmentResult'
+        403:
+          description: "User is not authorized to modify enrollments for program course.\n"
+        404:
+          description: "Course does not exist within program, or program was not found.\n"
+        413:
+          description: "Payload too large; at most 25 students may be supplied per\
+            \ request.\n"
+        422:
+          description: None of the students were successfully listed.
+          examples:
+            application/json:
+              student_0128fe4a: invalid-status
+              student_aae45c81: conflict
+          schema:
+            $ref: '#/models/ProgramEnrollmentResult'
+      summary: Enroll students in a program
+      tags:
+      - v2
 produces:
 - application/json
 program_enrollment_body:

--- a/api.yaml
+++ b/api.yaml
@@ -530,6 +530,53 @@ paths:
       operationId: registrar_v1_patch_program_enrollments
       tags: ['v1']
 
+  ### V2 API ###
+  '/v2/jobs/{job_id}/':
+    get:
+      <<: *get_job_status
+      operationId: registrar_v2_get_job_status
+      tags: ['v2']
+  '/v2/programs/':
+    get:
+      <<: *list_programs
+      operationId: registrar_v2_list_programs
+      tags: ['v2']
+  '/v2/programs/{program_key}/':
+    get:
+      <<: *get_program
+      operationId: registrar_v2_get_program
+      tags: ['v2']
+  '/v2/programs/{program_key}/courses/':
+    get:
+      <<: *list_courses
+      operationId: registrar_v2_list_courses
+      tags: ['v2']
+  '/v2/programs/{program_key}/courses/{course_id}/enrollments/':
+    get:
+      <<: *get_course_enrollments
+      operationId: registrar_v2_get_course_enrollments
+      tags: ['v2']
+    post:
+      <<: *post_course_enrollments
+      operationId: registrar_v2_post_course_enrollments
+      tags: ['v2']
+    patch:
+      <<: *patch_course_enrollments
+      operationId: registrar_v2_patch_course_enrollments
+      tags: ['v2']
+  '/v2/programs/{program_key}/enrollments/':
+    get:
+      <<: *get_program_enrollments
+      operationId: registrar_v2_get_program_enrollments
+      tags: ['v2']
+    post:
+      <<: *post_program_enrollments
+      operationId: registrar_v2_post_program_enrollments
+      tags: ['v2']
+    patch:
+      <<: *patch_program_enrollments
+      operationId: registrar_v2_patch_program_enrollments
+      tags: ['v2']
 
 ################################################################################
 #     Data Models                                                              #

--- a/registrar/apps/api/mixins.py
+++ b/registrar/apps/api/mixins.py
@@ -79,6 +79,8 @@ class TrackViewMixin(object):
         * HTTP response status code
         """
         event_name = self.event_method_map.get(self.request.method)
+        api_version = self.request.get_full_path().split('/')[2]
+        event_name = event_name.format(api_version=api_version)
         if not event_name:  # pragma: no cover
             logger.error(
                 'Segment tracking event name not found for request method ' +

--- a/registrar/apps/api/urls.py
+++ b/registrar/apps/api/urls.py
@@ -9,6 +9,7 @@ from django.conf.urls import include, url
 from registrar.apps.api.internal import urls as internal_urls
 from registrar.apps.api.v1 import urls as v1_urls
 from registrar.apps.api.v1_mock import urls as v1_mock_urls
+from registrar.apps.api.v2 import urls as v2_urls
 
 
 app_name = 'api'
@@ -16,4 +17,5 @@ urlpatterns = [
     url(r'^internal/', include(internal_urls)),
     url(r'^v1-mock/', include(v1_mock_urls)),
     url(r'^v1/', include(v1_urls)),
+    url(r'^v2/', include(v2_urls)),
 ]

--- a/registrar/apps/api/v1/mixins.py
+++ b/registrar/apps/api/v1/mixins.py
@@ -221,7 +221,8 @@ class JobInvokerMixin(object):
         Invoke a job with task_fn
         """
         job_id = start_job(self.request.user, task_fn, *args, **kwargs)
-        job_url = build_absolute_api_url('api:v1:job-status', job_id=job_id)
+        api_version = self.request.get_full_path().split('/')[2]
+        job_url = build_absolute_api_url('api:{}:job-status'.format(api_version), job_id=job_id)
         data = {'job_id': job_id, 'job_url': job_url}
         return Response(JobAcceptanceSerializer(data).data, HTTP_202_ACCEPTED)
 

--- a/registrar/apps/api/v1/views.py
+++ b/registrar/apps/api/v1/views.py
@@ -63,7 +63,7 @@ class ProgramListView(AuthMixin, TrackViewMixin, ListAPIView):
     """
     A view for listing program objects.
 
-    Path: /api/v1/programs?org={org_key}
+    Path: /api/[version]/programs?org={org_key}
 
     All programs within organization specified by `org_key` are returned.
     For users will global organization access, `org_key` can be omitted in order
@@ -76,7 +76,7 @@ class ProgramListView(AuthMixin, TrackViewMixin, ListAPIView):
     """
 
     serializer_class = ProgramSerializer
-    event_method_map = {'GET': 'registrar.v1.list_programs'}
+    event_method_map = {'GET': 'registrar.{api_version}.list_programs'}
     event_parameter_map = {
         'org': 'organization_filter',
         'user_has_perm': 'permission_filter',
@@ -169,7 +169,7 @@ class ProgramRetrieveView(ProgramSpecificViewMixin, RetrieveAPIView):
     """
     A view for retrieving a single program object.
 
-    Path: /api/v1/programs/{program_key}
+    Path: /api/[version]/programs/{program_key}
 
     Returns:
      * 200: OK
@@ -178,7 +178,7 @@ class ProgramRetrieveView(ProgramSpecificViewMixin, RetrieveAPIView):
     """
     serializer_class = ProgramSerializer
     permission_required = [perms.ORGANIZATION_READ_METADATA]
-    event_method_map = {'GET': 'registrar.v1.get_program_detail'}
+    event_method_map = {'GET': 'registrar.{api_version}.get_program_detail'}
     event_parameter_map = {'program_key': 'program_key'}
 
     def get_object(self):
@@ -189,7 +189,7 @@ class ProgramCourseListView(ProgramSpecificViewMixin, ListAPIView):
     """
     A view for listing courses in a program.
 
-    Path: /api/v1/programs/{program_key}/courses
+    Path: /api/[version]/programs/{program_key}/courses
 
     Returns:
      * 200: OK
@@ -198,7 +198,7 @@ class ProgramCourseListView(ProgramSpecificViewMixin, ListAPIView):
     """
     serializer_class = CourseRunSerializer
     permission_required = perms.ORGANIZATION_READ_METADATA
-    event_method_map = {'GET': 'registrar.v1.get_program_courses'}
+    event_method_map = {'GET': 'registrar.{api_version}.get_program_courses'}
     event_parameter_map = {'program_key': 'program_key'}
 
     def get_queryset(self):
@@ -211,7 +211,7 @@ class ProgramEnrollmentView(EnrollmentMixin, JobInvokerMixin, APIView):
     """
     A view for enrolling students in a program, or retrieving/modifying program enrollment data.
 
-    Path: /api/v1/programs/{program_key}/enrollments
+    Path: /api/[version]/programs/{program_key}/enrollments
 
     Accepts: [GET, POST, PATCH]
 
@@ -231,7 +231,7 @@ class ProgramEnrollmentView(EnrollmentMixin, JobInvokerMixin, APIView):
     Example Response:
     {
         "job_id": "3b985cec-dcf4-4d38-9498-8545ebcf5d0f",
-        "job_url": "http://localhost/api/v1/jobs/3b985cec-dcf4-4d38-9498-8545ebcf5d0f"
+        "job_url": "http://localhost/api/[version]/jobs/3b985cec-dcf4-4d38-9498-8545ebcf5d0f"
     }
 
     ------------------------------------------------------------------------------------
@@ -251,9 +251,9 @@ class ProgramEnrollmentView(EnrollmentMixin, JobInvokerMixin, APIView):
      * 422: Invalid request, unable to enroll students.
     """
     event_method_map = {
-        'GET': 'registrar.v1.get_program_enrollment',
-        'POST': 'registrar.v1.post_program_enrollment',
-        'PATCH': 'registrar.v1.patch_program_enrollment',
+        'GET': 'registrar.{api_version}.get_program_enrollment',
+        'POST': 'registrar.{api_version}.post_program_enrollment',
+        'PATCH': 'registrar.{api_version}.patch_program_enrollment',
     }
     event_parameter_map = {
         'program_key': 'program_key',
@@ -279,7 +279,7 @@ class CourseEnrollmentView(CourseSpecificViewMixin, JobInvokerMixin, EnrollmentM
     """
     A view for enrolling students in a program course run.
 
-    Path: /api/v1/programs/{program_key}/courses/{course_id}/enrollments
+    Path: /api/[version]/programs/{program_key}/courses/{course_id}/enrollments
 
     Accepts: [GET, PATCH, POST]
 
@@ -299,7 +299,7 @@ class CourseEnrollmentView(CourseSpecificViewMixin, JobInvokerMixin, EnrollmentM
     Example Response:
     {
         "job_id": "3b985cec-dcf4-4d38-9498-8545ebcf5d0f",
-        "job_url": "http://localhost/api/v1/jobs/3b985cec-dcf4-4d38-9498-8545ebcf5d0f"
+        "job_url": "http://localhost/api/[version]/jobs/3b985cec-dcf4-4d38-9498-8545ebcf5d0f"
     }
 
     ------------------------------------------------------------------------------------
@@ -319,9 +319,9 @@ class CourseEnrollmentView(CourseSpecificViewMixin, JobInvokerMixin, EnrollmentM
      * 422: Invalid request, unable to enroll students.
     """
     event_method_map = {
-        'GET': 'registrar.v1.get_course_enrollment',
-        'POST': 'registrar.v1.post_course_enrollment',
-        'PATCH': 'registrar.v1.patch_course_enrollment',
+        'GET': 'registrar.{api_version}.get_course_enrollment',
+        'POST': 'registrar.{api_version}.post_course_enrollment',
+        'PATCH': 'registrar.{api_version}.patch_course_enrollment',
     }
     event_parameter_map = {
         'program_key': 'program_key',
@@ -353,7 +353,7 @@ class JobStatusRetrieveView(TrackViewMixin, RetrieveAPIView):
     """
     A view for getting the status of a job.
 
-    Path: /api/v1/jobs/{job_id}
+    Path: /api/[version]/jobs/{job_id}
 
     Accepts: [GET]
 
@@ -372,7 +372,7 @@ class JobStatusRetrieveView(TrackViewMixin, RetrieveAPIView):
     authentication_classes = (JwtAuthentication, SessionAuthentication)
     permission_classes = (IsAuthenticated,)
     serializer_class = JobStatusSerializer
-    event_method_map = {'GET': 'registrar.v1.get_job_status'}
+    event_method_map = {'GET': 'registrar.{api_version}.get_job_status'}
     event_parameter_map = {'job_id': 'job_id'}
 
     def get_object(self):
@@ -392,7 +392,7 @@ class JobStatusListView(AuthMixin, TrackViewMixin, ListAPIView):
     """
     A view for listing currently processing jobs.
 
-    Path: /api/v1/jobs/
+    Path: /api/[version]/jobs/
 
     Returns:
      * 200: OK
@@ -402,7 +402,7 @@ class JobStatusListView(AuthMixin, TrackViewMixin, ListAPIView):
     authentication_classes = (JwtAuthentication, SessionAuthentication)
     permission_classes = (IsAuthenticated,)
     serializer_class = JobStatusSerializer
-    event_method_map = {'GET': 'registrar.v1.list_job_statuses'}
+    event_method_map = {'GET': 'registrar.{api_version}.list_job_statuses'}
 
     def get_queryset(self):
         return get_processing_jobs_for_user(self.request.user)
@@ -466,11 +466,11 @@ class ProgramEnrollmentUploadView(ProgramSpecificViewMixin, EnrollmentUploadView
     """
     A view for uploading program enrollments via csv file
 
-    Path: /api/v1/programs/{program_key}/enrollments
+    Path: /api/[version]/programs/{program_key}/enrollments
     """
     field_names = ['student_key', 'status']
     task_fn = write_program_enrollments
-    event_method_map = {'POST': 'registrar.v1.upload_program_enrollments'}
+    event_method_map = {'POST': 'registrar.{api_version}.upload_program_enrollments'}
     event_parameter_map = {'program_key': 'program_key'}
 
 
@@ -478,9 +478,9 @@ class CourseRunEnrollmentUploadView(ProgramSpecificViewMixin, EnrollmentUploadVi
     """
     A view for uploading course enrollments via csv file
 
-    Path: /api/v1/programs/{program_key}/course_enrollments
+    Path: /api/[version]/programs/{program_key}/course_enrollments
     """
     field_names = ['student_key', 'course_key', 'status']
     task_fn = write_course_run_enrollments
-    event_method_map = {'POST': 'registrar.v1.upload_course_enrollments'}
+    event_method_map = {'POST': 'registrar.{api_version}.upload_course_enrollments'}
     event_parameter_map = {'program_key': 'program_key'}

--- a/registrar/apps/api/v2/urls.py
+++ b/registrar/apps/api/v2/urls.py
@@ -1,0 +1,8 @@
+""" URL patterns for the v2 REST API. """
+
+from registrar.apps.api.v1.urls import urlpatterns as v1_urlpatterns
+
+
+app_name = 'v2'
+
+urlpatterns = [pattern for pattern in v1_urlpatterns]


### PR DESCRIPTION
In support of releasing a new partner integration guide, we're releasing a v2 of the API that simply imports all of the URL patterns from v1.

https://openedx.atlassian.net/browse/EDUCATOR-4441
