### PR TITLE
[Fix upgrades attempt 3] Pin edx-lint to 1.3.0 in constraints.txt

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -8,5 +8,10 @@
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
 
+# Pinned because upgrading to current version would introduce a bunch of
+# new Pylint warnings.
+# TODO EDUCATOR-4760
+edx-lint==1.3.0
+
 # These packages are pinned because their next version would require django 2.0.0
 django-guardian==2.0.0

--- a/requirements/devstack.txt
+++ b/requirements/devstack.txt
@@ -4,38 +4,24 @@
 #
 #    pip-compile --output-file=requirements/devstack.txt requirements/devstack.in
 #
-alabaster==0.7.12         # via sphinx
 amqp==1.4.9               # via kombu
 analytics-python==1.2.9
 anyjson==0.3.3            # via kombu
-asn1crypto==0.24.0        # via cryptography
-astroid==1.5.3            # via pylint, pylint-celery
 atomicwrites==1.3.0       # via pytest
-attrs==19.1.0             # via jsonschema, pytest
-aws-sam-translator==1.14.0  # via cfn-lint
-aws-xray-sdk==2.4.2       # via moto
-babel==2.7.0              # via sphinx
+attrs==19.3.0             # via pytest
 billiard==3.3.0.23        # via celery
-boto3==1.9.237            # via aws-sam-translator, moto
-boto==2.49.0              # via moto
-botocore==1.12.237        # via aws-xray-sdk, boto3, moto, s3transfer
 celery==3.1.26.post2
 certifi==2019.9.11        # via requests
-cffi==1.12.3              # via cryptography
-cfn-lint==0.24.2          # via moto
 chardet==3.0.4            # via requests
-click-log==0.3.2          # via edx-lint
-click==7.0                # via click-log, code-annotations, edx-lint
 code-annotations==0.3.2
 configobj==5.0.6          # via ruamel.yaml.cmd
 coverage==4.5.4
-cryptography==2.7         # via moto
 ddt==1.2.1
 defusedxml==0.6.0         # via python3-openid, social-auth-core
-django-cors-headers==3.1.0
+django-cors-headers==3.1.1
 django-debug-toolbar==2.0
 django-dynamic-fixture==2.0.0
-django-extensions==2.2.1
+django-extensions==2.2.5
 django-guardian==2.0.0
 django-model-utils==3.2.0
 django-mysql==3.2.0
@@ -43,116 +29,83 @@ django-simple-history==2.7.3
 django-storages==1.7.2
 django-user-tasks==0.2.1
 django-waffle==0.17.0
-django==1.11.24
+django==1.11.25
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.10.3
-docker==4.0.2             # via moto
 docopt==0.6.2             # via pipreqs
-docutils==0.15.2          # via botocore, sphinx
-ecdsa==0.13.3             # via python-jose
 edx-auth-backends==2.0.2
 edx-django-release-util==0.3.1
-edx-django-utils==2.0.0   # via edx-drf-extensions
-edx-drf-extensions==2.4.0
+edx-django-utils==2.0.1   # via edx-drf-extensions
+edx-drf-extensions==2.4.2
 edx-i18n-tools==0.4.8
 edx-lint==1.3.0
 edx-opaque-keys==2.0.0    # via edx-drf-extensions
 edx-rest-api-client==1.9.2
 edx-sphinx-theme==1.5.0
 factory-boy==2.12.0
-faker==2.0.2
-future==0.17.1            # via aws-xray-sdk, pyjwkest, python-jose
-idna==2.8                 # via moto, requests
-imagesize==1.1.0          # via sphinx
+faker==2.0.3
+future==0.18.1            # via pyjwkest
+idna==2.8                 # via requests
 importlib-metadata==0.23  # via path.py, pluggy, pytest
 isort[requirements]==4.3.21
-jinja2==2.10.1            # via code-annotations, moto, sphinx
-jmespath==0.9.4           # via boto3, botocore
-jsondiff==1.1.2           # via moto
-jsonpatch==1.24           # via cfn-lint
-jsonpickle==1.2           # via aws-xray-sdk
-jsonpointer==2.0          # via jsonpatch
-jsonschema==3.0.2         # via aws-sam-translator, cfn-lint
 kombu==3.0.37             # via celery
-lazy-object-proxy==1.4.2  # via astroid
-markupsafe==1.1.1         # via jinja2
-mccabe==0.6.1             # via pylint
 mock==3.0.5
 more-itertools==7.2.0     # via pytest, zipp
 moto==1.3.8
 mysqlclient==1.3.14
-newrelic==5.0.2.126       # via edx-django-utils
+newrelic==5.2.1.129       # via edx-django-utils
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 packaging==19.2           # via pytest
 path.py==12.0.1           # via edx-i18n-tools
-pathspec==0.5.9           # via yamllint
+pathlib2==2.3.5           # via pytest
+pathspec==0.6.0           # via yamllint
 pbr==5.4.3                # via stevedore
