### PR TITLE
use xvfb service in travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,12 @@ python:
     - 3.6
 sudo: false
 
+services:
+    - xvfb
+
 cache: pip
 before_install:
     - "export DISPLAY=:99.0"
-    - "sh -e /etc/init.d/xvfb start"
     - "sudo rm -f /etc/boto.cfg"  # See https://github.com/travis-ci/travis-ci/issues/7940
 install:
     - pip install -U pip wheel


### PR DESCRIPTION
## Description

Not sure why, but it seems that the Linux image used for Travis tests changed today from Trusty to Xenial. We were not specifying an OS version in our `.travis.yml` file. so we should just run on whatever the default is, but I haven't seen any posts on Travis-CI indicating a migration or change for this week.

Regardless, using a Xenial image requires a change to how to start xvfb. We could explicitly use Trusty images and keep starting xvfb the old way, but I think moving to Xenial is a good idea, to get test environments closet to production-like.
