### PR TITLE
Ignore read-only/old jobs when checking conflicts

### DIFF
--- a/registrar/apps/api/v1/tests/test_views.py
+++ b/registrar/apps/api/v1/tests/test_views.py
@@ -1786,7 +1786,10 @@ class EnrollmentUploadMixin(object):
     def test_enrollment_upload_conflict(self):
         enrollments = [self.build_enrollment('enrolled', '001')]
 
-        with mock.patch('registrar.apps.api.v1.views.is_enrollment_job_processing', return_value=True):
+        with mock.patch(
+                'registrar.apps.api.v1.views.is_enrollment_write_blocked',
+                return_value=True
+        ):
             upload_response = self._upload_enrollments(enrollments)
 
         self.assertEqual(upload_response.status_code, 409)

--- a/registrar/apps/api/v1/views.py
+++ b/registrar/apps/api/v1/views.py
@@ -54,7 +54,7 @@ from registrar.apps.enrollments.tasks import (
     write_course_run_enrollments,
     write_program_enrollments,
 )
-from registrar.apps.enrollments.utils import is_enrollment_job_processing
+from registrar.apps.enrollments.utils import is_enrollment_write_blocked
 from registrar.apps.grades.tasks import get_course_run_grades
 
 
@@ -435,7 +435,7 @@ class EnrollmentUploadView(JobInvokerMixin, APIView):
         if csv_file.size > UPLOAD_FILE_MAX_SIZE:
             raise FileTooLarge()
 
-        if is_enrollment_job_processing(self.program.key):
+        if is_enrollment_write_blocked(self.program.key):
             return Response('Job already in progress for program', HTTP_409_CONFLICT)
 
         file_itr = io.StringIO(csv_file.read().decode('utf-8'))

--- a/registrar/apps/enrollments/tests/test_utils.py
+++ b/registrar/apps/enrollments/tests/test_utils.py
@@ -4,13 +4,14 @@ from uuid import uuid4
 
 import ddt
 from django.test import TestCase
+from freezegun import freeze_time
 from user_tasks.models import UserTaskStatus
 
 from registrar.apps.core.tests.factories import OrganizationFactory, UserFactory
 from registrar.apps.enrollments.tests.factories import ProgramFactory
 from registrar.apps.enrollments.utils import (
     build_enrollment_job_status_name,
-    is_enrollment_job_processing,
+    is_enrollment_write_blocked,
 )
 
 
@@ -42,9 +43,9 @@ class EnrollmentJobTests(TestCase):
 
 
 @ddt.ddt
-class IsEnrollmentJobProcessingTests(EnrollmentJobTests):
+class IsEnrollmentWriteBlockedTests(EnrollmentJobTests):
     """
-    Tests for is_enrollment_job_processing
+    Tests for is_enrollment_write_blocked
     """
 
     @ddt.unpack
@@ -56,18 +57,29 @@ class IsEnrollmentJobProcessingTests(EnrollmentJobTests):
         (UserTaskStatus.CANCELED, False),
         (UserTaskStatus.RETRYING, True),
     )
-    def test_job_processing(self, state, expected):
+    def test_processing_job_blocks(self, state, expected):
         task_name = build_enrollment_job_status_name(self.program.key, 'write', self.TASK_NAME)
         self.create_dummy_job_status(state, self.user, task_name)
-        job_in_progress = is_enrollment_job_processing(self.program.key)
+        job_in_progress = is_enrollment_write_blocked(self.program.key)
         self.assertEqual(expected, job_in_progress)
 
-    def test_different_program(self):
+    def test_different_program_does_not_block(self):
         task_name = build_enrollment_job_status_name(self.program.key, 'write', self.TASK_NAME)
         self.create_dummy_job_status(UserTaskStatus.IN_PROGRESS, self.user, task_name)
-        self.assertFalse(is_enrollment_job_processing(self.program2.key))
+        self.assertFalse(is_enrollment_write_blocked(self.program2.key))
 
-    def test_wrong_name(self):
+    def test_wrong_name_does_not_block(self):
         task_name = build_enrollment_job_status_name(self.TASK_NAME, 'write', self.program.key)
         self.create_dummy_job_status(UserTaskStatus.IN_PROGRESS, self.user, task_name)
-        self.assertFalse(is_enrollment_job_processing(self.program.key))
+        self.assertFalse(is_enrollment_write_blocked(self.program.key))
+
+    def test_read_job_does_not_block(self):
+        task_name = build_enrollment_job_status_name(self.program.key, 'read', self.TASK_NAME)
+        self.create_dummy_job_status(UserTaskStatus.IN_PROGRESS, self.user, task_name)
+        self.assertFalse(is_enrollment_write_blocked(self.program.key))
+
+    def test_old_job_does_not_block(self):
+        task_name = build_enrollment_job_status_name(self.program.key, 'write', self.TASK_NAME)
+        with freeze_time("2000-01-01"):
+            self.create_dummy_job_status(UserTaskStatus.IN_PROGRESS, self.user, task_name)
+        self.assertFalse(is_enrollment_write_blocked(self.program.key))