-pip-api==0.0.12           # via isort
+pip-api==0.0.13           # via isort
 pipreqs==0.4.9            # via isort
 pluggy==0.13.0            # via pytest
 polib==1.1.0              # via edx-i18n-tools
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
 py==1.8.0                 # via pytest
-pyasn1==0.4.7             # via rsa
 pycodestyle==2.5.0
-pycparser==2.19           # via cffi
 pycryptodomex==3.9.0      # via pyjwkest
-pygments==2.4.2           # via sphinx
 pyinotify==0.9.6
 pyjwkest==1.3.2           # via edx-drf-extensions, social-auth-core
 pyjwt==1.7.1              # via djangorestframework-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
-pylint-celery==0.3        # via edx-lint
-pylint-django==0.7.2      # via edx-lint
-pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
-pylint==1.7.6             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.9.0            # via edx-opaque-keys
 pyparsing==2.4.2          # via packaging
-pyrsistent==0.15.4        # via jsonschema
-pytest-cov==2.7.1
-pytest-django==3.5.1
-pytest==5.1.3
-python-dateutil==2.8.0    # via analytics-python, botocore, edx-drf-extensions, faker, moto, ruamel.yaml.convert
-python-jose==3.0.1        # via moto
+pytest-cov==2.8.1
+pytest-django==3.6.0
+pytest==5.2.1
+python-dateutil==2.8.0    # via analytics-python, edx-drf-extensions, faker, ruamel.yaml.convert
 python-memcached==1.59
-python-slugify==1.2.6     # via code-annotations, transifex-client
 python3-openid==3.1.0     # via social-auth-core
-pytz==2019.2
-pyyaml==5.1.2             # via cfn-lint, code-annotations, edx-django-release-util, edx-i18n-tools, moto, yamllint
+pytz==2019.3
+pyyaml==5.1.2             # via edx-django-release-util, edx-i18n-tools, yamllint
 redis==2.8
 requests-oauthlib==1.2.0  # via social-auth-core
-requests==2.22.0          # via analytics-python, docker, edx-drf-extensions, edx-rest-api-client, moto, pyjwkest, requests-oauthlib, responses, slumber, social-auth-core, sphinx, transifex-client, yarg
+requests==2.22.0          # via analytics-python, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, responses, slumber, social-auth-core, yarg
 responses==0.10.6
 rest-condition==1.0.3     # via edx-drf-extensions
-rsa==4.0                  # via python-jose
 ruamel.std.argparse==0.8.1  # via ruamel.yaml.cmd
 ruamel.yaml.clib==0.2.0   # via ruamel.yaml
 ruamel.yaml.cmd==0.5.5
 ruamel.yaml.convert==0.3.2  # via ruamel.yaml.cmd
 ruamel.yaml==0.16.5       # via ruamel.yaml.cmd, ruamel.yaml.convert
-s3transfer==0.2.1         # via boto3
 semantic-version==2.8.2   # via edx-drf-extensions
-six==1.11.0               # via analytics-python, astroid, aws-sam-translator, cfn-lint, configobj, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, docker, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, faker, jsonschema, mock, moto, packaging, pyjwkest, pylint, pyrsistent, python-dateutil, python-jose, python-memcached, responses, social-auth-app-django, social-auth-core, sphinx, stevedore, transifex-client, websocket-client
+six==1.12.0               # via analytics-python, configobj, django-dynamic-fixture, django-extensions, django-simple-history, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-opaque-keys, edx-sphinx-theme, faker, mock, packaging, pathlib2, pyjwkest, python-dateutil, python-memcached, responses, social-auth-app-django, social-auth-core, stevedore
 slumber==0.7.1            # via edx-rest-api-client
-snowballstemmer==1.9.1    # via sphinx
 social-auth-app-django==1.2.0  # via edx-auth-backends
 social-auth-core[openidconnect]==1.7.0  # via edx-auth-backends, social-auth-app-django
 sphinx==1.6.7
-sphinxcontrib-websupport==1.1.2  # via sphinx
 sqlparse==0.3.0           # via django-debug-toolbar
-stevedore==1.31.0         # via code-annotations, edx-opaque-keys
+stevedore==1.31.0         # via edx-opaque-keys
 text-unidecode==1.3       # via faker
 transifex-client==0.13.6
-unidecode==1.1.1          # via python-slugify
-urllib3==1.23             # via botocore, requests, transifex-client
+urllib3==1.25.6           # via requests
 wcwidth==0.1.7            # via pytest
-websocket-client==0.56.0  # via docker
-werkzeug==0.16.0          # via moto
-wrapt==1.11.2             # via astroid, aws-xray-sdk
-xmltodict==0.12.0         # via moto
-yamllint==1.17.0
+yamllint==1.18.0
 yarg==0.1.9               # via pipreqs
 zipp==0.6.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip==19.3.1               # via pip-api
