### PR TITLE
fix manage_programs bugs

### DIFF
--- a/registrar/apps/enrollments/management/commands/manage_programs.py
+++ b/registrar/apps/enrollments/management/commands/manage_programs.py
@@ -3,6 +3,7 @@ import logging
 
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
+from django.http import Http404
 from requests.exceptions import HTTPError
 
 from registrar.apps.core.models import Organization
@@ -52,7 +53,7 @@ class Command(BaseCommand):
     def get_discovery_program_dict(self, program_uuid):
         try:
             return DiscoveryProgram.read_from_discovery(program_uuid)
-        except HTTPError as e:
+        except (HTTPError, Http404) as e:
             raise CommandError('Could not read program from course-discovery: {}'.format(e))
 
     def get_authoring_org_keys(self, program_dict):
@@ -92,7 +93,7 @@ class Command(BaseCommand):
                 'key': program_key or program_dict.get('marketing_slug'),
             },
         )
-        if not created and program.key != program_key:
+        if (not created) and program_key and (program.key != program_key):
             program.key = program_key
             program.save()
         verb = 'Created' if created else 'Modified existing'

--- a/registrar/apps/enrollments/management/commands/test/test_manage_programs.py
+++ b/registrar/apps/enrollments/management/commands/test/test_manage_programs.py
@@ -184,4 +184,3 @@ class TestManagePrograms(TestCase):
         # pylint: disable=deprecated-method
         with self.assertRaisesRegex(CommandError, 'Could not read program'):
             call_command(self.command, self._uuidkeys((self.english_uuid, 'english-program')))
-

--- a/registrar/apps/enrollments/management/commands/test/test_manage_programs.py
+++ b/registrar/apps/enrollments/management/commands/test/test_manage_programs.py
@@ -2,6 +2,7 @@
 import ddt
 from django.core.management import call_command
 from django.core.management.base import CommandError
+from django.http import Http404
 from django.test import TestCase
 from mock import patch
 from requests.exceptions import HTTPError
@@ -141,6 +142,12 @@ class TestManagePrograms(TestCase):
         call_command(self.command, self._uuidkeys((self.english_uuid, 'masters-in-english')))
         self.assert_program(self.english_uuid, 'masters-in-english', self.org)
 
+    def test_modify_program_no_key(self):
+        self.mock_get_discovery_program.return_value = self.english_discovery_program
+        self.assert_program(self.english_uuid, 'masters-in-english', self.org)
+        call_command(self.command, self.english_uuid)
+        self.assert_program(self.english_uuid, 'masters-in-english', self.org)
+
     def test_incorrect_format(self):
         # pylint: disable=deprecated-method
         with self.assertRaisesRegex(CommandError, 'incorrectly formatted argument'):
@@ -171,3 +178,10 @@ class TestManagePrograms(TestCase):
         # pylint: disable=deprecated-method
         with self.assertRaisesRegex(CommandError, 'Could not read program'):
             call_command(self.command, self._uuidkeys((self.english_uuid, 'english-program')))
+
+    def test_load_from_disco_404(self):
+        self.mock_get_discovery_program.side_effect = Http404()
+        # pylint: disable=deprecated-method
+        with self.assertRaisesRegex(CommandError, 'Could not read program'):
+            call_command(self.command, self._uuidkeys((self.english_uuid, 'english-program')))
+


### PR DESCRIPTION
catch the correct error on 404
if program_key isn't specified and there already is one, just keep it rather than trying to set it to none