### PR TITLE
Make root URL redirects more user-friendly

### DIFF
--- a/registrar/settings/base.py
+++ b/registrar/settings/base.py
@@ -274,7 +274,6 @@ SOCIAL_AUTH_REDIRECT_IS_HTTPS = False
 # Request the user's permissions in the ID token
 EXTRA_SCOPE = ['permissions']
 
-# TODO Set this to another (non-staff, ideally) path.
 LOGIN_REDIRECT_URL = '/api-docs/'
 # END AUTHENTICATION CONFIGURATION
 

--- a/registrar/urls.py
+++ b/registrar/urls.py
@@ -34,15 +34,31 @@ admin.autodiscover()
 app_name = 'registrar'
 
 urlpatterns = oauth2_urlpatterns + [
-    url(r'^admin/', admin.site.urls),
-    url(r'^admin$', RedirectView.as_view(pattern_name='admin:index')),
-    url(r'^api/', include(api_urls)),
-    url(r'^api-docs/', api_renderer.render_yaml_spec, name='api-docs'),
-    url(r'^api-docs$', RedirectView.as_view(pattern_name='api-docs')),
-    # Use the same auth views for all logins, including those originating from the browseable API.
+    # '/' and '/login' redirect to '/login/',
+    # which attempts LMS OAuth and then redirects to api-docs.
+    url(r'^/?$', RedirectView.as_view(url=settings.LOGIN_URL)),
+    url(r'^login$', RedirectView.as_view(url=settings.LOGIN_URL)),
+
+    # Use the same auth views for all logins,
+    # including those originating from the browseable API.
     url(r'^api-auth/', include(oauth2_urlpatterns)),
-    url(r'^auto_auth/?$', core_views.AutoAuth.as_view(), name='auto_auth'),
+
+    # Swagger documentation UI.
+    url(r'^api-docs$', RedirectView.as_view(pattern_name='api-docs')),
+    url(r'^api-docs/$', api_renderer.render_yaml_spec, name='api-docs'),
+
+    # Django admin panel.
+    url(r'^admin$', RedirectView.as_view(pattern_name='admin:index')),
+    url(r'^admin/', admin.site.urls),
+
+    # Health view.
     url(r'^health/?$', core_views.health, name='health'),
+
+    # Auto-auth for testing. View raises 404 if not `settings.ENABLE_AUTO_AUTH`
+    url(r'^auto_auth/?$', core_views.AutoAuth.as_view(), name='auto_auth'),
+
+    # The API itself!
+    url(r'^api/', include(api_urls)),
 ]
 
 # edx-drf-extensions csrf app


### PR DESCRIPTION
@edx/masters-devs 

Currently, the root of Registrar gives a 404. That's not a good look.

This PR makes it redirect to /login/, which redirects to /api-docs/.

Additionally /login now redirects to /login/.

Finally, I added some comments to the root urls.py.