### PR TITLE
Upgrade requirements; switch to new-style middleware

### DIFF
--- a/registrar/settings/base.py
+++ b/registrar/settings/base.py
@@ -50,7 +50,7 @@ PROJECT_APPS = (
 INSTALLED_APPS += THIRD_PARTY_APPS
 INSTALLED_APPS += PROJECT_APPS
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     'corsheaders.middleware.CorsMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',

--- a/requirements/devstack.txt
+++ b/requirements/devstack.txt
@@ -16,13 +16,13 @@ aws-sam-translator==1.12.0  # via cfn-lint
 aws-xray-sdk==2.4.2       # via moto
 babel==2.7.0              # via sphinx
 billiard==3.3.0.23        # via celery
-boto3==1.9.180            # via aws-sam-translator, moto
+boto3==1.9.185            # via aws-sam-translator, moto
 boto==2.49.0              # via moto
-botocore==1.12.180        # via aws-xray-sdk, boto3, moto, s3transfer
+botocore==1.12.185        # via aws-xray-sdk, boto3, moto, s3transfer
 celery==3.1.26.post2
 certifi==2019.6.16        # via requests
 cffi==1.12.3              # via cryptography
-cfn-lint==0.22.0          # via moto
+cfn-lint==0.22.2          # via moto
 chardet==3.0.4            # via requests
 click-log==0.3.2          # via edx-lint
 click==7.0                # via click-log, code-annotations, edx-lint
@@ -42,7 +42,7 @@ django-mysql==3.2.0
 django-simple-history==2.7.2
 django-storages==1.7.1
 django-user-tasks==0.1.7
-django-waffle==0.16.0
+django-waffle==0.17.0
 django==1.11.22
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.9.4
@@ -53,7 +53,7 @@ ecdsa==0.13.2             # via python-jose
 edx-auth-backends==2.0.1
 edx-django-release-util==0.3.1
 edx-django-utils==1.0.5   # via edx-drf-extensions
-edx-drf-extensions==2.3.1
+edx-drf-extensions==2.3.3
 edx-i18n-tools==0.4.8
 edx-lint==1.3.0
 edx-opaque-keys==1.0.1    # via edx-drf-extensions
@@ -82,13 +82,13 @@ more-itertools==7.1.0     # via pytest
 moto==1.3.8
 mysqlclient==1.3.14
 newrelic==4.20.1.121      # via edx-django-utils
-oauthlib==3.0.1           # via requests-oauthlib, social-auth-core
+oauthlib==3.0.2           # via requests-oauthlib, social-auth-core
 packaging==19.0           # via pytest
 path.py==12.0.1           # via edx-i18n-tools
 pathlib2==2.3.4           # via pytest
 pathspec==0.5.9           # via yamllint
-pbr==5.3.1                # via stevedore
-pip-api==0.0.10           # via isort
+pbr==5.4.0                # via stevedore
+pip-api==0.0.12           # via isort
 pipreqs==0.4.9            # via isort
 pluggy==0.12.0            # via pytest
 polib==1.1.0              # via edx-i18n-tools
@@ -107,10 +107,10 @@ pylint-plugin-utils==0.5  # via pylint-celery, pylint-django
 pylint==1.7.6             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.8.0            # via edx-opaque-keys
 pyparsing==2.4.0          # via packaging
-pyrsistent==0.15.2        # via jsonschema
+pyrsistent==0.15.3        # via jsonschema
 pytest-cov==2.7.1
 pytest-django==3.5.1
-pytest==5.0.0             # via pytest-cov, pytest-django
+pytest==5.0.1             # via pytest-cov, pytest-django
 python-dateutil==2.8.0    # via analytics-python, botocore, edx-drf-extensions, faker, moto, ruamel.yaml.convert
 python-jose==3.0.1        # via moto
 python-memcached==1.59
@@ -127,7 +127,7 @@ rsa==4.0                  # via python-jose
 ruamel.std.argparse==0.8.1  # via ruamel.yaml.cmd
 ruamel.yaml.cmd==0.5.3
 ruamel.yaml.convert==0.3.0  # via ruamel.yaml.cmd
-ruamel.yaml==0.15.97      # via ruamel.yaml.cmd, ruamel.yaml.convert
+ruamel.yaml==0.15.98      # via ruamel.yaml.cmd, ruamel.yaml.convert
 s3transfer==0.2.1         # via boto3
 semantic-version==2.6.0   # via edx-drf-extensions
 six==1.11.0               # via analytics-python, astroid, aws-sam-translator, cfn-lint, configobj, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, docker, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, faker, jsonschema, mock, moto, packaging, pathlib2, pyjwkest, pylint, pyrsistent, python-dateutil, python-jose, python-memcached, responses, social-auth-app-django, social-auth-core, sphinx, stevedore, transifex-client, websocket-client
@@ -150,7 +150,7 @@ wrapt==1.11.2             # via astroid, aws-xray-sdk
 xmltodict==0.12.0         # via moto
 yamllint==1.16.0
 yarg==0.1.9               # via pipreqs
-zipp==0.5.1               # via importlib-metadata
+zipp==0.5.2               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip==19.1.1               # via pip-api

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -16,13 +16,13 @@ aws-sam-translator==1.12.0  # via cfn-lint
 aws-xray-sdk==2.4.2       # via moto
 babel==2.7.0              # via sphinx
 billiard==3.3.0.23        # via celery
-boto3==1.9.180            # via aws-sam-translator, moto
+boto3==1.9.185            # via aws-sam-translator, moto
 boto==2.49.0              # via moto
-botocore==1.12.180        # via aws-xray-sdk, boto3, moto, s3transfer
+botocore==1.12.185        # via aws-xray-sdk, boto3, moto, s3transfer
 celery==3.1.26.post2
 certifi==2019.6.16        # via requests
 cffi==1.12.3              # via cryptography
-cfn-lint==0.22.0          # via moto
+cfn-lint==0.22.2          # via moto
 chardet==3.0.4            # via requests
 click-log==0.3.2          # via edx-lint
 click==7.0                # via click-log, code-annotations, edx-lint
@@ -42,7 +42,7 @@ django-mysql==3.2.0
 django-simple-history==2.7.2
 django-storages==1.7.1
 django-user-tasks==0.1.7
-django-waffle==0.16.0
+django-waffle==0.17.0
 django==1.11.22
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.9.4
@@ -53,7 +53,7 @@ ecdsa==0.13.2             # via python-jose
 edx-auth-backends==2.0.1
 edx-django-release-util==0.3.1
 edx-django-utils==1.0.5   # via edx-drf-extensions
-edx-drf-extensions==2.3.1
+edx-drf-extensions==2.3.3
 edx-i18n-tools==0.4.8
 edx-lint==1.3.0
 edx-opaque-keys==1.0.1    # via edx-drf-extensions
@@ -81,13 +81,13 @@ mock==3.0.5
 more-itertools==7.1.0     # via pytest
 moto==1.3.8
 newrelic==4.20.1.121      # via edx-django-utils
-oauthlib==3.0.1           # via requests-oauthlib, social-auth-core
+oauthlib==3.0.2           # via requests-oauthlib, social-auth-core
 packaging==19.0           # via pytest
 path.py==12.0.1           # via edx-i18n-tools
 pathlib2==2.3.4           # via pytest
 pathspec==0.5.9           # via yamllint
-pbr==5.3.1                # via stevedore
-pip-api==0.0.10           # via isort
+pbr==5.4.0                # via stevedore
+pip-api==0.0.12           # via isort
 pipreqs==0.4.9            # via isort
 pluggy==0.12.0            # via pytest
 polib==1.1.0              # via edx-i18n-tools
@@ -106,10 +106,10 @@ pylint-plugin-utils==0.5  # via pylint-celery, pylint-django
 pylint==1.7.6             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.8.0            # via edx-opaque-keys
 pyparsing==2.4.0          # via packaging
-pyrsistent==0.15.2        # via jsonschema
+pyrsistent==0.15.3        # via jsonschema
 pytest-cov==2.7.1
 pytest-django==3.5.1
-pytest==5.0.0             # via pytest-cov, pytest-django
+pytest==5.0.1             # via pytest-cov, pytest-django
 python-dateutil==2.8.0    # via analytics-python, botocore, edx-drf-extensions, faker, moto, ruamel.yaml.convert
 python-jose==3.0.1        # via moto
 python-slugify==1.2.6     # via code-annotations, transifex-client
@@ -125,7 +125,7 @@ rsa==4.0                  # via python-jose
 ruamel.std.argparse==0.8.1  # via ruamel.yaml.cmd
 ruamel.yaml.cmd==0.5.3
 ruamel.yaml.convert==0.3.0  # via ruamel.yaml.cmd
-ruamel.yaml==0.15.97      # via ruamel.yaml.cmd, ruamel.yaml.convert
+ruamel.yaml==0.15.98      # via ruamel.yaml.cmd, ruamel.yaml.convert
 s3transfer==0.2.1         # via boto3
 semantic-version==2.6.0   # via edx-drf-extensions
 six==1.11.0               # via analytics-python, astroid, aws-sam-translator, cfn-lint, configobj, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, docker, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, faker, jsonschema, mock, moto, packaging, pathlib2, pyjwkest, pylint, pyrsistent, python-dateutil, python-jose, responses, social-auth-app-django, social-auth-core, sphinx, stevedore, transifex-client, websocket-client
@@ -148,7 +148,7 @@ wrapt==1.11.2             # via astroid, aws-xray-sdk
 xmltodict==0.12.0         # via moto
 yamllint==1.16.0
 yarg==0.1.9               # via pipreqs
-zipp==0.5.1               # via importlib-metadata
+zipp==0.5.2               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip==19.1.1               # via pip-api

--- a/requirements/monitoring/requirements.txt
+++ b/requirements/monitoring/requirements.txt
@@ -16,13 +16,13 @@ aws-sam-translator==1.12.0  # via cfn-lint
 aws-xray-sdk==2.4.2       # via moto
 babel==2.7.0              # via sphinx
 billiard==3.3.0.23        # via celery
-boto3==1.9.180
+boto3==1.9.185
 boto==2.49.0              # via moto
-botocore==1.12.180        # via aws-xray-sdk, boto3, moto, s3transfer
+botocore==1.12.185        # via aws-xray-sdk, boto3, moto, s3transfer
 celery==3.1.26.post2
 certifi==2019.6.16        # via requests
 cffi==1.12.3              # via cryptography
-cfn-lint==0.22.0          # via moto
+cfn-lint==0.22.2          # via moto
 chardet==3.0.4            # via requests
 click-log==0.3.2          # via edx-lint
 click==7.0                # via click-log, code-annotations, edx-lint
@@ -42,7 +42,7 @@ django-mysql==3.2.0
 django-simple-history==2.7.2
 django-storages==1.7.1
 django-user-tasks==0.1.7
-django-waffle==0.16.0
+django-waffle==0.17.0
 django==1.11.22
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.9.4
@@ -53,7 +53,7 @@ ecdsa==0.13.2             # via python-jose
 edx-auth-backends==2.0.1
 edx-django-release-util==0.3.1
 edx-django-utils==1.0.5   # via edx-drf-extensions
-edx-drf-extensions==2.3.1
+edx-drf-extensions==2.3.3
 edx-i18n-tools==0.4.8
 edx-lint==1.3.0
 edx-opaque-keys==1.0.1    # via edx-drf-extensions
@@ -85,13 +85,13 @@ more-itertools==7.1.0     # via pytest
 moto==1.3.8
 mysqlclient==1.3.14
 newrelic==4.20.1.121
-oauthlib==3.0.1           # via requests-oauthlib, social-auth-core
+oauthlib==3.0.2           # via requests-oauthlib, social-auth-core
 packaging==19.0           # via pytest
 path.py==12.0.1           # via edx-i18n-tools
 pathlib2==2.3.4           # via pytest
 pathspec==0.5.9           # via yamllint
-pbr==5.3.1                # via stevedore
-pip-api==0.0.10           # via isort
+pbr==5.4.0                # via stevedore
+pip-api==0.0.12           # via isort
 pipreqs==0.4.9            # via isort
 pluggy==0.12.0            # via pytest
 polib==1.1.0              # via edx-i18n-tools
@@ -110,10 +110,10 @@ pylint-plugin-utils==0.5  # via pylint-celery, pylint-django
 pylint==1.7.6             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.8.0            # via edx-opaque-keys
 pyparsing==2.4.0          # via packaging
-pyrsistent==0.15.2        # via jsonschema
+pyrsistent==0.15.3        # via jsonschema
 pytest-cov==2.7.1
 pytest-django==3.5.1
-pytest==5.0.0             # via pytest-cov, pytest-django
+pytest==5.0.1             # via pytest-cov, pytest-django
 python-dateutil==2.8.0    # via analytics-python, botocore, edx-drf-extensions, faker, moto, ruamel.yaml.convert
 python-jose==3.0.1        # via moto
 python-memcached==1.59
@@ -130,7 +130,7 @@ rsa==4.0                  # via python-jose
 ruamel.std.argparse==0.8.1  # via ruamel.yaml.cmd
 ruamel.yaml.cmd==0.5.3
 ruamel.yaml.convert==0.3.0  # via ruamel.yaml.cmd
-ruamel.yaml==0.15.97      # via ruamel.yaml.cmd, ruamel.yaml.convert
+ruamel.yaml==0.15.98      # via ruamel.yaml.cmd, ruamel.yaml.convert
 s3transfer==0.2.1         # via boto3
 semantic-version==2.6.0   # via edx-drf-extensions
 six==1.11.0               # via analytics-python, astroid, aws-sam-translator, cfn-lint, configobj, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, docker, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, faker, jsonschema, mock, moto, packaging, pathlib2, pyjwkest, pylint, pyrsistent, python-dateutil, python-jose, python-memcached, responses, social-auth-app-django, social-auth-core, sphinx, stevedore, transifex-client, websocket-client
@@ -153,7 +153,7 @@ wrapt==1.11.2             # via astroid, aws-xray-sdk
 xmltodict==0.12.0         # via moto
 yamllint==1.16.0
 yarg==0.1.9               # via pipreqs
-zipp==0.5.1               # via importlib-metadata
+zipp==0.5.2               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip==19.1.1               # via pip-api

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -8,8 +8,8 @@ amqp==1.4.9               # via kombu
 analytics-python==1.2.9
 anyjson==0.3.3            # via kombu
 billiard==3.3.0.23        # via celery
-boto3==1.9.180
-botocore==1.12.180        # via boto3, s3transfer
+boto3==1.9.185
+botocore==1.12.185        # via boto3, s3transfer
 celery==3.1.26.post2
 certifi==2019.6.16        # via requests
 chardet==3.0.4            # via requests
@@ -22,7 +22,7 @@ django-mysql==3.2.0
 django-simple-history==2.7.2
 django-storages==1.7.1
 django-user-tasks==0.1.7
-django-waffle==0.16.0
+django-waffle==0.17.0
 django==1.11.22
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.9.4
@@ -30,7 +30,7 @@ docutils==0.14            # via botocore
 edx-auth-backends==2.0.1
 edx-django-release-util==0.3.1
 edx-django-utils==1.0.5   # via edx-drf-extensions
-edx-drf-extensions==2.3.1
+edx-drf-extensions==2.3.3
 edx-opaque-keys==1.0.1    # via edx-drf-extensions
 edx-rest-api-client==1.9.2
 future==0.17.1            # via pyjwkest
@@ -42,8 +42,8 @@ jmespath==0.9.4           # via boto3, botocore
 kombu==3.0.37             # via celery
 mysqlclient==1.3.14
 newrelic==4.20.1.121      # via edx-django-utils
-oauthlib==3.0.1           # via requests-oauthlib, social-auth-core
-pbr==5.3.1                # via stevedore
+oauthlib==3.0.2           # via requests-oauthlib, social-auth-core
+pbr==5.4.0                # via stevedore
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
 pycryptodomex==3.8.2      # via pyjwkest
 pyjwkest==1.3.2           # via edx-drf-extensions, social-auth-core

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -14,13 +14,13 @@ attrs==19.1.0             # via jsonschema, pytest
 aws-sam-translator==1.12.0  # via cfn-lint
 aws-xray-sdk==2.4.2       # via moto
 billiard==3.3.0.23        # via celery
-boto3==1.9.180            # via aws-sam-translator, moto
+boto3==1.9.185            # via aws-sam-translator, moto
 boto==2.49.0              # via moto
-botocore==1.12.180        # via aws-xray-sdk, boto3, moto, s3transfer
+botocore==1.12.185        # via aws-xray-sdk, boto3, moto, s3transfer
 celery==3.1.26.post2
 certifi==2019.6.16        # via requests
 cffi==1.12.3              # via cryptography
-cfn-lint==0.22.0          # via moto
+cfn-lint==0.22.2          # via moto
 chardet==3.0.4            # via requests
 click-log==0.3.2          # via edx-lint
 click==7.0                # via click-log, code-annotations, edx-lint
@@ -38,7 +38,7 @@ django-mysql==3.2.0
 django-simple-history==2.7.2
 django-storages==1.7.1
 django-user-tasks==0.1.7
-django-waffle==0.16.0
+django-waffle==0.17.0
 django==1.11.22
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.9.4
@@ -49,7 +49,7 @@ ecdsa==0.13.2             # via python-jose
 edx-auth-backends==2.0.1
 edx-django-release-util==0.3.1
 edx-django-utils==1.0.5   # via edx-drf-extensions
-edx-drf-extensions==2.3.1
+edx-drf-extensions==2.3.3
 edx-lint==1.3.0
 edx-opaque-keys==1.0.1    # via edx-drf-extensions
 edx-rest-api-client==1.9.2
@@ -74,12 +74,12 @@ mock==3.0.5
 more-itertools==7.1.0     # via pytest
 moto==1.3.8
 newrelic==4.20.1.121      # via edx-django-utils
-oauthlib==3.0.1           # via requests-oauthlib, social-auth-core
+oauthlib==3.0.2           # via requests-oauthlib, social-auth-core
 packaging==19.0           # via pytest
 pathlib2==2.3.4           # via pytest
 pathspec==0.5.9           # via yamllint
-pbr==5.3.1                # via stevedore
-pip-api==0.0.10           # via isort
+pbr==5.4.0                # via stevedore
+pip-api==0.0.12           # via isort
 pipreqs==0.4.9            # via isort
 pluggy==0.12.0            # via pytest
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
@@ -96,10 +96,10 @@ pylint-plugin-utils==0.5  # via pylint-celery, pylint-django
 pylint==1.7.6             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.8.0            # via edx-opaque-keys
 pyparsing==2.4.0          # via packaging
-pyrsistent==0.15.2        # via jsonschema
+pyrsistent==0.15.3        # via jsonschema
 pytest-cov==2.7.1
 pytest-django==3.5.1
-pytest==5.0.0             # via pytest-cov, pytest-django
+pytest==5.0.1             # via pytest-cov, pytest-django
 python-dateutil==2.8.0    # via analytics-python, botocore, edx-drf-extensions, faker, moto
 python-jose==3.0.1        # via moto
 python-slugify==3.0.2     # via code-annotations
@@ -128,7 +128,7 @@ wrapt==1.11.2             # via astroid, aws-xray-sdk
 xmltodict==0.12.0         # via moto
 yamllint==1.16.0
 yarg==0.1.9               # via pipreqs
-zipp==0.5.1               # via importlib-metadata
+zipp==0.5.2               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip==19.1.1               # via pip-api


### PR DESCRIPTION
@edx/masters-neem 

Along with https://github.com/edx/edx-drf-extensions/pull/76, gets rid of the 294 warnings we've been getting since the Django upgrade :)