-# setuptools==41.4.0        # via cfn-lint, jsonschema, sphinx

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -4,38 +4,24 @@
 #
 #    pip-compile --output-file=requirements/local.txt requirements/local.in
 #
-alabaster==0.7.12         # via sphinx
 amqp==1.4.9               # via kombu
 analytics-python==1.2.9
 anyjson==0.3.3            # via kombu
-asn1crypto==0.24.0        # via cryptography
-astroid==1.5.3            # via pylint, pylint-celery
 atomicwrites==1.3.0       # via pytest
-attrs==19.1.0             # via jsonschema, pytest
-aws-sam-translator==1.14.0  # via cfn-lint
-aws-xray-sdk==2.4.2       # via moto
-babel==2.7.0              # via sphinx
+attrs==19.3.0             # via pytest
 billiard==3.3.0.23        # via celery
-boto3==1.9.237            # via aws-sam-translator, moto
-boto==2.49.0              # via moto
-botocore==1.12.237        # via aws-xray-sdk, boto3, moto, s3transfer
 celery==3.1.26.post2
 certifi==2019.9.11        # via requests
-cffi==1.12.3              # via cryptography
-cfn-lint==0.24.2          # via moto
 chardet==3.0.4            # via requests
-click-log==0.3.2          # via edx-lint
-click==7.0                # via click-log, code-annotations, edx-lint
 code-annotations==0.3.2
 configobj==5.0.6          # via ruamel.yaml.cmd
 coverage==4.5.4
-cryptography==2.7         # via moto
 ddt==1.2.1
 defusedxml==0.6.0         # via python3-openid, social-auth-core
-django-cors-headers==3.1.0
+django-cors-headers==3.1.1
 django-debug-toolbar==2.0
 django-dynamic-fixture==2.0.0
-django-extensions==2.2.1
+django-extensions==2.2.5
 django-guardian==2.0.0
 django-model-utils==3.2.0
 django-mysql==3.2.0
@@ -43,114 +29,81 @@ django-simple-history==2.7.3
 django-storages==1.7.2
 django-user-tasks==0.2.1
 django-waffle==0.17.0
-django==1.11.24
+django==1.11.25
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.10.3
-docker==4.0.2             # via moto
 docopt==0.6.2             # via pipreqs
-docutils==0.15.2          # via botocore, sphinx
-ecdsa==0.13.3             # via python-jose
 edx-auth-backends==2.0.2
 edx-django-release-util==0.3.1
-edx-django-utils==2.0.0   # via edx-drf-extensions
-edx-drf-extensions==2.4.0
+edx-django-utils==2.0.1   # via edx-drf-extensions
+edx-drf-extensions==2.4.2
 edx-i18n-tools==0.4.8
 edx-lint==1.3.0
 edx-opaque-keys==2.0.0    # via edx-drf-extensions
 edx-rest-api-client==1.9.2
 edx-sphinx-theme==1.5.0
 factory-boy==2.12.0
-faker==2.0.2
-future==0.17.1            # via aws-xray-sdk, pyjwkest, python-jose
-idna==2.8                 # via moto, requests
-imagesize==1.1.0          # via sphinx
+faker==2.0.3
+future==0.18.1            # via pyjwkest
+idna==2.8                 # via requests
 importlib-metadata==0.23  # via path.py, pluggy, pytest
 isort[requirements]==4.3.21
-jinja2==2.10.1            # via code-annotations, moto, sphinx
-jmespath==0.9.4           # via boto3, botocore
-jsondiff==1.1.2           # via moto
-jsonpatch==1.24           # via cfn-lint
-jsonpickle==1.2           # via aws-xray-sdk
-jsonpointer==2.0          # via jsonpatch
-jsonschema==3.0.2         # via aws-sam-translator, cfn-lint
 kombu==3.0.37             # via celery
-lazy-object-proxy==1.4.2  # via astroid
-markupsafe==1.1.1         # via jinja2
-mccabe==0.6.1             # via pylint
 mock==3.0.5
 more-itertools==7.2.0     # via pytest, zipp
 moto==1.3.8
-newrelic==5.0.2.126       # via edx-django-utils
+newrelic==5.2.1.129       # via edx-django-utils
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 packaging==19.2           # via pytest
 path.py==12.0.1           # via edx-i18n-tools
-pathspec==0.5.9           # via yamllint
+pathlib2==2.3.5           # via pytest
+pathspec==0.6.0           # via yamllint
 pbr==5.4.3                # via stevedore
-pip-api==0.0.12           # via isort
+pip-api==0.0.13           # via isort
 pipreqs==0.4.9            # via isort
 pluggy==0.13.0            # via pytest
 polib==1.1.0              # via edx-i18n-tools
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
 py==1.8.0                 # via pytest
-pyasn1==0.4.7             # via rsa
 pycodestyle==2.5.0
-pycparser==2.19           # via cffi
 pycryptodomex==3.9.0      # via pyjwkest