--- a/registrar/apps/enrollments/utils.py
+++ b/registrar/apps/enrollments/utils.py
@@ -1,9 +1,19 @@
 """ Utilities for the enrollments app """
 
-from registrar.apps.core.jobs import processing_job_with_prefix_exists
+from registrar.apps.core.jobs import recent_processing_job_with_prefix_exists
 
 
 SEPARATOR = ':'
+WRITE_PREFIX = 'write'
+
+# Jobs older than this many minutes will NOT block enrollment writing
+# for the associated program.
+# This is because jobs get stuck permanently in Pending sometimes, which means
+# we'd have to modify the DB to un-block writes for associated program.
+# We can safely assume that jobs over 30 minutes old will never complete.
+# If we add long-running write jobs to Registrar, then this number may need
+# to be increased.
+MAX_AGE_MINUTES_FOR_BLOCKING_JOB = 30
 
 
 def build_enrollment_job_status_name(program_key, action, task_name):
@@ -18,14 +28,22 @@ def build_enrollment_job_status_name(program_key, action, task_name):
     return SEPARATOR.join((program_key, action, task_name))
 
 
-def is_enrollment_job_processing(program_key):
+def is_enrollment_write_blocked(program_key):
     """
     Returns whether or not a bulk enrollment job for a particular program
-    is currently processing (in progress, pending, or retrying)
+    is currently processing (in progress, pending, or retrying),
+    ignoring jobs over `MAX_AGE_MINUTES_FOR_BLOCKING_JOB` minutes old.
 
     Used to ensure only one bulk task can be run at a time for a program.
 
     Arguments:
         program_key (str): program key for the program we're checking
     """
-    return processing_job_with_prefix_exists(program_key + SEPARATOR)
+    prefix = "{key}{sep}{write}{sep}".format(
+        key=program_key,
+        sep=SEPARATOR,
+        write=WRITE_PREFIX,
+    )
+    return recent_processing_job_with_prefix_exists(
+        prefix, MAX_AGE_MINUTES_FOR_BLOCKING_JOB
+    )

--- a/requirements/devstack.txt
+++ b/requirements/devstack.txt
@@ -12,17 +12,17 @@ asn1crypto==0.24.0        # via cryptography
 astroid==1.5.3            # via pylint, pylint-celery
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via jsonschema, packaging, pytest
-aws-sam-translator==1.13.0  # via cfn-lint
+aws-sam-translator==1.13.2  # via cfn-lint
 aws-xray-sdk==2.4.2       # via moto
 babel==2.7.0              # via sphinx
 billiard==3.3.0.23        # via celery
-boto3==1.9.199            # via aws-sam-translator, moto
+boto3==1.9.211            # via aws-sam-translator, moto
 boto==2.49.0              # via moto
-botocore==1.12.199        # via aws-xray-sdk, boto3, moto, s3transfer
+botocore==1.12.211        # via aws-xray-sdk, boto3, moto, s3transfer
 celery==3.1.26.post2
 certifi==2019.6.16        # via requests
 cffi==1.12.3              # via cryptography
-cfn-lint==0.23.1          # via moto
+cfn-lint==0.23.3          # via moto
 chardet==3.0.4            # via requests
 click-log==0.3.2          # via edx-lint
 click==7.0                # via click-log, code-annotations, edx-lint
@@ -32,7 +32,7 @@ coverage==4.5.4
 cryptography==2.7         # via moto
 ddt==1.2.1
 defusedxml==0.6.0         # via python3-openid, social-auth-core
-django-cors-headers==3.0.2
+django-cors-headers==3.1.0
 django-debug-toolbar==2.0
 django-dynamic-fixture==2.0.0
 django-extensions==2.2.1
@@ -48,19 +48,20 @@ djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.10.2
 docker==4.0.2             # via moto
 docopt==0.6.2             # via pipreqs
-docutils==0.14            # via botocore, sphinx
+docutils==0.15.2          # via botocore, sphinx
 ecdsa==0.13.2             # via python-jose
-edx-auth-backends==2.0.1
+edx-auth-backends==2.0.2
 edx-django-release-util==0.3.1
 edx-django-utils==2.0.0   # via edx-drf-extensions
-edx-drf-extensions==2.3.8
+edx-drf-extensions==2.4.0
 edx-i18n-tools==0.4.8
 edx-lint==1.3.0
 edx-opaque-keys==1.0.1    # via edx-drf-extensions
 edx-rest-api-client==1.9.2
 edx-sphinx-theme==1.5.0
 factory-boy==2.12.0
-faker==2.0.0
+faker==2.0.1
+freezegun==0.3.12
 future==0.17.1            # via aws-xray-sdk, pyjwkest, python-jose
 idna==2.8                 # via moto, requests
 imagesize==1.1.0          # via sphinx
@@ -81,13 +82,13 @@ mock==3.0.5
 more-itertools==7.2.0     # via pytest
 moto==1.3.8
 mysqlclient==1.3.14
