### PR TITLE
EDUCATOR-4667 Add program type to the DiscoveryProgram cache object

### DIFF
--- a/registrar/apps/common/data.py
+++ b/registrar/apps/common/data.py
@@ -43,6 +43,7 @@ class DiscoveryProgram(object):
         * active_curriculum_uuid (str): UUID-4 of active curriculum.
         * course_runs (list[DiscoveryCourseRun]):
             Flattened list of all course runs in program
+        * program_type (str): The type of the program (Masters, Micromasters, Professional Certificate...)
     """
 
     # If we change the schema of this class, bump the `class_version`
@@ -113,6 +114,7 @@ class DiscoveryProgram(object):
         """
         program_title = program_data.get('title')
         program_url = program_data.get('marketing_url')
+        program_type = program_data.get('type')
         # this make two temporary assumptions (zwh 03/19)
         #  1. one *active* curriculum per program
         #  2. no programs are nested within a curriculum
@@ -132,6 +134,7 @@ class DiscoveryProgram(object):
                 uuid=program_uuid,
                 title=program_title,
                 url=program_url,
+                program_type=program_type,
                 active_curriculum_uuid=None,
                 course_runs=[],
             )
@@ -151,6 +154,7 @@ class DiscoveryProgram(object):
             uuid=program_uuid,
             title=program_title,
             url=program_url,
+            program_type=program_type,
             active_curriculum_uuid=active_curriculum_uuid,
             course_runs=course_runs,
         )

--- a/registrar/apps/common/tests/test_data.py
+++ b/registrar/apps/common/tests/test_data.py
@@ -36,9 +36,11 @@ class GetDiscoveryProgramTestCase(TestCase):
     }
     program_title = "Master's in CS"
     program_url = 'https://stem-institute.edx.org/masters-in-cs'
+    program_type = "Masters"
     programs_response = {
         'title': program_title,
         'marketing_url': program_url,
+        'type': program_type
         'curricula': [{
             'uuid': curriculum_uuid,
             'is_active': True,
@@ -51,6 +53,7 @@ class GetDiscoveryProgramTestCase(TestCase):
         uuid=program_uuid,
         title=program_title,
         url=program_url,
+        program_type=program_type,
         active_curriculum_uuid=curriculum_uuid,
         course_runs=[
             DiscoveryCourseRun(
@@ -72,6 +75,7 @@ class GetDiscoveryProgramTestCase(TestCase):
         self.assertEqual(this_program.uuid, that_program.uuid)
         self.assertEqual(this_program.title, that_program.title)
         self.assertEqual(this_program.url, that_program.url)
+        self.assertEqual(this_program.program_type, that_program.program_type)
         self.assertEqual(this_program.active_curriculum_uuid, that_program.active_curriculum_uuid)
         self.assertEqual(this_program.course_runs, that_program.course_runs)
 
@@ -171,12 +175,14 @@ class DiscoveryProgramTests(TestCase):
         curriculum_uuid = str(uuid.uuid4())
         program_title = "Master's in CS"
         program_url = 'https://stem-institute.edx.org/masters-in-cs'
+        progrma_type = 'Micromasters'
         self.program = DiscoveryProgram(
             version=0,
             loaded=datetime.now(),
             uuid=program_uuid,
             title=program_title,
             url=program_url,
+            program_type=progrma_type,
             active_curriculum_uuid=curriculum_uuid,
             course_runs=[
                 self.make_course_run(i) for i in range(4)

--- a/registrar/apps/common/tests/test_data.py
+++ b/registrar/apps/common/tests/test_data.py
@@ -40,7 +40,7 @@ class GetDiscoveryProgramTestCase(TestCase):
     programs_response = {
         'title': program_title,
         'marketing_url': program_url,
-        'type': program_type
+        'type': program_type,
         'curricula': [{
             'uuid': curriculum_uuid,
             'is_active': True,
@@ -175,14 +175,14 @@ class DiscoveryProgramTests(TestCase):
         curriculum_uuid = str(uuid.uuid4())
         program_title = "Master's in CS"
         program_url = 'https://stem-institute.edx.org/masters-in-cs'
-        progrma_type = 'Micromasters'
+        program_type = 'Micromasters'
         self.program = DiscoveryProgram(
             version=0,
             loaded=datetime.now(),
             uuid=program_uuid,
             title=program_title,
             url=program_url,
-            program_type=progrma_type,
+            program_type=program_type,
             active_curriculum_uuid=curriculum_uuid,
             course_runs=[
                 self.make_course_run(i) for i in range(4)


### PR DESCRIPTION
In registrar program cache, we currently do not cache the program type string. Cache that helps us distinguish Micromasters program with Masters program

EDUCATOR-4667

@edx/masters-devs Please help review