-pygments==2.4.2           # via sphinx
 pyinotify==0.9.6
 pyjwkest==1.3.2           # via edx-drf-extensions, social-auth-core
 pyjwt==1.7.1              # via djangorestframework-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
-pylint-celery==0.3        # via edx-lint
-pylint-django==0.7.2      # via edx-lint
-pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
-pylint==1.7.6             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.9.0            # via edx-opaque-keys
 pyparsing==2.4.2          # via packaging
-pyrsistent==0.15.4        # via jsonschema
-pytest-cov==2.7.1
-pytest-django==3.5.1
-pytest==5.1.3
-python-dateutil==2.8.0    # via analytics-python, botocore, edx-drf-extensions, faker, moto, ruamel.yaml.convert
-python-jose==3.0.1        # via moto
-python-slugify==1.2.6     # via code-annotations, transifex-client
+pytest-cov==2.8.1
+pytest-django==3.6.0
+pytest==5.2.1
+python-dateutil==2.8.0    # via analytics-python, edx-drf-extensions, faker, ruamel.yaml.convert
 python3-openid==3.1.0     # via social-auth-core
-pytz==2019.2
-pyyaml==5.1.2             # via cfn-lint, code-annotations, edx-django-release-util, edx-i18n-tools, moto, yamllint
+pytz==2019.3
+pyyaml==5.1.2             # via edx-django-release-util, edx-i18n-tools, yamllint
 redis==2.8
 requests-oauthlib==1.2.0  # via social-auth-core
-requests==2.22.0          # via analytics-python, docker, edx-drf-extensions, edx-rest-api-client, moto, pyjwkest, requests-oauthlib, responses, slumber, social-auth-core, sphinx, transifex-client, yarg
+requests==2.22.0          # via analytics-python, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, responses, slumber, social-auth-core, yarg
 responses==0.10.6
 rest-condition==1.0.3     # via edx-drf-extensions
-rsa==4.0                  # via python-jose
 ruamel.std.argparse==0.8.1  # via ruamel.yaml.cmd
 ruamel.yaml.clib==0.2.0   # via ruamel.yaml
 ruamel.yaml.cmd==0.5.5
 ruamel.yaml.convert==0.3.2  # via ruamel.yaml.cmd
 ruamel.yaml==0.16.5       # via ruamel.yaml.cmd, ruamel.yaml.convert
-s3transfer==0.2.1         # via boto3
 semantic-version==2.8.2   # via edx-drf-extensions
-six==1.11.0               # via analytics-python, astroid, aws-sam-translator, cfn-lint, configobj, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, docker, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, faker, jsonschema, mock, moto, packaging, pyjwkest, pylint, pyrsistent, python-dateutil, python-jose, responses, social-auth-app-django, social-auth-core, sphinx, stevedore, transifex-client, websocket-client
+six==1.12.0               # via analytics-python, configobj, django-dynamic-fixture, django-extensions, django-simple-history, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-opaque-keys, edx-sphinx-theme, faker, mock, packaging, pathlib2, pyjwkest, python-dateutil, responses, social-auth-app-django, social-auth-core, stevedore
 slumber==0.7.1            # via edx-rest-api-client
-snowballstemmer==1.9.1    # via sphinx
 social-auth-app-django==1.2.0  # via edx-auth-backends
 social-auth-core[openidconnect]==1.7.0  # via edx-auth-backends, social-auth-app-django
 sphinx==1.6.7
-sphinxcontrib-websupport==1.1.2  # via sphinx
 sqlparse==0.3.0           # via django-debug-toolbar
-stevedore==1.31.0         # via code-annotations, edx-opaque-keys
+stevedore==1.31.0         # via edx-opaque-keys
 text-unidecode==1.3       # via faker
 transifex-client==0.13.6
-unidecode==1.1.1          # via python-slugify
-urllib3==1.23             # via botocore, requests, transifex-client
+urllib3==1.25.6           # via requests
 wcwidth==0.1.7            # via pytest
-websocket-client==0.56.0  # via docker
-werkzeug==0.16.0          # via moto
-wrapt==1.11.2             # via astroid, aws-xray-sdk
-xmltodict==0.12.0         # via moto
-yamllint==1.17.0
+yamllint==1.18.0
 yarg==0.1.9               # via pipreqs
 zipp==0.6.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip==19.3.1               # via pip-api
-# setuptools==41.4.0        # via cfn-lint, jsonschema, sphinx

--- a/requirements/monitoring/requirements.txt
+++ b/requirements/monitoring/requirements.txt
@@ -4,38 +4,26 @@
 #
 #    pip-compile --output-file=requirements/monitoring/requirements.txt requirements/monitoring/requirements.in
 #
-alabaster==0.7.12         # via sphinx
 amqp==1.4.9               # via kombu
 analytics-python==1.2.9
 anyjson==0.3.3            # via kombu