-newrelic==4.20.1.121      # via edx-django-utils
-oauthlib==3.0.2           # via requests-oauthlib, social-auth-core
+newrelic==5.0.2.126       # via edx-django-utils
+oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 packaging==19.1           # via pytest
 path.py==12.0.1           # via edx-i18n-tools
 pathlib2==2.3.4           # via pytest
 pathspec==0.5.9           # via yamllint
-pbr==5.4.1                # via stevedore
+pbr==5.4.2                # via stevedore
 pip-api==0.0.12           # via isort
 pipreqs==0.4.9            # via isort
 pluggy==0.12.0            # via pytest
@@ -105,13 +106,13 @@ pylint-celery==0.3        # via edx-lint
 pylint-django==0.7.2      # via edx-lint
 pylint-plugin-utils==0.5  # via pylint-celery, pylint-django
 pylint==1.7.6             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pymongo==3.8.0            # via edx-opaque-keys
+pymongo==3.9.0            # via edx-opaque-keys
 pyparsing==2.4.2          # via packaging
 pyrsistent==0.15.4        # via jsonschema
 pytest-cov==2.7.1
 pytest-django==3.5.1
-pytest==5.0.1             # via pytest-cov, pytest-django
-python-dateutil==2.8.0    # via analytics-python, botocore, edx-drf-extensions, faker, moto, ruamel.yaml.convert
+pytest==5.1.0             # via pytest-cov, pytest-django
+python-dateutil==2.8.0    # via analytics-python, botocore, edx-drf-extensions, faker, freezegun, moto, ruamel.yaml.convert
 python-jose==3.0.1        # via moto
 python-memcached==1.59
 python-slugify==1.2.6     # via code-annotations, transifex-client
@@ -120,18 +121,18 @@ pytz==2019.2
 pyyaml==5.1.2             # via cfn-lint, code-annotations, edx-django-release-util, edx-i18n-tools, moto, yamllint
 redis==2.8
 requests-oauthlib==1.2.0  # via social-auth-core
-requests==2.22.0          # via analytics-python, cfn-lint, docker, edx-drf-extensions, edx-rest-api-client, moto, pyjwkest, requests-oauthlib, responses, slumber, social-auth-core, sphinx, transifex-client, yarg
+requests==2.22.0          # via analytics-python, docker, edx-drf-extensions, edx-rest-api-client, moto, pyjwkest, requests-oauthlib, responses, slumber, social-auth-core, sphinx, transifex-client, yarg
 responses==0.10.6
 rest-condition==1.0.3     # via edx-drf-extensions
 rsa==4.0                  # via python-jose
 ruamel.std.argparse==0.8.1  # via ruamel.yaml.cmd
-ruamel.yaml.clib==0.1.0   # via ruamel.yaml
-ruamel.yaml.cmd==0.5.4
-ruamel.yaml.convert==0.3.1  # via ruamel.yaml.cmd
-ruamel.yaml==0.16.0       # via ruamel.yaml.cmd, ruamel.yaml.convert
+ruamel.yaml.clib==0.1.2   # via ruamel.yaml
+ruamel.yaml.cmd==0.5.5
+ruamel.yaml.convert==0.3.2  # via ruamel.yaml.cmd
+ruamel.yaml==0.16.5       # via ruamel.yaml.cmd, ruamel.yaml.convert
 s3transfer==0.2.1         # via boto3
 semantic-version==2.6.0   # via edx-drf-extensions
-six==1.11.0               # via analytics-python, astroid, aws-sam-translator, cfn-lint, configobj, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, docker, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, faker, jsonschema, mock, moto, packaging, pathlib2, pyjwkest, pylint, pyrsistent, python-dateutil, python-jose, python-memcached, responses, social-auth-app-django, social-auth-core, sphinx, stevedore, transifex-client, websocket-client
+six==1.11.0               # via analytics-python, astroid, aws-sam-translator, cfn-lint, configobj, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, docker, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, faker, freezegun, jsonschema, mock, moto, packaging, pathlib2, pyjwkest, pylint, pyrsistent, python-dateutil, python-jose, python-memcached, responses, social-auth-app-django, social-auth-core, sphinx, stevedore, transifex-client, websocket-client
 slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==1.9.0    # via sphinx
 social-auth-app-django==1.2.0  # via edx-auth-backends
@@ -149,10 +150,10 @@ websocket-client==0.56.0  # via docker
 werkzeug==0.15.5          # via moto
 wrapt==1.11.2             # via astroid, aws-xray-sdk
 xmltodict==0.12.0         # via moto
-yamllint==1.16.0
+yamllint==1.17.0
 yarg==0.1.9               # via pipreqs
 zipp==0.5.2               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-# pip==19.2.1               # via pip-api
-# setuptools==41.0.1        # via cfn-lint, jsonschema, sphinx
+# pip==19.2.2               # via pip-api
+# setuptools==41.1.0        # via cfn-lint, jsonschema, sphinx

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -12,17 +12,17 @@ asn1crypto==0.24.0        # via cryptography
 astroid==1.5.3            # via pylint, pylint-celery
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via jsonschema, packaging, pytest
-aws-sam-translator==1.13.0  # via cfn-lint
+aws-sam-translator==1.13.2  # via cfn-lint
 aws-xray-sdk==2.4.2       # via moto
 babel==2.7.0              # via sphinx
 billiard==3.3.0.23        # via celery
