### PR TITLE
Kill Celery tasks after five minutes

### DIFF
--- a/registrar/settings/base.py
+++ b/registrar/settings/base.py
@@ -144,6 +144,16 @@ BROKER_URL = "{0}://{1}:{2}@{3}/{4}".format(
     CELERY_BROKER_VHOST
 )
 
+# Celery task time limits.
+# Tasks will be asked to quit after four minutes, and un-gracefully killed
+# after five.
+# This should prevent UserTasks from getting stuck indefinitely in an
+# In-Progress/Pending state, which in the case of enrollment-writing tasks,
+# would block any other enrollment-writing tasks for the associated program
+# from ever starting.
+CELERY_TASK_SOFT_TIME_LIMIT = 240
+CELERY_TASK_TIME_LIMIT = 300
+
 ############################# END CELERY #################################3
 
 # Internationalization


### PR DESCRIPTION
@edx/masters-neem 

Set `CELERY_TASK_SOFT_TIME_LIMIT` to four minutes and `CELERY_TASK_TIME_LIMIT` to five minutes. This should prevent enrollment-writing UserTasks from getting stuck indefinitely in
a processing state and blocking future tasks.

I know no way of testing this, automated or manually. Unless there are any suggestions, we'll just have to keep an eye on "Job already in progress for program" errors.