### PR TITLE
Add authorization checks to the CSV upload to write enrollments endpoints

### DIFF
--- a/registrar/apps/api/v1/tests/test_views.py
+++ b/registrar/apps/api/v1/tests/test_views.py
@@ -1804,7 +1804,7 @@ class EnrollmentUploadMixin(object):
             settings.LMS_BASE_URL, 'api/program_enrollments/v1/programs/{}/enrollments/'
         ).format(program_uuid)
 
-    def _upload_enrollments(self, enrollments, user=None):
+    def _upload_enrollments(self, enrollments, user=None):   # pylint: disable=missing-docstring
         upload_file = StringIO(
             serialize_to_csv(enrollments, self.csv_headers, include_headers=True)
         )

--- a/registrar/apps/api/v1/views.py
+++ b/registrar/apps/api/v1/views.py
@@ -452,7 +452,7 @@ class EnrollmentUploadView(JobInvokerMixin, APIView):
         return self.invoke_upload_job(self.task_fn, json.dumps(enrollments), *args, **kwargs)
 
 
-class ProgramEnrollmentUploadView(ProgramSpecificViewMixin, EnrollmentUploadView):
+class ProgramEnrollmentUploadView(EnrollmentMixin, EnrollmentUploadView):
     """
     A view for uploading program enrollments via csv file
 
@@ -464,7 +464,7 @@ class ProgramEnrollmentUploadView(ProgramSpecificViewMixin, EnrollmentUploadView
     event_parameter_map = {'program_key': 'program_key'}
 
 
-class CourseRunEnrollmentUploadView(ProgramSpecificViewMixin, EnrollmentUploadView):
+class CourseRunEnrollmentUploadView(EnrollmentMixin, CourseSpecificViewMixin, EnrollmentUploadView):
     """
     A view for uploading course enrollments via csv file
 


### PR DESCRIPTION
## Description
Thanks to @kdmccormick, it is realized that our CSV upload endpoints do not have authorization checks in place.
Use this PR to properly put those checks in place to make sure the CSV upload endpoints are properly protected.

@edx/masters-devs Please help review