-asn1crypto==0.24.0        # via cryptography
-astroid==1.5.3            # via pylint, pylint-celery
 atomicwrites==1.3.0       # via pytest
-attrs==19.1.0             # via jsonschema, pytest
-aws-sam-translator==1.14.0  # via cfn-lint
-aws-xray-sdk==2.4.2       # via moto
-babel==2.7.0              # via sphinx
+attrs==19.3.0             # via pytest
 billiard==3.3.0.23        # via celery
-boto3==1.9.237
-boto==2.49.0              # via moto
-botocore==1.12.237        # via aws-xray-sdk, boto3, moto, s3transfer
+boto3==1.10.2
+botocore==1.13.2          # via boto3, s3transfer
 celery==3.1.26.post2
 certifi==2019.9.11        # via requests
-cffi==1.12.3              # via cryptography
-cfn-lint==0.24.2          # via moto
 chardet==3.0.4            # via requests
-click-log==0.3.2          # via edx-lint
-click==7.0                # via click-log, code-annotations, edx-lint
 code-annotations==0.3.2
 configobj==5.0.6          # via ruamel.yaml.cmd
 coverage==4.5.4
-cryptography==2.7         # via moto
 ddt==1.2.1
 defusedxml==0.6.0         # via python3-openid, social-auth-core
-django-cors-headers==3.1.0
+django-cors-headers==3.1.1
 django-debug-toolbar==2.0
 django-dynamic-fixture==2.0.0
-django-extensions==2.2.1
+django-extensions==2.2.5
 django-guardian==2.0.0
 django-model-utils==3.2.0
 django-mysql==3.2.0
@@ -43,90 +31,68 @@ django-simple-history==2.7.3
 django-storages==1.7.2
 django-user-tasks==0.2.1
 django-waffle==0.17.0
-django==1.11.24
+django==1.11.25
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.10.3
-docker==4.0.2             # via moto
 docopt==0.6.2             # via pipreqs
-docutils==0.15.2          # via botocore, sphinx
-ecdsa==0.13.3             # via python-jose
+docutils==0.15.2          # via botocore
 edx-auth-backends==2.0.2
 edx-django-release-util==0.3.1
-edx-django-utils==2.0.0   # via edx-drf-extensions
-edx-drf-extensions==2.4.0
+edx-django-utils==2.0.1   # via edx-drf-extensions
+edx-drf-extensions==2.4.2
 edx-i18n-tools==0.4.8
 edx-lint==1.3.0
 edx-opaque-keys==2.0.0    # via edx-drf-extensions
 edx-rest-api-client==1.9.2
 edx-sphinx-theme==1.5.0
 factory-boy==2.12.0
-faker==2.0.2
-future==0.17.1            # via aws-xray-sdk, pyjwkest, python-jose
+faker==2.0.3
+future==0.18.1            # via pyjwkest
 gevent==1.4.0
 greenlet==0.4.15          # via gevent
 gunicorn==19.9.0
-idna==2.8                 # via moto, requests
-imagesize==1.1.0          # via sphinx
+idna==2.8                 # via requests
 importlib-metadata==0.23  # via path.py, pluggy, pytest
 isort[requirements]==4.3.21
-jinja2==2.10.1            # via code-annotations, moto, sphinx
 jmespath==0.9.4           # via boto3, botocore
-jsondiff==1.1.2           # via moto
-jsonpatch==1.24           # via cfn-lint
-jsonpickle==1.2           # via aws-xray-sdk
-jsonpointer==2.0          # via jsonpatch
-jsonschema==3.0.2         # via aws-sam-translator, cfn-lint
 kombu==3.0.37             # via celery
-lazy-object-proxy==1.4.2  # via astroid
-markupsafe==1.1.1         # via jinja2
-mccabe==0.6.1             # via pylint
 mock==3.0.5
 more-itertools==7.2.0     # via pytest, zipp
 moto==1.3.8
 mysqlclient==1.3.14
-newrelic==5.0.2.126
+newrelic==5.2.1.129
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 packaging==19.2           # via pytest
 path.py==12.0.1           # via edx-i18n-tools
-pathspec==0.5.9           # via yamllint
+pathlib2==2.3.5           # via pytest
+pathspec==0.6.0           # via yamllint
 pbr==5.4.3                # via stevedore
-pip-api==0.0.12           # via isort
+pip-api==0.0.13           # via isort
 pipreqs==0.4.9            # via isort
 pluggy==0.13.0            # via pytest
 polib==1.1.0              # via edx-i18n-tools
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
 py==1.8.0                 # via pytest
-pyasn1==0.4.7             # via rsa
 pycodestyle==2.5.0
-pycparser==2.19           # via cffi
 pycryptodomex==3.9.0      # via pyjwkest
-pygments==2.4.2           # via sphinx
 pyinotify==0.9.6
 pyjwkest==1.3.2           # via edx-drf-extensions, social-auth-core
 pyjwt==1.7.1              # via djangorestframework-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