-boto3==1.9.199            # via aws-sam-translator, moto
+boto3==1.9.211            # via aws-sam-translator, moto
 boto==2.49.0              # via moto
-botocore==1.12.199        # via aws-xray-sdk, boto3, moto, s3transfer
+botocore==1.12.211        # via aws-xray-sdk, boto3, moto, s3transfer
 celery==3.1.26.post2
 certifi==2019.6.16        # via requests
 cffi==1.12.3              # via cryptography
-cfn-lint==0.23.1          # via moto
+cfn-lint==0.23.3          # via moto
 chardet==3.0.4            # via requests
 click-log==0.3.2          # via edx-lint
 click==7.0                # via click-log, code-annotations, edx-lint
@@ -32,7 +32,7 @@ coverage==4.5.4
 cryptography==2.7         # via moto
 ddt==1.2.1
 defusedxml==0.6.0         # via python3-openid, social-auth-core
-django-cors-headers==3.0.2
+django-cors-headers==3.1.0
 django-debug-toolbar==2.0
 django-dynamic-fixture==2.0.0
 django-extensions==2.2.1
@@ -48,19 +48,20 @@ djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.10.2
 docker==4.0.2             # via moto
 docopt==0.6.2             # via pipreqs
-docutils==0.14            # via botocore, sphinx
+docutils==0.15.2          # via botocore, sphinx
 ecdsa==0.13.2             # via python-jose
-edx-auth-backends==2.0.1
+edx-auth-backends==2.0.2
 edx-django-release-util==0.3.1
 edx-django-utils==2.0.0   # via edx-drf-extensions
-edx-drf-extensions==2.3.8
+edx-drf-extensions==2.4.0
 edx-i18n-tools==0.4.8
 edx-lint==1.3.0
 edx-opaque-keys==1.0.1    # via edx-drf-extensions
 edx-rest-api-client==1.9.2
 edx-sphinx-theme==1.5.0
 factory-boy==2.12.0
-faker==2.0.0
+faker==2.0.1
+freezegun==0.3.12
 future==0.17.1            # via aws-xray-sdk, pyjwkest, python-jose
 idna==2.8                 # via moto, requests
 imagesize==1.1.0          # via sphinx
@@ -80,13 +81,13 @@ mccabe==0.6.1             # via pylint
 mock==3.0.5
 more-itertools==7.2.0     # via pytest
 moto==1.3.8
-newrelic==4.20.1.121      # via edx-django-utils
-oauthlib==3.0.2           # via requests-oauthlib, social-auth-core
+newrelic==5.0.2.126       # via edx-django-utils
+oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 packaging==19.1           # via pytest
 path.py==12.0.1           # via edx-i18n-tools
 pathlib2==2.3.4           # via pytest
 pathspec==0.5.9           # via yamllint
-pbr==5.4.1                # via stevedore
+pbr==5.4.2                # via stevedore
 pip-api==0.0.12           # via isort
 pipreqs==0.4.9            # via isort
 pluggy==0.12.0            # via pytest
@@ -104,13 +105,13 @@ pylint-celery==0.3        # via edx-lint
 pylint-django==0.7.2      # via edx-lint
 pylint-plugin-utils==0.5  # via pylint-celery, pylint-django
 pylint==1.7.6             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pymongo==3.8.0            # via edx-opaque-keys
+pymongo==3.9.0            # via edx-opaque-keys
 pyparsing==2.4.2          # via packaging
 pyrsistent==0.15.4        # via jsonschema
 pytest-cov==2.7.1
 pytest-django==3.5.1
-pytest==5.0.1             # via pytest-cov, pytest-django
-python-dateutil==2.8.0    # via analytics-python, botocore, edx-drf-extensions, faker, moto, ruamel.yaml.convert
+pytest==5.1.0             # via pytest-cov, pytest-django
+python-dateutil==2.8.0    # via analytics-python, botocore, edx-drf-extensions, faker, freezegun, moto, ruamel.yaml.convert
 python-jose==3.0.1        # via moto
 python-slugify==1.2.6     # via code-annotations, transifex-client
 python3-openid==3.1.0     # via social-auth-core
@@ -118,18 +119,18 @@ pytz==2019.2
 pyyaml==5.1.2             # via cfn-lint, code-annotations, edx-django-release-util, edx-i18n-tools, moto, yamllint
 redis==2.8
 requests-oauthlib==1.2.0  # via social-auth-core
-requests==2.22.0          # via analytics-python, cfn-lint, docker, edx-drf-extensions, edx-rest-api-client, moto, pyjwkest, requests-oauthlib, responses, slumber, social-auth-core, sphinx, transifex-client, yarg
+requests==2.22.0          # via analytics-python, docker, edx-drf-extensions, edx-rest-api-client, moto, pyjwkest, requests-oauthlib, responses, slumber, social-auth-core, sphinx, transifex-client, yarg
 responses==0.10.6
 rest-condition==1.0.3     # via edx-drf-extensions
 rsa==4.0                  # via python-jose
 ruamel.std.argparse==0.8.1  # via ruamel.yaml.cmd
