### PR TITLE
[Fix upgrades attempt 5] Just pin edx-lint==1.3.0 in test.in

### DIFF
--- a/requirements/devstack.txt
+++ b/requirements/devstack.txt
@@ -8,34 +8,33 @@ alabaster==0.7.12         # via sphinx
 amqp==1.4.9               # via kombu
 analytics-python==1.2.9
 anyjson==0.3.3            # via kombu
-asn1crypto==0.24.0        # via cryptography
 astroid==1.5.3            # via pylint, pylint-celery
 atomicwrites==1.3.0       # via pytest
-attrs==19.1.0             # via jsonschema, pytest
-aws-sam-translator==1.14.0  # via cfn-lint
+attrs==19.3.0             # via jsonschema, pytest
+aws-sam-translator==1.15.1  # via cfn-lint
 aws-xray-sdk==2.4.2       # via moto
 babel==2.7.0              # via sphinx
 billiard==3.3.0.23        # via celery
-boto3==1.9.237            # via aws-sam-translator, moto
+boto3==1.10.2             # via aws-sam-translator, moto
 boto==2.49.0              # via moto
-botocore==1.12.237        # via aws-xray-sdk, boto3, moto, s3transfer
+botocore==1.13.2          # via aws-xray-sdk, boto3, moto, s3transfer
 celery==3.1.26.post2
 certifi==2019.9.11        # via requests
-cffi==1.12.3              # via cryptography
-cfn-lint==0.24.2          # via moto
+cffi==1.13.1              # via cryptography
+cfn-lint==0.24.6          # via moto
 chardet==3.0.4            # via requests
 click-log==0.3.2          # via edx-lint
 click==7.0                # via click-log, code-annotations, edx-lint
 code-annotations==0.3.2
 configobj==5.0.6          # via ruamel.yaml.cmd
 coverage==4.5.4
-cryptography==2.7         # via moto
+cryptography==2.8         # via moto
 ddt==1.2.1
 defusedxml==0.6.0         # via python3-openid, social-auth-core
-django-cors-headers==3.1.0
+django-cors-headers==3.1.1
 django-debug-toolbar==2.0
 django-dynamic-fixture==2.0.0
-django-extensions==2.2.1
+django-extensions==2.2.5
 django-guardian==2.0.0
 django-model-utils==3.2.0
 django-mysql==3.2.0
@@ -43,36 +42,36 @@ django-simple-history==2.7.3
 django-storages==1.7.2
 django-user-tasks==0.2.1
 django-waffle==0.17.0
-django==1.11.24
+django==1.11.25
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.10.3
-docker==4.0.2             # via moto
+docker==4.1.0             # via moto
 docopt==0.6.2             # via pipreqs
 docutils==0.15.2          # via botocore, sphinx
 ecdsa==0.13.3             # via python-jose
 edx-auth-backends==2.0.2
 edx-django-release-util==0.3.1
-edx-django-utils==2.0.0   # via edx-drf-extensions
-edx-drf-extensions==2.4.0
+edx-django-utils==2.0.1   # via edx-drf-extensions
+edx-drf-extensions==2.4.2
 edx-i18n-tools==0.4.8
 edx-lint==1.3.0
 edx-opaque-keys==2.0.0    # via edx-drf-extensions
 edx-rest-api-client==1.9.2
 edx-sphinx-theme==1.5.0
 factory-boy==2.12.0
-faker==2.0.2
-future==0.17.1            # via aws-xray-sdk, pyjwkest, python-jose
+faker==2.0.3
+future==0.18.1            # via aws-xray-sdk, pyjwkest, python-jose
 idna==2.8                 # via moto, requests
 imagesize==1.1.0          # via sphinx
-importlib-metadata==0.23  # via path.py, pluggy, pytest
+importlib-metadata==0.23  # via jsonschema, path.py, pluggy, pytest
 isort[requirements]==4.3.21
-jinja2==2.10.1            # via code-annotations, moto, sphinx
+jinja2==2.10.3            # via code-annotations, moto, sphinx
 jmespath==0.9.4           # via boto3, botocore
 jsondiff==1.1.2           # via moto
 jsonpatch==1.24           # via cfn-lint
 jsonpickle==1.2           # via aws-xray-sdk
 jsonpointer==2.0          # via jsonpatch