-pylint-celery==0.3        # via edx-lint
-pylint-django==0.7.2      # via edx-lint
-pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
-pylint==1.7.6             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.9.0            # via edx-opaque-keys
 pyparsing==2.4.2          # via packaging
-pyrsistent==0.15.4        # via jsonschema
-pytest-cov==2.7.1
-pytest-django==3.5.1
-pytest==5.1.3
-python-dateutil==2.8.0    # via analytics-python, botocore, edx-drf-extensions, faker, moto, ruamel.yaml.convert
-python-jose==3.0.1        # via moto
+pytest-cov==2.8.1
+pytest-django==3.6.0
+pytest==5.2.1
+python-dateutil==2.8.0    # via analytics-python, botocore, edx-drf-extensions, faker, ruamel.yaml.convert
 python-memcached==1.59
-python-slugify==1.2.6     # via code-annotations, transifex-client
 python3-openid==3.1.0     # via social-auth-core
-pytz==2019.2
+pytz==2019.3
 pyyaml==5.1
 redis==2.8
 requests-oauthlib==1.2.0  # via social-auth-core
-requests==2.22.0          # via analytics-python, docker, edx-drf-extensions, edx-rest-api-client, moto, pyjwkest, requests-oauthlib, responses, slumber, social-auth-core, sphinx, transifex-client, yarg
+requests==2.22.0          # via analytics-python, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, responses, slumber, social-auth-core, yarg
 responses==0.10.6
 rest-condition==1.0.3     # via edx-drf-extensions
-rsa==4.0                  # via python-jose
 ruamel.std.argparse==0.8.1  # via ruamel.yaml.cmd
 ruamel.yaml.clib==0.2.0   # via ruamel.yaml
 ruamel.yaml.cmd==0.5.5
@@ -134,28 +100,20 @@ ruamel.yaml.convert==0.3.2  # via ruamel.yaml.cmd
 ruamel.yaml==0.16.5       # via ruamel.yaml.cmd, ruamel.yaml.convert
 s3transfer==0.2.1         # via boto3
 semantic-version==2.8.2   # via edx-drf-extensions
-six==1.11.0               # via analytics-python, astroid, aws-sam-translator, cfn-lint, configobj, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, docker, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, faker, jsonschema, mock, moto, packaging, pyjwkest, pylint, pyrsistent, python-dateutil, python-jose, python-memcached, responses, social-auth-app-django, social-auth-core, sphinx, stevedore, transifex-client, websocket-client
+six==1.12.0               # via analytics-python, configobj, django-dynamic-fixture, django-extensions, django-simple-history, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-opaque-keys, edx-sphinx-theme, faker, mock, packaging, pathlib2, pyjwkest, python-dateutil, python-memcached, responses, social-auth-app-django, social-auth-core, stevedore
 slumber==0.7.1            # via edx-rest-api-client
-snowballstemmer==1.9.1    # via sphinx
 social-auth-app-django==1.2.0  # via edx-auth-backends
 social-auth-core[openidconnect]==1.7.0  # via edx-auth-backends, social-auth-app-django
 sphinx==1.6.7
-sphinxcontrib-websupport==1.1.2  # via sphinx
 sqlparse==0.3.0           # via django-debug-toolbar
-stevedore==1.31.0         # via code-annotations, edx-opaque-keys
+stevedore==1.31.0         # via edx-opaque-keys
 text-unidecode==1.3       # via faker
 transifex-client==0.13.6
-unidecode==1.1.1          # via python-slugify
-urllib3==1.23             # via botocore, requests, transifex-client
+urllib3==1.25.6           # via botocore, requests
 wcwidth==0.1.7            # via pytest
-websocket-client==0.56.0  # via docker
-werkzeug==0.16.0          # via moto
-wrapt==1.11.2             # via astroid, aws-xray-sdk
-xmltodict==0.12.0         # via moto
-yamllint==1.17.0
+yamllint==1.18.0
 yarg==0.1.9               # via pipreqs
 zipp==0.6.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip==19.3.1               # via pip-api
-# setuptools==41.4.0        # via cfn-lint, jsonschema, sphinx

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -8,14 +8,14 @@ amqp==1.4.9               # via kombu
 analytics-python==1.2.9
 anyjson==0.3.3            # via kombu
 billiard==3.3.0.23        # via celery
-boto3==1.9.237
-botocore==1.12.237        # via boto3, s3transfer
+boto3==1.10.2
+botocore==1.13.2          # via boto3, s3transfer
 celery==3.1.26.post2
 certifi==2019.9.11        # via requests
 chardet==3.0.4            # via requests
 defusedxml==0.6.0         # via python3-openid, social-auth-core
-django-cors-headers==3.1.0
-django-extensions==2.2.1
+django-cors-headers==3.1.1
+django-extensions==2.2.5
 django-guardian==2.0.0
 django-model-utils==3.2.0
 django-mysql==3.2.0