-ruamel.yaml.clib==0.1.0   # via ruamel.yaml
-ruamel.yaml.cmd==0.5.4
-ruamel.yaml.convert==0.3.1  # via ruamel.yaml.cmd
-ruamel.yaml==0.16.0       # via ruamel.yaml.cmd, ruamel.yaml.convert
+ruamel.yaml.clib==0.1.2   # via ruamel.yaml
+ruamel.yaml.cmd==0.5.5
+ruamel.yaml.convert==0.3.2  # via ruamel.yaml.cmd
+ruamel.yaml==0.16.5       # via ruamel.yaml.cmd, ruamel.yaml.convert
 s3transfer==0.2.1         # via boto3
 semantic-version==2.6.0   # via edx-drf-extensions
-six==1.11.0               # via analytics-python, astroid, aws-sam-translator, cfn-lint, configobj, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, docker, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, faker, jsonschema, mock, moto, packaging, pathlib2, pyjwkest, pylint, pyrsistent, python-dateutil, python-jose, responses, social-auth-app-django, social-auth-core, sphinx, stevedore, transifex-client, websocket-client
+six==1.11.0               # via analytics-python, astroid, aws-sam-translator, cfn-lint, configobj, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, docker, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, faker, freezegun, jsonschema, mock, moto, packaging, pathlib2, pyjwkest, pylint, pyrsistent, python-dateutil, python-jose, responses, social-auth-app-django, social-auth-core, sphinx, stevedore, transifex-client, websocket-client
 slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==1.9.0    # via sphinx
 social-auth-app-django==1.2.0  # via edx-auth-backends
@@ -147,10 +148,10 @@ websocket-client==0.56.0  # via docker
 werkzeug==0.15.5          # via moto
 wrapt==1.11.2             # via astroid, aws-xray-sdk
 xmltodict==0.12.0         # via moto
-yamllint==1.16.0
+yamllint==1.17.0
 yarg==0.1.9               # via pipreqs
 zipp==0.5.2               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-# pip==19.2.1               # via pip-api
-# setuptools==41.0.1        # via cfn-lint, jsonschema, sphinx
+# pip==19.2.2               # via pip-api
+# setuptools==41.1.0        # via cfn-lint, jsonschema, sphinx

--- a/requirements/monitoring/requirements.txt
+++ b/requirements/monitoring/requirements.txt
@@ -12,17 +12,17 @@ asn1crypto==0.24.0        # via cryptography
 astroid==1.5.3            # via pylint, pylint-celery
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via jsonschema, packaging, pytest
-aws-sam-translator==1.13.0  # via cfn-lint
+aws-sam-translator==1.13.2  # via cfn-lint
 aws-xray-sdk==2.4.2       # via moto
 babel==2.7.0              # via sphinx
 billiard==3.3.0.23        # via celery
-boto3==1.9.199
+boto3==1.9.211
 boto==2.49.0              # via moto
-botocore==1.12.199        # via aws-xray-sdk, boto3, moto, s3transfer
+botocore==1.12.211        # via aws-xray-sdk, boto3, moto, s3transfer
 celery==3.1.26.post2
 certifi==2019.6.16        # via requests
 cffi==1.12.3              # via cryptography
-cfn-lint==0.23.1          # via moto
+cfn-lint==0.23.3          # via moto
 chardet==3.0.4            # via requests
 click-log==0.3.2          # via edx-lint
 click==7.0                # via click-log, code-annotations, edx-lint
@@ -32,7 +32,7 @@ coverage==4.5.4
 cryptography==2.7         # via moto
 ddt==1.2.1
 defusedxml==0.6.0         # via python3-openid, social-auth-core
-django-cors-headers==3.0.2
+django-cors-headers==3.1.0
 django-debug-toolbar==2.0
 django-dynamic-fixture==2.0.0
 django-extensions==2.2.1
@@ -48,19 +48,20 @@ djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.10.2
 docker==4.0.2             # via moto
 docopt==0.6.2             # via pipreqs
-docutils==0.14            # via botocore, sphinx
+docutils==0.15.2          # via botocore, sphinx
 ecdsa==0.13.2             # via python-jose
-edx-auth-backends==2.0.1
+edx-auth-backends==2.0.2
 edx-django-release-util==0.3.1
 edx-django-utils==2.0.0   # via edx-drf-extensions
-edx-drf-extensions==2.3.8
+edx-drf-extensions==2.4.0
 edx-i18n-tools==0.4.8
 edx-lint==1.3.0
 edx-opaque-keys==1.0.1    # via edx-drf-extensions
 edx-rest-api-client==1.9.2
 edx-sphinx-theme==1.5.0
 factory-boy==2.12.0