-jsonschema==3.0.2         # via aws-sam-translator, cfn-lint
+jsonschema==3.1.1         # via aws-sam-translator, cfn-lint
 kombu==3.0.37             # via celery
 lazy-object-proxy==1.4.2  # via astroid
 markupsafe==1.1.1         # via jinja2
@@ -81,13 +80,14 @@ mock==3.0.5
 more-itertools==7.2.0     # via pytest, zipp
 moto==1.3.8
 mysqlclient==1.3.14
-newrelic==5.0.2.126       # via edx-django-utils
+newrelic==5.2.1.129       # via edx-django-utils
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 packaging==19.2           # via pytest
 path.py==12.0.1           # via edx-i18n-tools
-pathspec==0.5.9           # via yamllint
+pathlib2==2.3.5           # via pytest
+pathspec==0.6.0           # via yamllint
 pbr==5.4.3                # via stevedore
-pip-api==0.0.12           # via isort
+pip-api==0.0.13           # via isort
 pipreqs==0.4.9            # via isort
 pluggy==0.13.0            # via pytest
 polib==1.1.0              # via edx-i18n-tools
@@ -108,15 +108,15 @@ pylint==1.7.6             # via edx-lint, pylint-celery, pylint-django, pylint-p
 pymongo==3.9.0            # via edx-opaque-keys
 pyparsing==2.4.2          # via packaging
 pyrsistent==0.15.4        # via jsonschema
-pytest-cov==2.7.1
-pytest-django==3.5.1
-pytest==5.1.3
+pytest-cov==2.8.1
+pytest-django==3.6.0
+pytest==5.2.2
 python-dateutil==2.8.0    # via analytics-python, botocore, edx-drf-extensions, faker, moto, ruamel.yaml.convert
 python-jose==3.0.1        # via moto
 python-memcached==1.59
 python-slugify==1.2.6     # via code-annotations, transifex-client
 python3-openid==3.1.0     # via social-auth-core
-pytz==2019.2
+pytz==2019.3
 pyyaml==5.1.2             # via cfn-lint, code-annotations, edx-django-release-util, edx-i18n-tools, moto, yamllint
 redis==2.8
 requests-oauthlib==1.2.0  # via social-auth-core
@@ -131,9 +131,9 @@ ruamel.yaml.convert==0.3.2  # via ruamel.yaml.cmd
 ruamel.yaml==0.16.5       # via ruamel.yaml.cmd, ruamel.yaml.convert
 s3transfer==0.2.1         # via boto3
 semantic-version==2.8.2   # via edx-drf-extensions
-six==1.11.0               # via analytics-python, astroid, aws-sam-translator, cfn-lint, configobj, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, docker, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, faker, jsonschema, mock, moto, packaging, pyjwkest, pylint, pyrsistent, python-dateutil, python-jose, python-memcached, responses, social-auth-app-django, social-auth-core, sphinx, stevedore, transifex-client, websocket-client
+six==1.11.0               # via analytics-python, astroid, aws-sam-translator, cfn-lint, configobj, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, docker, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, faker, jsonschema, mock, moto, packaging, pathlib2, pyjwkest, pylint, pyrsistent, python-dateutil, python-jose, python-memcached, responses, social-auth-app-django, social-auth-core, sphinx, stevedore, transifex-client, websocket-client
 slumber==0.7.1            # via edx-rest-api-client
-snowballstemmer==1.9.1    # via sphinx
+snowballstemmer==2.0.0    # via sphinx
 social-auth-app-django==1.2.0  # via edx-auth-backends
 social-auth-core[openidconnect]==1.7.0  # via edx-auth-backends, social-auth-app-django
 sphinx==1.6.7
@@ -149,7 +149,7 @@ websocket-client==0.56.0  # via docker
 werkzeug==0.16.0          # via moto
 wrapt==1.11.2             # via astroid, aws-xray-sdk
 xmltodict==0.12.0         # via moto
-yamllint==1.17.0
+yamllint==1.18.0
 yarg==0.1.9               # via pipreqs
 zipp==0.6.0               # via importlib-metadata
 

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -8,34 +8,33 @@ alabaster==0.7.12         # via sphinx
 amqp==1.4.9               # via kombu
 analytics-python==1.2.9
 anyjson==0.3.3            # via kombu
-asn1crypto==0.24.0        # via cryptography
 astroid==1.5.3            # via pylint, pylint-celery
 atomicwrites==1.3.0       # via pytest