@@ -23,17 +23,17 @@ django-simple-history==2.7.3
 django-storages==1.7.2
 django-user-tasks==0.2.1
 django-waffle==0.17.0
-django==1.11.24
+django==1.11.25
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.10.3
 docutils==0.15.2          # via botocore
 edx-auth-backends==2.0.2
 edx-django-release-util==0.3.1
-edx-django-utils==2.0.0   # via edx-drf-extensions
-edx-drf-extensions==2.4.0
+edx-django-utils==2.0.1   # via edx-drf-extensions
+edx-drf-extensions==2.4.2
 edx-opaque-keys==2.0.0    # via edx-drf-extensions
 edx-rest-api-client==1.9.2
-future==0.17.1            # via pyjwkest
+future==0.18.1            # via pyjwkest
 gevent==1.4.0
 greenlet==0.4.15          # via gevent
 gunicorn==19.9.0
@@ -41,7 +41,7 @@ idna==2.8                 # via requests
 jmespath==0.9.4           # via boto3, botocore
 kombu==3.0.37             # via celery
 mysqlclient==1.3.14
-newrelic==5.0.2.126       # via edx-django-utils
+newrelic==5.2.1.129       # via edx-django-utils
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 pbr==5.4.3                # via stevedore
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
@@ -52,7 +52,7 @@ pymongo==3.9.0            # via edx-opaque-keys
 python-dateutil==2.8.0    # via analytics-python, botocore, edx-drf-extensions
 python-memcached==1.59
 python3-openid==3.1.0     # via social-auth-core
-pytz==2019.2
+pytz==2019.3
 pyyaml==5.1
 redis==2.8
 requests-oauthlib==1.2.0  # via social-auth-core

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -7,31 +7,19 @@
 amqp==1.4.9               # via kombu
 analytics-python==1.2.9
 anyjson==0.3.3            # via kombu
-asn1crypto==0.24.0        # via cryptography
-astroid==1.5.3            # via pylint, pylint-celery
 atomicwrites==1.3.0       # via pytest
-attrs==19.1.0             # via jsonschema, pytest
-aws-sam-translator==1.14.0  # via cfn-lint
-aws-xray-sdk==2.4.2       # via moto
+attrs==19.3.0             # via pytest
 billiard==3.3.0.23        # via celery
-boto3==1.9.237            # via aws-sam-translator, moto
-boto==2.49.0              # via moto
-botocore==1.12.237        # via aws-xray-sdk, boto3, moto, s3transfer
 celery==3.1.26.post2
 certifi==2019.9.11        # via requests
-cffi==1.12.3              # via cryptography
-cfn-lint==0.24.2          # via moto
 chardet==3.0.4            # via requests
-click-log==0.3.2          # via edx-lint
-click==7.0                # via click-log, code-annotations, edx-lint
 code-annotations==0.3.2
 coverage==4.5.4
-cryptography==2.7         # via moto
 ddt==1.2.1
 defusedxml==0.6.0         # via python3-openid, social-auth-core
-django-cors-headers==3.1.0
+django-cors-headers==3.1.1
 django-dynamic-fixture==2.0.0
-django-extensions==2.2.1
+django-extensions==2.2.5
 django-guardian==2.0.0
 django-model-utils==3.2.0
 django-mysql==3.2.0
@@ -39,96 +27,68 @@ django-simple-history==2.7.3
 django-storages==1.7.2
 django-user-tasks==0.2.1
 django-waffle==0.17.0
-django==1.11.24
+django==1.11.25
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.10.3
-docker==4.0.2             # via moto
 docopt==0.6.2             # via pipreqs
-docutils==0.15.2          # via botocore
-ecdsa==0.13.3             # via python-jose
 edx-auth-backends==2.0.2
 edx-django-release-util==0.3.1
-edx-django-utils==2.0.0   # via edx-drf-extensions
-edx-drf-extensions==2.4.0
+edx-django-utils==2.0.1   # via edx-drf-extensions
+edx-drf-extensions==2.4.2
 edx-lint==1.3.0
 edx-opaque-keys==2.0.0    # via edx-drf-extensions
 edx-rest-api-client==1.9.2
 factory-boy==2.12.0
-faker==2.0.2
-future==0.17.1            # via aws-xray-sdk, pyjwkest, python-jose
-idna==2.8                 # via moto, requests
+faker==2.0.3
+future==0.18.1            # via pyjwkest
+idna==2.8                 # via requests
 importlib-metadata==0.23  # via pluggy, pytest
 isort[requirements]==4.3.21
-jinja2==2.10.1            # via code-annotations, moto
-jmespath==0.9.4           # via boto3, botocore
-jsondiff==1.1.2           # via moto
-jsonpatch==1.24           # via cfn-lint
-jsonpickle==1.2           # via aws-xray-sdk
-jsonpointer==2.0          # via jsonpatch
-jsonschema==3.0.2         # via aws-sam-translator, cfn-lint
 kombu==3.0.37             # via celery