-faker==2.0.0
+faker==2.0.1
+freezegun==0.3.12
 future==0.17.1            # via aws-xray-sdk, pyjwkest, python-jose
 gevent==1.4.0
 greenlet==0.4.15          # via gevent
@@ -84,13 +85,13 @@ mock==3.0.5
 more-itertools==7.2.0     # via pytest
 moto==1.3.8
 mysqlclient==1.3.14
-newrelic==4.20.1.121
-oauthlib==3.0.2           # via requests-oauthlib, social-auth-core
+newrelic==5.0.2.126
+oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 packaging==19.1           # via pytest
 path.py==12.0.1           # via edx-i18n-tools
 pathlib2==2.3.4           # via pytest
 pathspec==0.5.9           # via yamllint
-pbr==5.4.1                # via stevedore
+pbr==5.4.2                # via stevedore
 pip-api==0.0.12           # via isort
 pipreqs==0.4.9            # via isort
 pluggy==0.12.0            # via pytest
@@ -108,13 +109,13 @@ pylint-celery==0.3        # via edx-lint
 pylint-django==0.7.2      # via edx-lint
 pylint-plugin-utils==0.5  # via pylint-celery, pylint-django
 pylint==1.7.6             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pymongo==3.8.0            # via edx-opaque-keys
+pymongo==3.9.0            # via edx-opaque-keys
 pyparsing==2.4.2          # via packaging
 pyrsistent==0.15.4        # via jsonschema
 pytest-cov==2.7.1
 pytest-django==3.5.1
-pytest==5.0.1             # via pytest-cov, pytest-django
-python-dateutil==2.8.0    # via analytics-python, botocore, edx-drf-extensions, faker, moto, ruamel.yaml.convert
+pytest==5.1.0             # via pytest-cov, pytest-django
+python-dateutil==2.8.0    # via analytics-python, botocore, edx-drf-extensions, faker, freezegun, moto, ruamel.yaml.convert
 python-jose==3.0.1        # via moto
 python-memcached==1.59
 python-slugify==1.2.6     # via code-annotations, transifex-client
@@ -123,18 +124,18 @@ pytz==2019.2
 pyyaml==5.1
 redis==2.8
 requests-oauthlib==1.2.0  # via social-auth-core
-requests==2.22.0          # via analytics-python, cfn-lint, docker, edx-drf-extensions, edx-rest-api-client, moto, pyjwkest, requests-oauthlib, responses, slumber, social-auth-core, sphinx, transifex-client, yarg
+requests==2.22.0          # via analytics-python, docker, edx-drf-extensions, edx-rest-api-client, moto, pyjwkest, requests-oauthlib, responses, slumber, social-auth-core, sphinx, transifex-client, yarg
 responses==0.10.6
 rest-condition==1.0.3     # via edx-drf-extensions
 rsa==4.0                  # via python-jose
 ruamel.std.argparse==0.8.1  # via ruamel.yaml.cmd
-ruamel.yaml.clib==0.1.0   # via ruamel.yaml
-ruamel.yaml.cmd==0.5.4
-ruamel.yaml.convert==0.3.1  # via ruamel.yaml.cmd
-ruamel.yaml==0.16.0       # via ruamel.yaml.cmd, ruamel.yaml.convert
+ruamel.yaml.clib==0.1.2   # via ruamel.yaml
+ruamel.yaml.cmd==0.5.5
+ruamel.yaml.convert==0.3.2  # via ruamel.yaml.cmd
+ruamel.yaml==0.16.5       # via ruamel.yaml.cmd, ruamel.yaml.convert
 s3transfer==0.2.1         # via boto3
 semantic-version==2.6.0   # via edx-drf-extensions
-six==1.11.0               # via analytics-python, astroid, aws-sam-translator, cfn-lint, configobj, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, docker, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, faker, jsonschema, mock, moto, packaging, pathlib2, pyjwkest, pylint, pyrsistent, python-dateutil, python-jose, python-memcached, responses, social-auth-app-django, social-auth-core, sphinx, stevedore, transifex-client, websocket-client
+six==1.11.0               # via analytics-python, astroid, aws-sam-translator, cfn-lint, configobj, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, docker, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, faker, freezegun, jsonschema, mock, moto, packaging, pathlib2, pyjwkest, pylint, pyrsistent, python-dateutil, python-jose, python-memcached, responses, social-auth-app-django, social-auth-core, sphinx, stevedore, transifex-client, websocket-client
 slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==1.9.0    # via sphinx
 social-auth-app-django==1.2.0  # via edx-auth-backends
@@ -152,10 +153,10 @@ websocket-client==0.56.0  # via docker
 werkzeug==0.15.5          # via moto
 wrapt==1.11.2             # via astroid, aws-xray-sdk
 xmltodict==0.12.0         # via moto
-yamllint==1.16.0
+yamllint==1.17.0
 yarg==0.1.9               # via pipreqs
 zipp==0.5.2               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-# pip==19.2.1               # via pip-api
