### PR TITLE
Prevent org level enrollment permitted users to access enrollment api for Micromasters programs

### DIFF
--- a/registrar/apps/api/v1/mixins.py
+++ b/registrar/apps/api/v1/mixins.py
@@ -1,6 +1,7 @@
 """
 Mixins for the public V1 REST API.
 """
+import logging
 import uuid
 from collections.abc import Iterable
 
@@ -35,6 +36,7 @@ from registrar.apps.enrollments.data import (
 )
 from registrar.apps.enrollments.models import Program
 
+logger = logging.getLogger(__name__)
 
 upload_filestore = get_filestore(UPLOADS_PATH_PREFIX)
 
@@ -94,7 +96,6 @@ class AuthMixin(TrackViewMixin):
         if self.staff_only and not request.user.is_staff:
             self.add_tracking_data(failure='user_is_not_staff')
             self._unauthorized_response()
-
         required = self.get_required_permissions(request)
         missing_global_permissions = {
             perm for perm in required
@@ -146,7 +147,10 @@ class ProgramSpecificViewMixin(AuthMixin):
         """
         Returns an organization object against which permissions should be checked.
         """
-        return self.program.managing_organization
+        if self.program.program_type == 'Masters':
+            return self.program.managing_organization
+        else:
+            return self.program
 
 
 class CourseSpecificViewMixin(ProgramSpecificViewMixin):

--- a/registrar/apps/api/v1/tests/test_views.py
+++ b/registrar/apps/api/v1/tests/test_views.py
@@ -224,6 +224,7 @@ class ViewMethodNotSupportedTests(RegistrarAPITestCase, AuthRequestMixin):
     def test_not_supported_http_method(self, path, view_name):
         self.mock_logging.reset_mock()
         self.path = path
+        self._add_programs_to_cache()
         response = self.request(self.method, path, self.edx_admin)
         self.mock_logging.error.assert_called_once_with(
             'Segment tracking event name not found for request method %s on view %s',
@@ -767,6 +768,10 @@ class ProgramEnrollmentWriteMixin(object):
         cls.lms_request_url = urljoin(
             settings.LMS_BASE_URL, 'api/program_enrollments/v1/programs/{}/enrollments/'
         ).format(program_uuid)
+    
+    def setUp(self):
+        super().setUp()
+        self._add_programs_to_cache()
 
     def mock_enrollments_response(self, method, expected_response, response_code=200):
         self.mock_api_response(self.lms_request_url, expected_response, method=method, response_code=response_code)

--- a/registrar/apps/core/permissions.py
+++ b/registrar/apps/core/permissions.py
@@ -39,15 +39,6 @@ ORGANIZATION_PERMISSIONS = {
     ORGANIZATION_WRITE_ENROLLMENTS,
 }
 
-# Non-prefixed names of program data read permissions
-PROGRAM_READ_DATA_KEY = 'program_read_data'
-
-# A user with this permission can read program data report associated
-# with the program. This permission do not allow program enrollments
-# nor program course enrollment reads or writes
-PROGRAM_READ_DATA = APP_PREFIX + PROGRAM_READ_DATA_KEY
-
-
 # A user with this permission can view the status of all jobs.
 # A user without it can only view their own.
 # This permission should be reserved for edX staff.

--- a/registrar/apps/core/permissions.py
+++ b/registrar/apps/core/permissions.py
@@ -39,6 +39,14 @@ ORGANIZATION_PERMISSIONS = {
     ORGANIZATION_WRITE_ENROLLMENTS,
 }
 
+# Non-prefixed names of program data read permissions
+PROGRAM_READ_DATA_KEY = 'program_read_data'
+
+# A user with this permission can read program data report associated
+# with the program. This permission do not allow program enrollments
+# nor program course enrollment reads or writes
+PROGRAM_READ_DATA = APP_PREFIX + PROGRAM_READ_DATA_KEY
+
 
 # A user with this permission can view the status of all jobs.
 # A user without it can only view their own.

--- a/registrar/apps/enrollments/permissions.py
+++ b/registrar/apps/enrollments/permissions.py
@@ -12,53 +12,11 @@ PROGRAM_READ_ENROLLMENTS_KEY = 'program_read_enrollments'
 # Non-prefixed names of program enrollment write permissions
 PROGRAM_WRITE_ENROLLMENTS_KEY = 'program_write_enrollments'
 
-# A user with this permission can read program data report associated
-# with the program. This permission do not allow program enrollments
-# nor program course enrollment reads or writes
+# These permissions should not be assigned to any use on Registrar.
+# These are the permissions we created to prevent any users from accessing
+# the enrollments reports on Micromasters programs. Registrar right now
+# does not facilitate the enrollments of Micromasters programs, hence
+# there is no enrollment mechanism that is valid associated with Micromasters
+# programs. No user should have the permissions below
 PROGRAM_READ_ENROLLMENTS = APP_PREFIX + PROGRAM_READ_ENROLLMENTS_KEY
 PROGRAM_WRITE_ENROLLMENTS = APP_PREFIX + PROGRAM_WRITE_ENROLLMENTS_KEY
-
-
-
-
-class ProgramRole(object):
-    """
-    A collection of Program permissions that can be assigned
-    to a Group or ProgramGroup.
-    """
-
-    name = None
-    description = None
-    permissions = ()
-
-    @classmethod
-    def assign_to_group(cls, group, program):
-        """
-        For the given program, assigns all permissions under this role
-        to the given group.
-        """
-        for permission in cls.permissions:
-            assign_perm(permission, group, program)
-
-
-class ProgramReadEnrollmentsRole(ProgramRole):
-    """
-    The least-privileged program-scoped role, it may only
-    read enrollments about a program and its courses.
-    """
-    name = 'program_read_enrollments'
-    description = 'Read Enrollments Only'
-    permissions = (
-        PROGRAM_READ_ENROLLMENTS,
-    )
-
-class ProgramReadWriteEnrollmentsRole(ProgramRole):
-    """
-    The read and write privileged program-scoped role, it may read
-    and write enrollments about a program and its courses.
-    """
-    name = 'program_read_write_enrollments'
-    description = 'Read and Write Enrollments'
-    permissions = (
-        PROGRAM_READ_ENROLLMENTS, PROGRAM_WRITE_ENROLLMENTS,
-    )

--- a/registrar/apps/enrollments/permissions.py
+++ b/registrar/apps/enrollments/permissions.py
@@ -1,0 +1,64 @@
+"""
+This module defines constants for permission codenames
+and sets of permissions that can be used as roles.
+"""
+from guardian.shortcuts import assign_perm
+
+APP_PREFIX = 'enrollments.'
+
+# Non-prefixed names of program enrollment read permissions
+PROGRAM_READ_ENROLLMENTS_KEY = 'program_read_enrollments'
+
+# Non-prefixed names of program enrollment write permissions
+PROGRAM_WRITE_ENROLLMENTS_KEY = 'program_write_enrollments'
+
+# A user with this permission can read program data report associated
+# with the program. This permission do not allow program enrollments
+# nor program course enrollment reads or writes
+PROGRAM_READ_ENROLLMENTS = APP_PREFIX + PROGRAM_READ_ENROLLMENTS_KEY
+PROGRAM_WRITE_ENROLLMENTS = APP_PREFIX + PROGRAM_WRITE_ENROLLMENTS_KEY
+
+
+
+
+class ProgramRole(object):
+    """
+    A collection of Program permissions that can be assigned
+    to a Group or ProgramGroup.
+    """
+
+    name = None
+    description = None
+    permissions = ()
+
+    @classmethod
+    def assign_to_group(cls, group, program):
+        """
+        For the given program, assigns all permissions under this role
+        to the given group.
+        """
+        for permission in cls.permissions:
+            assign_perm(permission, group, program)
+
+
+class ProgramReadEnrollmentsRole(ProgramRole):
+    """
+    The least-privileged program-scoped role, it may only
+    read enrollments about a program and its courses.
+    """
+    name = 'program_read_enrollments'
+    description = 'Read Enrollments Only'
+    permissions = (
+        PROGRAM_READ_ENROLLMENTS,
+    )
+
+class ProgramReadWriteEnrollmentsRole(ProgramRole):
+    """
+    The read and write privileged program-scoped role, it may read
+    and write enrollments about a program and its courses.
+    """
+    name = 'program_read_write_enrollments'
+    description = 'Read and Write Enrollments'
+    permissions = (
+        PROGRAM_READ_ENROLLMENTS, PROGRAM_WRITE_ENROLLMENTS,
+    )


### PR DESCRIPTION
## Description
Currently, we have quite a few users on registrar who can read and write the enrollments associated with programs within an organization. However, we should deny any user trying to access enrollment apis for those Micromasters programs.