-attrs==19.1.0             # via jsonschema, pytest
-aws-sam-translator==1.14.0  # via cfn-lint
+attrs==19.3.0             # via jsonschema, pytest
+aws-sam-translator==1.15.1  # via cfn-lint
 aws-xray-sdk==2.4.2       # via moto
 babel==2.7.0              # via sphinx
 billiard==3.3.0.23        # via celery
-boto3==1.9.237            # via aws-sam-translator, moto
+boto3==1.10.2             # via aws-sam-translator, moto
 boto==2.49.0              # via moto
-botocore==1.12.237        # via aws-xray-sdk, boto3, moto, s3transfer
+botocore==1.13.2          # via aws-xray-sdk, boto3, moto, s3transfer
 celery==3.1.26.post2
 certifi==2019.9.11        # via requests
-cffi==1.12.3              # via cryptography
-cfn-lint==0.24.2          # via moto
+cffi==1.13.1              # via cryptography
+cfn-lint==0.24.6          # via moto
 chardet==3.0.4            # via requests
 click-log==0.3.2          # via edx-lint
 click==7.0                # via click-log, code-annotations, edx-lint
 code-annotations==0.3.2
 configobj==5.0.6          # via ruamel.yaml.cmd
 coverage==4.5.4
-cryptography==2.7         # via moto
+cryptography==2.8         # via moto
 ddt==1.2.1
 defusedxml==0.6.0         # via python3-openid, social-auth-core
-django-cors-headers==3.1.0
+django-cors-headers==3.1.1
 django-debug-toolbar==2.0
 django-dynamic-fixture==2.0.0
-django-extensions==2.2.1
+django-extensions==2.2.5
 django-guardian==2.0.0
 django-model-utils==3.2.0
 django-mysql==3.2.0
@@ -43,36 +42,36 @@ django-simple-history==2.7.3
 django-storages==1.7.2
 django-user-tasks==0.2.1
 django-waffle==0.17.0
-django==1.11.24
+django==1.11.25
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.10.3
-docker==4.0.2             # via moto
+docker==4.1.0             # via moto
 docopt==0.6.2             # via pipreqs
 docutils==0.15.2          # via botocore, sphinx
 ecdsa==0.13.3             # via python-jose
 edx-auth-backends==2.0.2
 edx-django-release-util==0.3.1
-edx-django-utils==2.0.0   # via edx-drf-extensions
-edx-drf-extensions==2.4.0
+edx-django-utils==2.0.1   # via edx-drf-extensions
+edx-drf-extensions==2.4.2
 edx-i18n-tools==0.4.8
 edx-lint==1.3.0
 edx-opaque-keys==2.0.0    # via edx-drf-extensions
 edx-rest-api-client==1.9.2
 edx-sphinx-theme==1.5.0
 factory-boy==2.12.0
-faker==2.0.2
-future==0.17.1            # via aws-xray-sdk, pyjwkest, python-jose
+faker==2.0.3
+future==0.18.1            # via aws-xray-sdk, pyjwkest, python-jose
 idna==2.8                 # via moto, requests
 imagesize==1.1.0          # via sphinx
-importlib-metadata==0.23  # via path.py, pluggy, pytest
+importlib-metadata==0.23  # via jsonschema, path.py, pluggy, pytest
 isort[requirements]==4.3.21
-jinja2==2.10.1            # via code-annotations, moto, sphinx
+jinja2==2.10.3            # via code-annotations, moto, sphinx
 jmespath==0.9.4           # via boto3, botocore
 jsondiff==1.1.2           # via moto
 jsonpatch==1.24           # via cfn-lint
 jsonpickle==1.2           # via aws-xray-sdk
 jsonpointer==2.0          # via jsonpatch
-jsonschema==3.0.2         # via aws-sam-translator, cfn-lint
+jsonschema==3.1.1         # via aws-sam-translator, cfn-lint
 kombu==3.0.37             # via celery
 lazy-object-proxy==1.4.2  # via astroid
 markupsafe==1.1.1         # via jinja2
@@ -80,13 +79,14 @@ mccabe==0.6.1             # via pylint
 mock==3.0.5
 more-itertools==7.2.0     # via pytest, zipp
 moto==1.3.8
-newrelic==5.0.2.126       # via edx-django-utils
+newrelic==5.2.1.129       # via edx-django-utils
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 packaging==19.2           # via pytest
 path.py==12.0.1           # via edx-i18n-tools