-# setuptools==41.0.1        # via cfn-lint, jsonschema, sphinx
+# pip==19.2.2               # via pip-api
+# setuptools==41.1.0        # via cfn-lint, jsonschema, sphinx

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -8,13 +8,13 @@ amqp==1.4.9               # via kombu
 analytics-python==1.2.9
 anyjson==0.3.3            # via kombu
 billiard==3.3.0.23        # via celery
-boto3==1.9.199
-botocore==1.12.199        # via boto3, s3transfer
+boto3==1.9.211
+botocore==1.12.211        # via boto3, s3transfer
 celery==3.1.26.post2
 certifi==2019.6.16        # via requests
 chardet==3.0.4            # via requests
 defusedxml==0.6.0         # via python3-openid, social-auth-core
-django-cors-headers==3.0.2
+django-cors-headers==3.1.0
 django-extensions==2.2.1
 django-guardian==2.0.0
 django-model-utils==3.2.0
@@ -26,11 +26,11 @@ django-waffle==0.17.0
 django==1.11.23
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.10.2
-docutils==0.14            # via botocore
-edx-auth-backends==2.0.1
+docutils==0.15.2          # via botocore
+edx-auth-backends==2.0.2
 edx-django-release-util==0.3.1
 edx-django-utils==2.0.0   # via edx-drf-extensions
-edx-drf-extensions==2.3.8
+edx-drf-extensions==2.4.0
 edx-opaque-keys==1.0.1    # via edx-drf-extensions
 edx-rest-api-client==1.9.2
 future==0.17.1            # via pyjwkest
@@ -41,14 +41,14 @@ idna==2.8                 # via requests
 jmespath==0.9.4           # via boto3, botocore
 kombu==3.0.37             # via celery
 mysqlclient==1.3.14
-newrelic==4.20.1.121      # via edx-django-utils
-oauthlib==3.0.2           # via requests-oauthlib, social-auth-core
-pbr==5.4.1                # via stevedore
+newrelic==5.0.2.126       # via edx-django-utils
+oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
+pbr==5.4.2                # via stevedore
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
 pycryptodomex==3.8.2      # via pyjwkest
 pyjwkest==1.3.2           # via edx-drf-extensions, social-auth-core
 pyjwt==1.7.1              # via djangorestframework-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
-pymongo==3.8.0            # via edx-opaque-keys
+pymongo==3.9.0            # via edx-opaque-keys
 python-dateutil==2.8.0    # via analytics-python, botocore, edx-drf-extensions
 python-memcached==1.59
 python3-openid==3.1.0     # via social-auth-core

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -16,3 +16,4 @@ pytest-django
 responses
 yamllint
 isort[requirements]
+freezegun

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -11,16 +11,16 @@ asn1crypto==0.24.0        # via cryptography
 astroid==1.5.3            # via pylint, pylint-celery
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via jsonschema, packaging, pytest
-aws-sam-translator==1.13.0  # via cfn-lint
+aws-sam-translator==1.13.2  # via cfn-lint
 aws-xray-sdk==2.4.2       # via moto
 billiard==3.3.0.23        # via celery
-boto3==1.9.199            # via aws-sam-translator, moto
+boto3==1.9.211            # via aws-sam-translator, moto
 boto==2.49.0              # via moto
-botocore==1.12.199        # via aws-xray-sdk, boto3, moto, s3transfer
+botocore==1.12.211        # via aws-xray-sdk, boto3, moto, s3transfer
 celery==3.1.26.post2
 certifi==2019.6.16        # via requests
 cffi==1.12.3              # via cryptography
-cfn-lint==0.23.1          # via moto
+cfn-lint==0.23.3          # via moto
 chardet==3.0.4            # via requests
 click-log==0.3.2          # via edx-lint
 click==7.0                # via click-log, code-annotations, edx-lint
@@ -29,7 +29,7 @@ coverage==4.5.4
 cryptography==2.7         # via moto
 ddt==1.2.1
 defusedxml==0.6.0         # via python3-openid, social-auth-core
-django-cors-headers==3.0.2
+django-cors-headers==3.1.0
 django-dynamic-fixture==2.0.0
 django-extensions==2.2.1
 django-guardian==2.0.0
@@ -44,17 +44,18 @@ djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.10.2
 docker==4.0.2             # via moto
 docopt==0.6.2             # via pipreqs
-docutils==0.14            # via botocore
+docutils==0.15.2          # via botocore
 ecdsa==0.13.2             # via python-jose
-edx-auth-backends==2.0.1
+edx-auth-backends==2.0.2
 edx-django-release-util==0.3.1
 edx-django-utils==2.0.0   # via edx-drf-extensions
-edx-drf-extensions==2.3.8
+edx-drf-extensions==2.4.0
 edx-lint==1.3.0
 edx-opaque-keys==1.0.1    # via edx-drf-extensions
 edx-rest-api-client==1.9.2
 factory-boy==2.12.0
-faker==2.0.0
+faker==2.0.1
+freezegun==0.3.12
 future==0.17.1            # via aws-xray-sdk, pyjwkest, python-jose
 idna==2.8                 # via moto, requests
 importlib-metadata==0.19  # via pluggy, pytest
