### PR TITLE
return 404 if discovery returns 404

### DIFF
--- a/registrar/apps/api/v1/tests/test_views.py
+++ b/registrar/apps/api/v1/tests/test_views.py
@@ -956,6 +956,23 @@ class ProgramEnrollmentWriteMixin(object):
             response = self.request(self.method, 'programs/masters-in-cs/enrollments/', self.stem_admin, req_data)
         self.assertEqual(response.status_code, 413)
 
+    @mock_oauth_login
+    def test_discovery_404(self):
+        req_data = [
+            self.student_enrollment('enrolled', '001'),
+        ]
+        mock_response = mock.Mock()
+        mock_response.status_code = 404
+        error = requests.exceptions.HTTPError(response=mock_response)
+        with mock.patch('registrar.apps.enrollments.data._make_request', side_effect=error):
+            response = self.request(
+                self.method,
+                'programs/masters-in-cs/enrollments/',
+                self.stem_admin,
+                req_data,
+            )
+        self.assertEqual(404, response.status_code)
+
 
 class ProgramEnrollmentPostTests(ProgramEnrollmentWriteMixin, RegistrarAPITestCase, AuthRequestMixin):
     method = 'POST'

--- a/registrar/apps/enrollments/data.py
+++ b/registrar/apps/enrollments/data.py
@@ -79,6 +79,7 @@ class DiscoveryProgram(object):
         Get a DiscoveryProgram instance, either by loading it from the cache,
         or query the Course Discovery service if it is not in the cache.
 
+        Raises Http404 if program is not cached and Discovery returns 404
         Raises HTTPError if program is not cached and Discover returns error.
         Raises ValidationError if program is not cached and Discovery returns
             data in a format we don't like.
@@ -95,7 +96,8 @@ class DiscoveryProgram(object):
         """
         Load a DiscoveryProgram instance from the Course Discovery service.
 
-        Raises HTTPError if program is not cached AND Discovery returns error.
+        Raises Http404 if program is not cached and Discovery returns 404
+        Raises HTTPError if program is not cached AND Discovery returns error
         """
         url = urljoin(
             settings.DISCOVERY_BASE_URL, 'api/v1/programs/{}/'

--- a/registrar/apps/enrollments/tests/test_data.py
+++ b/registrar/apps/enrollments/tests/test_data.py
@@ -15,6 +15,7 @@ import mock
 import responses
 from django.conf import settings
 from django.core.cache import cache
+from django.http import Http404
 from django.test import TestCase
 from requests.exceptions import HTTPError
 from rest_framework.exceptions import ValidationError
@@ -488,6 +489,20 @@ class GetDiscoveryProgramTestCase(TestCase):
         )
         loaded_program = DiscoveryProgram.get(self.program_uuid)
         self.assert_discovery_programs_equal(loaded_program, self.expected_program)
+
+        nonexistant_program_uuid = str(uuid.uuid4())
+        discovery_url = urljoin(
+            settings.DISCOVERY_BASE_URL,
+            DISCOVERY_PROGRAM_API_TPL.format(nonexistant_program_uuid)
+        )
+        responses.add(
+            responses.GET,
+            discovery_url,
+            json={'message': 'program not found!'},
+            status=404
+        )
+        with self.assertRaises(Http404):
+            DiscoveryProgram.get(nonexistant_program_uuid)
 
     @mock_oauth_login
     @responses.activate


### PR DESCRIPTION
If we 404 trying to get a program from discovery, return a 404 rather than a 500