### PR TITLE
Update BROKER_URL setting from config in production.py (OPS-4272)

### DIFF
--- a/registrar/settings/production.py
+++ b/registrar/settings/production.py
@@ -46,6 +46,10 @@ DB_OVERRIDES = dict(
 for override, value in DB_OVERRIDES.items():
     DATABASES['default'][override] = value
 
-CELERY_ALWAYS_EAGER = (
-    os.environ.get("CELERY_ALWAYS_EAGER", "false").lower() == "true"
+BROKER_URL = "{0}://{1}:{2}@{3}/{4}".format(
+    CELERY_BROKER_TRANSPORT,
+    CELERY_BROKER_USER,
+    CELERY_BROKER_PASSWORD,
+    CELERY_BROKER_HOSTNAME,
+    CELERY_BROKER_VHOST
 )


### PR DESCRIPTION
## Description

We are removing extra variables from environment of services and adding to config file (https://github.com/edx/configuration/pull/5381). In registrar celery settings are going to config and  ```BROKER_URL``` need to be build from variables injected from config in production.py rather than importing this setting from base.py.