@@ -73,12 +74,12 @@ mccabe==0.6.1             # via pylint
 mock==3.0.5
 more-itertools==7.2.0     # via pytest
 moto==1.3.8
-newrelic==4.20.1.121      # via edx-django-utils
-oauthlib==3.0.2           # via requests-oauthlib, social-auth-core
+newrelic==5.0.2.126       # via edx-django-utils
+oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 packaging==19.1           # via pytest
 pathlib2==2.3.4           # via pytest
 pathspec==0.5.9           # via yamllint
-pbr==5.4.1                # via stevedore
+pbr==5.4.2                # via stevedore
 pip-api==0.0.12           # via isort
 pipreqs==0.4.9            # via isort
 pluggy==0.12.0            # via pytest
@@ -94,13 +95,13 @@ pylint-celery==0.3        # via edx-lint
 pylint-django==0.7.2      # via edx-lint
 pylint-plugin-utils==0.5  # via pylint-celery, pylint-django
 pylint==1.7.6             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pymongo==3.8.0            # via edx-opaque-keys
+pymongo==3.9.0            # via edx-opaque-keys
 pyparsing==2.4.2          # via packaging
 pyrsistent==0.15.4        # via jsonschema
 pytest-cov==2.7.1
 pytest-django==3.5.1
-pytest==5.0.1             # via pytest-cov, pytest-django
-python-dateutil==2.8.0    # via analytics-python, botocore, edx-drf-extensions, faker, moto
+pytest==5.1.0             # via pytest-cov, pytest-django
+python-dateutil==2.8.0    # via analytics-python, botocore, edx-drf-extensions, faker, freezegun, moto
 python-jose==3.0.1        # via moto
 python-slugify==3.0.3     # via code-annotations
 python3-openid==3.1.0     # via social-auth-core
@@ -108,13 +109,13 @@ pytz==2019.2
 pyyaml==5.1.2             # via cfn-lint, code-annotations, edx-django-release-util, moto, yamllint
 redis==2.8
 requests-oauthlib==1.2.0  # via social-auth-core
-requests==2.22.0          # via analytics-python, cfn-lint, docker, edx-drf-extensions, edx-rest-api-client, moto, pyjwkest, requests-oauthlib, responses, slumber, social-auth-core, yarg
+requests==2.22.0          # via analytics-python, docker, edx-drf-extensions, edx-rest-api-client, moto, pyjwkest, requests-oauthlib, responses, slumber, social-auth-core, yarg
 responses==0.10.6
 rest-condition==1.0.3     # via edx-drf-extensions
 rsa==4.0                  # via python-jose
 s3transfer==0.2.1         # via boto3
 semantic-version==2.6.0   # via edx-drf-extensions
-six==1.12.0               # via analytics-python, astroid, aws-sam-translator, cfn-lint, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, docker, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-lint, edx-opaque-keys, faker, jsonschema, mock, moto, packaging, pathlib2, pyjwkest, pylint, pyrsistent, python-dateutil, python-jose, responses, social-auth-app-django, social-auth-core, stevedore, websocket-client
+six==1.12.0               # via analytics-python, astroid, aws-sam-translator, cfn-lint, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, docker, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-lint, edx-opaque-keys, faker, freezegun, jsonschema, mock, moto, packaging, pathlib2, pyjwkest, pylint, pyrsistent, python-dateutil, python-jose, responses, social-auth-app-django, social-auth-core, stevedore, websocket-client
 slumber==0.7.1            # via edx-rest-api-client
 social-auth-app-django==1.2.0  # via edx-auth-backends
 social-auth-core[openidconnect]==1.7.0  # via edx-auth-backends, social-auth-app-django
@@ -126,10 +127,10 @@ websocket-client==0.56.0  # via docker
 werkzeug==0.15.5          # via moto
 wrapt==1.11.2             # via astroid, aws-xray-sdk
 xmltodict==0.12.0         # via moto
-yamllint==1.16.0
+yamllint==1.17.0
 yarg==0.1.9               # via pipreqs
 zipp==0.5.2               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-# pip==19.2.1               # via pip-api
-# setuptools==41.0.1        # via cfn-lint, jsonschema
+# pip==19.2.2               # via pip-api
+# setuptools==41.1.0        # via cfn-lint, jsonschema


### PR DESCRIPTION
@edx/masters-neem 

**Motivation**
Curtin will be not be able to run new enrollment-writing jobs due to two enrollment-reading jobs that are currently stuck in the Pending state.

**Description**
Currently, we disallow any enrollment-writing job from starting if the associated program has any
jobs in the one of processing states (IN PROGRESS, RETRYING, and PENDING). This commit relaxes that constraint in two ways:
* Only block if a 'write' job is processing
* Ignore jobs of a certain age (currently 30 minutes)

The reason for the second relaxation is that jobs ocassionally becomes 'stuck' in the PENDING state, so
we have to modify the database to unblock future jobs for that program. This is not desirable, so we can assume that any job older than 30 minutes will never complete.

If Registrar begins to have longer-running jobs, then the maximum age may need to be reconsidered.