### PR TITLE
ARCH-1269: upgrade edx-drf-extensions to 2.4.5

### DIFF
--- a/registrar/settings/base.py
+++ b/registrar/settings/base.py
@@ -266,7 +266,6 @@ JWT_AUTH = {
     'JWT_PUBLIC_SIGNING_JWK_SET': None,
     'JWT_AUTH_COOKIE_HEADER_PAYLOAD': 'edx-jwt-cookie-header-payload',
     'JWT_AUTH_COOKIE_SIGNATURE': 'edx-jwt-cookie-signature',
-    'JWT_AUTH_REFRESH_COOKIE': 'edx-jwt-refresh-cookie'
 }
 
 SOCIAL_AUTH_REDIRECT_IS_HTTPS = False

--- a/requirements/devstack.txt
+++ b/requirements/devstack.txt
@@ -52,7 +52,7 @@ ecdsa==0.13.3             # via python-jose
 edx-auth-backends==2.0.2
 edx-django-release-util==0.3.1
 edx-django-utils==2.0.1   # via edx-drf-extensions
-edx-drf-extensions==2.4.2
+edx-drf-extensions==2.4.5
 edx-i18n-tools==0.4.8
 edx-lint==1.3.0
 edx-opaque-keys==2.0.0    # via edx-drf-extensions

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -52,7 +52,7 @@ ecdsa==0.13.3             # via python-jose
 edx-auth-backends==2.0.2
 edx-django-release-util==0.3.1
 edx-django-utils==2.0.1   # via edx-drf-extensions
-edx-drf-extensions==2.4.2
+edx-drf-extensions==2.4.5
 edx-i18n-tools==0.4.8
 edx-lint==1.3.0
 edx-opaque-keys==2.0.0    # via edx-drf-extensions

--- a/requirements/monitoring/requirements.txt
+++ b/requirements/monitoring/requirements.txt
@@ -52,7 +52,7 @@ ecdsa==0.13.3             # via python-jose
 edx-auth-backends==2.0.2
 edx-django-release-util==0.3.1
 edx-django-utils==2.0.1   # via edx-drf-extensions
-edx-drf-extensions==2.4.2
+edx-drf-extensions==2.4.5
 edx-i18n-tools==0.4.8
 edx-lint==1.3.0
 edx-opaque-keys==2.0.0    # via edx-drf-extensions

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -30,7 +30,7 @@ docutils==0.15.2          # via botocore
 edx-auth-backends==2.0.2
 edx-django-release-util==0.3.1
 edx-django-utils==2.0.1   # via edx-drf-extensions
-edx-drf-extensions==2.4.2
+edx-drf-extensions==2.4.5
 edx-opaque-keys==2.0.0    # via edx-drf-extensions
 edx-rest-api-client==1.9.2
 future==0.18.2            # via pyjwkest

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -48,7 +48,7 @@ ecdsa==0.13.3             # via python-jose
 edx-auth-backends==2.0.2
 edx-django-release-util==0.3.1
 edx-django-utils==2.0.1   # via edx-drf-extensions
-edx-drf-extensions==2.4.2
+edx-drf-extensions==2.4.5
 edx-lint==1.3.0
 edx-opaque-keys==2.0.0    # via edx-drf-extensions
 edx-rest-api-client==1.9.2


### PR DESCRIPTION
## Description

- Upgrade edx-drf-extensions to 2.4.5
- Remove unused JWT_AUTH_REFRESH_COOKIE setting.

ARCH-418, ARCH-1269, ARCH-1044