### PR TITLE
Ignore read-only jobs when checking conflicts

### DIFF
--- a/registrar/apps/api/v1/tests/test_views.py
+++ b/registrar/apps/api/v1/tests/test_views.py
@@ -1786,7 +1786,10 @@ class EnrollmentUploadMixin(object):
     def test_enrollment_upload_conflict(self):
         enrollments = [self.build_enrollment('enrolled', '001')]
 
-        with mock.patch('registrar.apps.api.v1.views.is_enrollment_job_processing', return_value=True):
+        with mock.patch(
+                'registrar.apps.api.v1.views.is_enrollment_write_blocked',
+                return_value=True
+        ):
             upload_response = self._upload_enrollments(enrollments)
 
         self.assertEqual(upload_response.status_code, 409)

--- a/registrar/apps/api/v1/views.py
+++ b/registrar/apps/api/v1/views.py
@@ -54,7 +54,7 @@ from registrar.apps.enrollments.tasks import (
     write_course_run_enrollments,
     write_program_enrollments,
 )
-from registrar.apps.enrollments.utils import is_enrollment_job_processing
+from registrar.apps.enrollments.utils import is_enrollment_write_blocked
 from registrar.apps.grades.tasks import get_course_run_grades
 
 
@@ -435,7 +435,7 @@ class EnrollmentUploadView(JobInvokerMixin, APIView):
         if csv_file.size > UPLOAD_FILE_MAX_SIZE:
             raise FileTooLarge()
 
-        if is_enrollment_job_processing(self.program.key):
+        if is_enrollment_write_blocked(self.program.key):
             return Response('Job already in progress for program', HTTP_409_CONFLICT)
 
         file_itr = io.StringIO(csv_file.read().decode('utf-8'))

--- a/registrar/apps/core/jobs.py
+++ b/registrar/apps/core/jobs.py
@@ -12,7 +12,6 @@ in the future to include retrying tasks, the job_id could be decoupled
 from the UserTask ID. For this reason, we attempt not to expose the relationship
 between job_ids and UserTask IDs outside of this module.
 """
-
 import logging
 import uuid
 from collections import namedtuple

--- a/registrar/apps/enrollments/utils.py
+++ b/registrar/apps/enrollments/utils.py
@@ -4,6 +4,7 @@ from registrar.apps.core.jobs import processing_job_with_prefix_exists
 
 
 SEPARATOR = ':'
+WRITE_PREFIX = 'write'
 
 
 def build_enrollment_job_status_name(program_key, action, task_name):
@@ -18,14 +19,19 @@ def build_enrollment_job_status_name(program_key, action, task_name):
     return SEPARATOR.join((program_key, action, task_name))
 
 
-def is_enrollment_job_processing(program_key):
+def is_enrollment_write_blocked(program_key):
     """
     Returns whether or not a bulk enrollment job for a particular program
-    is currently processing (in progress, pending, or retrying)
+    is currently processing (in progress, pending, or retrying).
 
-    Used to ensure only one bulk task can be run at a time for a program.
+    Used to ensure only one bulk write task can be run at a time for a program.
 
     Arguments:
         program_key (str): program key for the program we're checking
     """
-    return processing_job_with_prefix_exists(program_key + SEPARATOR)
+    prefix = "{key}{sep}{write}{sep}".format(
+        key=program_key,
+        sep=SEPARATOR,
+        write=WRITE_PREFIX,
+    )
+    return processing_job_with_prefix_exists(prefix)


### PR DESCRIPTION
Currently, we disallow any enrollment-writing job from starting if the associated program has any jobs in the one of processing states (IN PROGRESS, RETRYING, and PENDING). This commit relaxes that
restriction by only blocking if a 'write' job is processing.

@edx/masters-neem 
Should (temporarily) unblock Curtin from running enrollment-write jobs.
