### PR TITLE
Add program_key to read job names, include action in job names.

### DIFF
--- a/registrar/apps/api/v1/views.py
+++ b/registrar/apps/api/v1/views.py
@@ -434,7 +434,7 @@ class EnrollmentUploadView(JobInvokerMixin, APIView):
         if csv_file.size > UPLOAD_FILE_MAX_SIZE:
             raise FileTooLarge()
 
-        if is_enrollment_job_processing(self.program):
+        if is_enrollment_job_processing(self.program.key):
             return Response('Job already in progress for program', HTTP_409_CONFLICT)
 
         file_itr = io.StringIO(csv_file.read().decode('utf-8'))

--- a/registrar/apps/enrollments/tests/test_utils.py
+++ b/registrar/apps/enrollments/tests/test_utils.py
@@ -57,17 +57,17 @@ class IsEnrollmentJobProcessingTests(EnrollmentJobTests):
         (UserTaskStatus.RETRYING, True),
     )
     def test_job_processing(self, state, expected):
-        task_name = build_enrollment_job_status_name(self.program.key, self.TASK_NAME)
+        task_name = build_enrollment_job_status_name(self.program.key, 'write', self.TASK_NAME)
         self.create_dummy_job_status(state, self.user, task_name)
         job_in_progress = is_enrollment_job_processing(self.program.key)
         self.assertEqual(expected, job_in_progress)
 
     def test_different_program(self):
-        task_name = build_enrollment_job_status_name(self.program.key, self.TASK_NAME)
+        task_name = build_enrollment_job_status_name(self.program.key, 'write', self.TASK_NAME)
         self.create_dummy_job_status(UserTaskStatus.IN_PROGRESS, self.user, task_name)
         self.assertFalse(is_enrollment_job_processing(self.program2.key))
 
     def test_wrong_name(self):
-        task_name = build_enrollment_job_status_name(self.TASK_NAME, self.program.key)
+        task_name = build_enrollment_job_status_name(self.TASK_NAME, 'write', self.program.key)
         self.create_dummy_job_status(UserTaskStatus.IN_PROGRESS, self.user, task_name)
         self.assertFalse(is_enrollment_job_processing(self.program.key))

--- a/registrar/apps/enrollments/utils.py
+++ b/registrar/apps/enrollments/utils.py
@@ -3,15 +3,19 @@
 from registrar.apps.core.jobs import processing_job_with_prefix_exists
 
 
-def build_enrollment_job_status_name(program_key, task_name):
+SEPARATOR = ':'
+
+
+def build_enrollment_job_status_name(program_key, action, task_name):
     """
-    Build the UserTaskStatus.name for the given task and program
+    Build the UserTaskStatus.name for the given program, action, and task name.
 
     Arguments:
-        program_key (str): program key for the program we're writing enrollments
-        task_name (str): the name of the task that is being executed
+        program_key (str): The key of the program the task is acting on.
+        action (str): The type of action performed by the task (e.g. "read" or "write").
+        task_name (str): The name of the task that is being executed.
     """
-    return "{}:{}".format(program_key, task_name)
+    return SEPARATOR.join((program_key, action, task_name))
 
 
 def is_enrollment_job_processing(program_key):
@@ -24,5 +28,4 @@ def is_enrollment_job_processing(program_key):
     Arguments:
         program_key (str): program key for the program we're checking
     """
-    program_prefix = build_enrollment_job_status_name(program_key, '')
-    return processing_job_with_prefix_exists(program_prefix)
+    return processing_job_with_prefix_exists(program_key + SEPARATOR)


### PR DESCRIPTION
https://openedx.atlassian.net/browse/EDUCATOR-4476

* Adds a program key to the name of our enrollment-reading jobs.
* Adds a "read" or "write" action to all of our enrollment reading and writing jobs.
* I didn't do anything about not blocking concurrent reads while writes were in progress, or visa versa.  It's not clear to me yet that this is an ok thing to do.

Tested manually by making a request to the program enrollments read endpoint and verified that the `UserTaskStatus` object generated had the program key and "read" in it's name:
```
>>> status = UserTaskStatus.objects.order_by('-created').first()
>>> status.name
'd4014686-0fbe-438a-a3b2-425416746e3d:read:list_program_enrollments'
```