-lazy-object-proxy==1.4.2  # via astroid
-markupsafe==1.1.1         # via jinja2
-mccabe==0.6.1             # via pylint
 mock==3.0.5
 more-itertools==7.2.0     # via pytest, zipp
 moto==1.3.8
-newrelic==5.0.2.126       # via edx-django-utils
+newrelic==5.2.1.129       # via edx-django-utils
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 packaging==19.2           # via pytest
-pathspec==0.5.9           # via yamllint
+pathlib2==2.3.5           # via pytest
+pathspec==0.6.0           # via yamllint
 pbr==5.4.3                # via stevedore
-pip-api==0.0.12           # via isort
+pip-api==0.0.13           # via isort
 pipreqs==0.4.9            # via isort
 pluggy==0.13.0            # via pytest
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
 py==1.8.0                 # via pytest
-pyasn1==0.4.7             # via rsa
 pycodestyle==2.5.0
-pycparser==2.19           # via cffi
 pycryptodomex==3.9.0      # via pyjwkest
 pyjwkest==1.3.2           # via edx-drf-extensions, social-auth-core
 pyjwt==1.7.1              # via djangorestframework-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
-pylint-celery==0.3        # via edx-lint
-pylint-django==0.7.2      # via edx-lint
-pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
-pylint==1.7.6             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.9.0            # via edx-opaque-keys
 pyparsing==2.4.2          # via packaging
-pyrsistent==0.15.4        # via jsonschema
-pytest-cov==2.7.1
-pytest-django==3.5.1
-pytest==5.1.3
-python-dateutil==2.8.0    # via analytics-python, botocore, edx-drf-extensions, faker, moto
-python-jose==3.0.1        # via moto
-python-slugify==3.0.4     # via code-annotations
+pytest-cov==2.8.1
+pytest-django==3.6.0
+pytest==5.2.1
+python-dateutil==2.8.0    # via analytics-python, edx-drf-extensions, faker
 python3-openid==3.1.0     # via social-auth-core
-pytz==2019.2
-pyyaml==5.1.2             # via cfn-lint, code-annotations, edx-django-release-util, moto, yamllint
+pytz==2019.3
+pyyaml==5.1.2             # via edx-django-release-util, yamllint
 redis==2.8
 requests-oauthlib==1.2.0  # via social-auth-core
-requests==2.22.0          # via analytics-python, docker, edx-drf-extensions, edx-rest-api-client, moto, pyjwkest, requests-oauthlib, responses, slumber, social-auth-core, yarg
+requests==2.22.0          # via analytics-python, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, responses, slumber, social-auth-core, yarg
 responses==0.10.6
 rest-condition==1.0.3     # via edx-drf-extensions
-rsa==4.0                  # via python-jose
-s3transfer==0.2.1         # via boto3
 semantic-version==2.8.2   # via edx-drf-extensions
-six==1.12.0               # via analytics-python, astroid, aws-sam-translator, cfn-lint, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, docker, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-lint, edx-opaque-keys, faker, jsonschema, mock, moto, packaging, pyjwkest, pylint, pyrsistent, python-dateutil, python-jose, responses, social-auth-app-django, social-auth-core, stevedore, websocket-client
+six==1.12.0               # via analytics-python, django-dynamic-fixture, django-extensions, django-simple-history, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-opaque-keys, faker, mock, packaging, pathlib2, pyjwkest, python-dateutil, responses, social-auth-app-django, social-auth-core, stevedore
 slumber==0.7.1            # via edx-rest-api-client
 social-auth-app-django==1.2.0  # via edx-auth-backends
 social-auth-core[openidconnect]==1.7.0  # via edx-auth-backends, social-auth-app-django
-stevedore==1.31.0         # via code-annotations, edx-opaque-keys
-text-unidecode==1.3       # via faker, python-slugify
-urllib3==1.25.6           # via botocore, requests
+stevedore==1.31.0         # via edx-opaque-keys
+text-unidecode==1.3       # via faker
+urllib3==1.25.6           # via requests
 wcwidth==0.1.7            # via pytest
-websocket-client==0.56.0  # via docker
-werkzeug==0.16.0          # via moto
-wrapt==1.11.2             # via astroid, aws-xray-sdk
-xmltodict==0.12.0         # via moto
-yamllint==1.17.0
+yamllint==1.18.0
 yarg==0.1.9               # via pipreqs
 zipp==0.6.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip==19.3.1               # via pip-api
-# setuptools==41.4.0        # via cfn-lint, jsonschema


### PR DESCRIPTION
@edx/masters-devs 

# Context

After fixing travis builds, our `make upgrade` was broken.
https://openedx.atlassian.net/browse/EDUCATOR-4760

# This PR

Takes the simple approach of just pinning edx-lint to 1.3.0 in constraints.txt