-pathspec==0.5.9           # via yamllint
+pathlib2==2.3.5           # via pytest
+pathspec==0.6.0           # via yamllint
 pbr==5.4.3                # via stevedore
-pip-api==0.0.12           # via isort
+pip-api==0.0.13           # via isort
 pipreqs==0.4.9            # via isort
 pluggy==0.13.0            # via pytest
 polib==1.1.0              # via edx-i18n-tools
@@ -107,14 +107,14 @@ pylint==1.7.6             # via edx-lint, pylint-celery, pylint-django, pylint-p
 pymongo==3.9.0            # via edx-opaque-keys
 pyparsing==2.4.2          # via packaging
 pyrsistent==0.15.4        # via jsonschema
-pytest-cov==2.7.1
-pytest-django==3.5.1
-pytest==5.1.3
+pytest-cov==2.8.1
+pytest-django==3.6.0
+pytest==5.2.2
 python-dateutil==2.8.0    # via analytics-python, botocore, edx-drf-extensions, faker, moto, ruamel.yaml.convert
 python-jose==3.0.1        # via moto
 python-slugify==1.2.6     # via code-annotations, transifex-client
 python3-openid==3.1.0     # via social-auth-core
-pytz==2019.2
+pytz==2019.3
 pyyaml==5.1.2             # via cfn-lint, code-annotations, edx-django-release-util, edx-i18n-tools, moto, yamllint
 redis==2.8
 requests-oauthlib==1.2.0  # via social-auth-core
@@ -129,9 +129,9 @@ ruamel.yaml.convert==0.3.2  # via ruamel.yaml.cmd
 ruamel.yaml==0.16.5       # via ruamel.yaml.cmd, ruamel.yaml.convert
 s3transfer==0.2.1         # via boto3
 semantic-version==2.8.2   # via edx-drf-extensions
-six==1.11.0               # via analytics-python, astroid, aws-sam-translator, cfn-lint, configobj, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, docker, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, faker, jsonschema, mock, moto, packaging, pyjwkest, pylint, pyrsistent, python-dateutil, python-jose, responses, social-auth-app-django, social-auth-core, sphinx, stevedore, transifex-client, websocket-client
+six==1.11.0               # via analytics-python, astroid, aws-sam-translator, cfn-lint, configobj, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, docker, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, faker, jsonschema, mock, moto, packaging, pathlib2, pyjwkest, pylint, pyrsistent, python-dateutil, python-jose, responses, social-auth-app-django, social-auth-core, sphinx, stevedore, transifex-client, websocket-client
 slumber==0.7.1            # via edx-rest-api-client
-snowballstemmer==1.9.1    # via sphinx
+snowballstemmer==2.0.0    # via sphinx
 social-auth-app-django==1.2.0  # via edx-auth-backends
 social-auth-core[openidconnect]==1.7.0  # via edx-auth-backends, social-auth-app-django
 sphinx==1.6.7
@@ -147,7 +147,7 @@ websocket-client==0.56.0  # via docker
 werkzeug==0.16.0          # via moto
 wrapt==1.11.2             # via astroid, aws-xray-sdk
 xmltodict==0.12.0         # via moto
-yamllint==1.17.0
+yamllint==1.18.0
 yarg==0.1.9               # via pipreqs
 zipp==0.6.0               # via importlib-metadata
 

--- a/requirements/monitoring/requirements.txt
+++ b/requirements/monitoring/requirements.txt
@@ -8,34 +8,33 @@ alabaster==0.7.12         # via sphinx
 amqp==1.4.9               # via kombu
 analytics-python==1.2.9
 anyjson==0.3.3            # via kombu
-asn1crypto==0.24.0        # via cryptography
 astroid==1.5.3            # via pylint, pylint-celery
 atomicwrites==1.3.0       # via pytest
-attrs==19.1.0             # via jsonschema, pytest
-aws-sam-translator==1.14.0  # via cfn-lint
+attrs==19.3.0             # via jsonschema, pytest
+aws-sam-translator==1.15.1  # via cfn-lint
 aws-xray-sdk==2.4.2       # via moto
 babel==2.7.0              # via sphinx
 billiard==3.3.0.23        # via celery
-boto3==1.9.237
+boto3==1.10.2
 boto==2.49.0              # via moto
-botocore==1.12.237        # via aws-xray-sdk, boto3, moto, s3transfer
+botocore==1.13.2          # via aws-xray-sdk, boto3, moto, s3transfer
 celery==3.1.26.post2
 certifi==2019.9.11        # via requests
