### PR TITLE
Do not allow enrollments API endpoints to be accessed for non-degree programs

### DIFF
--- a/registrar/apps/api/v1/mixins.py
+++ b/registrar/apps/api/v1/mixins.py
@@ -231,6 +231,7 @@ class EnrollmentMixin(ProgramSpecificViewMixin):
     """
     This mixin defines the required permissions
     for any views that read or write program/course enrollment data.
+    Overrides AuthMixin.check_permissions.
     """
     def get_required_permissions(self, request):
         if request.method == 'GET':
@@ -238,6 +239,17 @@ class EnrollmentMixin(ProgramSpecificViewMixin):
         if request.method == 'POST' or self.request.method == 'PATCH':
             return [perms.ORGANIZATION_WRITE_ENROLLMENTS]
         return []  # pragma: no cover
+
+    def check_permissions(self, request):
+        if not self.program.is_enrollment_enabled:
+            # Raise exception if the program (MM at the moment) is not
+            # available for enrollments related API endpoints
+            raise PermissionDenied(
+                'Cannot access enrollment endpoints with program [%s] whose enrollments are disabled',
+                self.program.key
+            )
+
+        super().check_permissions(request)
 
     def handle_enrollments(self, course_id=None):
         """

--- a/registrar/apps/enrollments/models.py
+++ b/registrar/apps/enrollments/models.py
@@ -37,6 +37,10 @@ class Program(TimeStampedModel):
     def program_type(self):
         return self._get_cached_field('program_type')
 
+    @property
+    def is_enrollment_enabled(self):
+        return self.program_type == 'Masters'
+
     def _get_cached_field(self, field):
         """
         Returns the specified field from a cached Discovery program.


### PR DESCRIPTION
## Description
Currently, we have quite a few users on registrar who can read and write the enrollments associated with programs within an organization. However, we should deny any user trying to access enrollment apis for those Micromasters programs.