-cffi==1.12.3              # via cryptography
-cfn-lint==0.24.2          # via moto
+cffi==1.13.1              # via cryptography
+cfn-lint==0.24.6          # via moto
 chardet==3.0.4            # via requests
 click-log==0.3.2          # via edx-lint
 click==7.0                # via click-log, code-annotations, edx-lint
 code-annotations==0.3.2
 configobj==5.0.6          # via ruamel.yaml.cmd
 coverage==4.5.4
-cryptography==2.7         # via moto
+cryptography==2.8         # via moto
 ddt==1.2.1
 defusedxml==0.6.0         # via python3-openid, social-auth-core
-django-cors-headers==3.1.0
+django-cors-headers==3.1.1
 django-debug-toolbar==2.0
 django-dynamic-fixture==2.0.0
-django-extensions==2.2.1
+django-extensions==2.2.5
 django-guardian==2.0.0
 django-model-utils==3.2.0
 django-mysql==3.2.0
@@ -43,39 +42,39 @@ django-simple-history==2.7.3
 django-storages==1.7.2
 django-user-tasks==0.2.1
 django-waffle==0.17.0
-django==1.11.24
+django==1.11.25
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.10.3
-docker==4.0.2             # via moto
+docker==4.1.0             # via moto
 docopt==0.6.2             # via pipreqs
 docutils==0.15.2          # via botocore, sphinx
 ecdsa==0.13.3             # via python-jose
 edx-auth-backends==2.0.2
 edx-django-release-util==0.3.1
-edx-django-utils==2.0.0   # via edx-drf-extensions
-edx-drf-extensions==2.4.0
+edx-django-utils==2.0.1   # via edx-drf-extensions
+edx-drf-extensions==2.4.2
 edx-i18n-tools==0.4.8
 edx-lint==1.3.0
 edx-opaque-keys==2.0.0    # via edx-drf-extensions
 edx-rest-api-client==1.9.2
 edx-sphinx-theme==1.5.0
 factory-boy==2.12.0
-faker==2.0.2
-future==0.17.1            # via aws-xray-sdk, pyjwkest, python-jose
+faker==2.0.3
+future==0.18.1            # via aws-xray-sdk, pyjwkest, python-jose
 gevent==1.4.0
 greenlet==0.4.15          # via gevent
 gunicorn==19.9.0
 idna==2.8                 # via moto, requests
 imagesize==1.1.0          # via sphinx
-importlib-metadata==0.23  # via path.py, pluggy, pytest
+importlib-metadata==0.23  # via jsonschema, path.py, pluggy, pytest
 isort[requirements]==4.3.21
-jinja2==2.10.1            # via code-annotations, moto, sphinx
+jinja2==2.10.3            # via code-annotations, moto, sphinx
 jmespath==0.9.4           # via boto3, botocore
 jsondiff==1.1.2           # via moto
 jsonpatch==1.24           # via cfn-lint
 jsonpickle==1.2           # via aws-xray-sdk
 jsonpointer==2.0          # via jsonpatch
-jsonschema==3.0.2         # via aws-sam-translator, cfn-lint
+jsonschema==3.1.1         # via aws-sam-translator, cfn-lint
 kombu==3.0.37             # via celery
 lazy-object-proxy==1.4.2  # via astroid
 markupsafe==1.1.1         # via jinja2
@@ -84,13 +83,14 @@ mock==3.0.5
 more-itertools==7.2.0     # via pytest, zipp
 moto==1.3.8
 mysqlclient==1.3.14
-newrelic==5.0.2.126
+newrelic==5.2.1.129
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 packaging==19.2           # via pytest
 path.py==12.0.1           # via edx-i18n-tools
-pathspec==0.5.9           # via yamllint
+pathlib2==2.3.5           # via pytest
+pathspec==0.6.0           # via yamllint
 pbr==5.4.3                # via stevedore
-pip-api==0.0.12           # via isort
+pip-api==0.0.13           # via isort
 pipreqs==0.4.9            # via isort
 pluggy==0.13.0            # via pytest
 polib==1.1.0              # via edx-i18n-tools
@@ -111,15 +111,15 @@ pylint==1.7.6             # via edx-lint, pylint-celery, pylint-django, pylint-p
 pymongo==3.9.0            # via edx-opaque-keys
 pyparsing==2.4.2          # via packaging
 pyrsistent==0.15.4        # via jsonschema
-pytest-cov==2.7.1
-pytest-django==3.5.1
-pytest==5.1.3
+pytest-cov==2.8.1
+pytest-django==3.6.0
+pytest==5.2.2
 python-dateutil==2.8.0    # via analytics-python, botocore, edx-drf-extensions, faker, moto, ruamel.yaml.convert
 python-jose==3.0.1        # via moto
 python-memcached==1.59
 python-slugify==1.2.6     # via code-annotations, transifex-client
 python3-openid==3.1.0     # via social-auth-core
-pytz==2019.2
+pytz==2019.3
 pyyaml==5.1
 redis==2.8
 requests-oauthlib==1.2.0  # via social-auth-core
@@ -134,9 +134,9 @@ ruamel.yaml.convert==0.3.2  # via ruamel.yaml.cmd
 ruamel.yaml==0.16.5       # via ruamel.yaml.cmd, ruamel.yaml.convert
 s3transfer==0.2.1         # via boto3
 semantic-version==2.8.2   # via edx-drf-extensions
-six==1.11.0               # via analytics-python, astroid, aws-sam-translator, cfn-lint, configobj, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, docker, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, faker, jsonschema, mock, moto, packaging, pyjwkest, pylint, pyrsistent, python-dateutil, python-jose, python-memcached, responses, social-auth-app-django, social-auth-core, sphinx, stevedore, transifex-client, websocket-client
+six==1.11.0               # via analytics-python, astroid, aws-sam-translator, cfn-lint, configobj, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, docker, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, faker, jsonschema, mock, moto, packaging, pathlib2, pyjwkest, pylint, pyrsistent, python-dateutil, python-jose, python-memcached, responses, social-auth-app-django, social-auth-core, sphinx, stevedore, transifex-client, websocket-client
 slumber==0.7.1            # via edx-rest-api-client
-snowballstemmer==1.9.1    # via sphinx
+snowballstemmer==2.0.0    # via sphinx
 social-auth-app-django==1.2.0  # via edx-auth-backends
 social-auth-core[openidconnect]==1.7.0  # via edx-auth-backends, social-auth-app-django
 sphinx==1.6.7
@@ -152,7 +152,7 @@ websocket-client==0.56.0  # via docker
 werkzeug==0.16.0          # via moto
 wrapt==1.11.2             # via astroid, aws-xray-sdk
 xmltodict==0.12.0         # via moto
-yamllint==1.17.0
+yamllint==1.18.0
 yarg==0.1.9               # via pipreqs
 zipp==0.6.0               # via importlib-metadata
 

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -8,14 +8,14 @@ amqp==1.4.9               # via kombu
 analytics-python==1.2.9
 anyjson==0.3.3            # via kombu
 billiard==3.3.0.23        # via celery
-boto3==1.9.237
-botocore==1.12.237        # via boto3, s3transfer
+boto3==1.10.2
+botocore==1.13.2          # via boto3, s3transfer
 celery==3.1.26.post2
 certifi==2019.9.11        # via requests
 chardet==3.0.4            # via requests
 defusedxml==0.6.0         # via python3-openid, social-auth-core
-django-cors-headers==3.1.0
-django-extensions==2.2.1
+django-cors-headers==3.1.1
+django-extensions==2.2.5
 django-guardian==2.0.0
 django-model-utils==3.2.0
 django-mysql==3.2.0
@@ -23,17 +23,17 @@ django-simple-history==2.7.3
 django-storages==1.7.2
 django-user-tasks==0.2.1
 django-waffle==0.17.0
-django==1.11.24
+django==1.11.25
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.10.3
 docutils==0.15.2          # via botocore
 edx-auth-backends==2.0.2
 edx-django-release-util==0.3.1
-edx-django-utils==2.0.0   # via edx-drf-extensions
-edx-drf-extensions==2.4.0
+edx-django-utils==2.0.1   # via edx-drf-extensions
+edx-drf-extensions==2.4.2
 edx-opaque-keys==2.0.0    # via edx-drf-extensions
 edx-rest-api-client==1.9.2
-future==0.17.1            # via pyjwkest
+future==0.18.1            # via pyjwkest
 gevent==1.4.0
 greenlet==0.4.15          # via gevent
 gunicorn==19.9.0
@@ -41,7 +41,7 @@ idna==2.8                 # via requests
 jmespath==0.9.4           # via boto3, botocore
 kombu==3.0.37             # via celery
 mysqlclient==1.3.14
-newrelic==5.0.2.126       # via edx-django-utils
+newrelic==5.2.1.129       # via edx-django-utils
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 pbr==5.4.3                # via stevedore
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
@@ -52,7 +52,7 @@ pymongo==3.9.0            # via edx-opaque-keys
 python-dateutil==2.8.0    # via analytics-python, botocore, edx-drf-extensions
 python-memcached==1.59
 python3-openid==3.1.0     # via social-auth-core
-pytz==2019.2
+pytz==2019.3
 pyyaml==5.1
 redis==2.8
 requests-oauthlib==1.2.0  # via social-auth-core

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -6,7 +6,7 @@
 coverage
 django-dynamic-fixture
 code-annotations>=0.3.1
-edx-lint
+edx-lint==1.3.0  # Temporary pin. More recent versions require newer pylint, which causes quality failures (TODO EDUCATOR-4764).
 factory_boy
 Faker
 mock

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -7,31 +7,30 @@
 amqp==1.4.9               # via kombu
 analytics-python==1.2.9
 anyjson==0.3.3            # via kombu
-asn1crypto==0.24.0        # via cryptography
 astroid==1.5.3            # via pylint, pylint-celery
 atomicwrites==1.3.0       # via pytest
-attrs==19.1.0             # via jsonschema, pytest
-aws-sam-translator==1.14.0  # via cfn-lint
+attrs==19.3.0             # via jsonschema, pytest
+aws-sam-translator==1.15.1  # via cfn-lint
 aws-xray-sdk==2.4.2       # via moto
 billiard==3.3.0.23        # via celery
-boto3==1.9.237            # via aws-sam-translator, moto
+boto3==1.10.2             # via aws-sam-translator, moto
 boto==2.49.0              # via moto
-botocore==1.12.237        # via aws-xray-sdk, boto3, moto, s3transfer
+botocore==1.13.2          # via aws-xray-sdk, boto3, moto, s3transfer
 celery==3.1.26.post2
 certifi==2019.9.11        # via requests
-cffi==1.12.3              # via cryptography
-cfn-lint==0.24.2          # via moto
+cffi==1.13.1              # via cryptography
+cfn-lint==0.24.6          # via moto
 chardet==3.0.4            # via requests
 click-log==0.3.2          # via edx-lint
 click==7.0                # via click-log, code-annotations, edx-lint
 code-annotations==0.3.2
 coverage==4.5.4
-cryptography==2.7         # via moto
+cryptography==2.8         # via moto
 ddt==1.2.1
 defusedxml==0.6.0         # via python3-openid, social-auth-core
-django-cors-headers==3.1.0
+django-cors-headers==3.1.1
 django-dynamic-fixture==2.0.0
-django-extensions==2.2.1
+django-extensions==2.2.5
 django-guardian==2.0.0
 django-model-utils==3.2.0
 django-mysql==3.2.0
@@ -39,33 +38,33 @@ django-simple-history==2.7.3
 django-storages==1.7.2
 django-user-tasks==0.2.1
 django-waffle==0.17.0
-django==1.11.24
+django==1.11.25
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.10.3
-docker==4.0.2             # via moto
+docker==4.1.0             # via moto
 docopt==0.6.2             # via pipreqs
 docutils==0.15.2          # via botocore
 ecdsa==0.13.3             # via python-jose
 edx-auth-backends==2.0.2
 edx-django-release-util==0.3.1
-edx-django-utils==2.0.0   # via edx-drf-extensions
-edx-drf-extensions==2.4.0
+edx-django-utils==2.0.1   # via edx-drf-extensions
+edx-drf-extensions==2.4.2
 edx-lint==1.3.0
 edx-opaque-keys==2.0.0    # via edx-drf-extensions
 edx-rest-api-client==1.9.2
 factory-boy==2.12.0
-faker==2.0.2
-future==0.17.1            # via aws-xray-sdk, pyjwkest, python-jose
+faker==2.0.3
+future==0.18.1            # via aws-xray-sdk, pyjwkest, python-jose
 idna==2.8                 # via moto, requests
-importlib-metadata==0.23  # via pluggy, pytest
+importlib-metadata==0.23  # via jsonschema, pluggy, pytest
 isort[requirements]==4.3.21
-jinja2==2.10.1            # via code-annotations, moto
+jinja2==2.10.3            # via code-annotations, moto
 jmespath==0.9.4           # via boto3, botocore
 jsondiff==1.1.2           # via moto
 jsonpatch==1.24           # via cfn-lint
 jsonpickle==1.2           # via aws-xray-sdk
 jsonpointer==2.0          # via jsonpatch
-jsonschema==3.0.2         # via aws-sam-translator, cfn-lint
+jsonschema==3.1.1         # via aws-sam-translator, cfn-lint
 kombu==3.0.37             # via celery
 lazy-object-proxy==1.4.2  # via astroid
 markupsafe==1.1.1         # via jinja2
@@ -73,12 +72,13 @@ mccabe==0.6.1             # via pylint
 mock==3.0.5
 more-itertools==7.2.0     # via pytest, zipp
 moto==1.3.8
-newrelic==5.0.2.126       # via edx-django-utils
+newrelic==5.2.1.129       # via edx-django-utils
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 packaging==19.2           # via pytest
-pathspec==0.5.9           # via yamllint
+pathlib2==2.3.5           # via pytest
+pathspec==0.6.0           # via yamllint
 pbr==5.4.3                # via stevedore
-pip-api==0.0.12           # via isort
+pip-api==0.0.13           # via isort
 pipreqs==0.4.9            # via isort
 pluggy==0.13.0            # via pytest
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
@@ -96,14 +96,14 @@ pylint==1.7.6             # via edx-lint, pylint-celery, pylint-django, pylint-p
 pymongo==3.9.0            # via edx-opaque-keys
 pyparsing==2.4.2          # via packaging
 pyrsistent==0.15.4        # via jsonschema
-pytest-cov==2.7.1
-pytest-django==3.5.1
-pytest==5.1.3
+pytest-cov==2.8.1
+pytest-django==3.6.0
+pytest==5.2.2
 python-dateutil==2.8.0    # via analytics-python, botocore, edx-drf-extensions, faker, moto
 python-jose==3.0.1        # via moto
-python-slugify==3.0.4     # via code-annotations
+python-slugify==4.0.0     # via code-annotations
 python3-openid==3.1.0     # via social-auth-core
-pytz==2019.2
+pytz==2019.3
 pyyaml==5.1.2             # via cfn-lint, code-annotations, edx-django-release-util, moto, yamllint
 redis==2.8
 requests-oauthlib==1.2.0  # via social-auth-core
@@ -113,7 +113,7 @@ rest-condition==1.0.3     # via edx-drf-extensions
 rsa==4.0                  # via python-jose
 s3transfer==0.2.1         # via boto3
 semantic-version==2.8.2   # via edx-drf-extensions
-six==1.12.0               # via analytics-python, astroid, aws-sam-translator, cfn-lint, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, docker, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-lint, edx-opaque-keys, faker, jsonschema, mock, moto, packaging, pyjwkest, pylint, pyrsistent, python-dateutil, python-jose, responses, social-auth-app-django, social-auth-core, stevedore, websocket-client
+six==1.12.0               # via analytics-python, astroid, aws-sam-translator, cfn-lint, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, docker, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-lint, edx-opaque-keys, faker, jsonschema, mock, moto, packaging, pathlib2, pyjwkest, pylint, pyrsistent, python-dateutil, python-jose, responses, social-auth-app-django, social-auth-core, stevedore, websocket-client
 slumber==0.7.1            # via edx-rest-api-client
 social-auth-app-django==1.2.0  # via edx-auth-backends
 social-auth-core[openidconnect]==1.7.0  # via edx-auth-backends, social-auth-app-django
@@ -125,7 +125,7 @@ websocket-client==0.56.0  # via docker
 werkzeug==0.16.0          # via moto
 wrapt==1.11.2             # via astroid, aws-xray-sdk
 xmltodict==0.12.0         # via moto
-yamllint==1.17.0
+yamllint==1.18.0
 yarg==0.1.9               # via pipreqs
 zipp==0.6.0               # via importlib-metadata
 


### PR DESCRIPTION
@edx/masters-devs 

After fixing travis builds, our `make upgrade` was broken (https://openedx.atlassian.net/browse/EDUCATOR-4760)

This PR simply pins `edx-lint==1.3.0` in `test.in`, which isn't the "right" place, but whatever.

Follow-up to un-pin edx-lint: https://openedx.atlassian.net/browse/EDUCATOR-4764