### PR TITLE
Refactor filestore to handle multiple buckets

### DIFF
--- a/registrar/apps/api/v1/mixins.py
+++ b/registrar/apps/api/v1/mixins.py
@@ -26,8 +26,7 @@ from registrar.apps.api.mixins import TrackViewMixin
 from registrar.apps.api.serializers import JobAcceptanceSerializer
 from registrar.apps.api.utils import build_absolute_api_url
 from registrar.apps.core import permissions as perms
-from registrar.apps.core.constants import UPLOADS_PATH_PREFIX
-from registrar.apps.core.filestore import get_filestore
+from registrar.apps.core.filestore import get_enrollment_uploads_filestore
 from registrar.apps.core.jobs import start_job
 from registrar.apps.core.models import Program
 from registrar.apps.enrollments.data import (
@@ -36,7 +35,7 @@ from registrar.apps.enrollments.data import (
 )
 
 
-upload_filestore = get_filestore(UPLOADS_PATH_PREFIX)
+upload_filestore = get_enrollment_uploads_filestore()
 
 
 class AuthMixin(TrackViewMixin):

--- a/registrar/apps/api/v1/tests/test_views.py
+++ b/registrar/apps/api/v1/tests/test_views.py
@@ -619,8 +619,8 @@ class ProgramCourseListViewTests(RegistrarAPITestCase, AuthRequestMixin):
     event = 'registrar.v1.get_program_courses'
 
     program_uuid = str(uuid.uuid4())
-    program_title = Faker().sentence(nb_words=6)  # pylint: disable=no-member
-    program_url = Faker().uri()  # pylint: disable=no-member
+    program_title = Faker().sentence(nb_words=6)
+    program_url = Faker().uri()
     program_type = 'Masters'
 
     @ddt.data(True, False)
@@ -1403,7 +1403,7 @@ class JobStatusRetrieveViewTests(S3MockMixin, RegistrarAPITestCase, AuthRequestM
 @shared_task(base=UserTask, bind=True)
 def _succeeding_job(self, job_id, user_id, *args, **kwargs):  # pylint: disable=unused-argument
     """ A job that just succeeds, posting an empty JSON list as its result. """
-    fake_data = Faker().pystruct(20, str, int, bool)  # pylint: disable=no-member
+    fake_data = Faker().pystruct(20, str, int, bool)
     post_job_success(job_id, json.dumps(fake_data), 'json')
 
 

--- a/registrar/apps/common/tasks.py
+++ b/registrar/apps/common/tasks.py
@@ -6,14 +6,11 @@ from celery.utils.log import get_task_logger
 from user_tasks.models import UserTaskArtifact
 from user_tasks.tasks import UserTask
 
-from registrar.apps.core.constants import UPLOADS_PATH_PREFIX
-from registrar.apps.core.filestore import get_filestore
 from registrar.apps.core.jobs import post_job_failure
 from registrar.apps.core.models import Program
 
 
 log = get_task_logger(__name__)
-uploads_filestore = get_filestore(UPLOADS_PATH_PREFIX)
 
 # pylint: disable=unused-argument
 @shared_task(bind=True)

--- a/registrar/apps/core/constants.py
+++ b/registrar/apps/core/constants.py
@@ -26,7 +26,4 @@ PROGRAM_KEY_PATTERN = r'(?P<program_key>[A-Za-z0-9-_]+)'
 # jobs.get_job_status anyway, so it's not necessary.
 JOB_ID_PATTERN = r'(?P<job_id>[0-9a-f-]+)'
 
-JOB_RESULT_PATH_PREFIX = "job-results"
-UPLOADS_PATH_PREFIX = "uploads"
-
 ORGANIZATION_KEY_PATTERN = r'[A-Za-z0-9-_]+'

--- a/registrar/apps/core/jobs.py
+++ b/registrar/apps/core/jobs.py
@@ -19,8 +19,7 @@ from collections import namedtuple
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from user_tasks.models import UserTaskArtifact, UserTaskStatus
 
-from registrar.apps.core.constants import JOB_RESULT_PATH_PREFIX
-from registrar.apps.core.filestore import get_filestore
+from registrar.apps.core.filestore import get_job_results_filestore
 from registrar.apps.core.permissions import JOB_GLOBAL_READ
 
 
@@ -30,7 +29,7 @@ JobStatus = namedtuple(
 )
 
 logger = logging.getLogger(__name__)
-result_filestore = get_filestore(JOB_RESULT_PATH_PREFIX)
+result_filestore = get_job_results_filestore()
 
 _RESULT_ARTIFACT_NAME = 'Job Result'
 

--- a/registrar/apps/enrollments/tasks.py
+++ b/registrar/apps/enrollments/tasks.py
@@ -11,8 +11,7 @@ from rest_framework.exceptions import ValidationError
 from user_tasks.tasks import UserTask
 
 from registrar.apps.common.tasks import _get_program
-from registrar.apps.core.constants import UPLOADS_PATH_PREFIX
-from registrar.apps.core.filestore import get_filestore
+from registrar.apps.core.filestore import get_enrollment_uploads_filestore
 from registrar.apps.core.jobs import post_job_failure, post_job_success
 from registrar.apps.core.utils import serialize_to_csv
 from registrar.apps.enrollments import data
@@ -29,7 +28,7 @@ from registrar.apps.enrollments.utils import build_enrollment_job_status_name
 
 
 log = get_task_logger(__name__)
-uploads_filestore = get_filestore(UPLOADS_PATH_PREFIX)
+uploads_filestore = get_enrollment_uploads_filestore()
 
 
 class EnrollmentReadTask(UserTask):

--- a/registrar/apps/enrollments/tests/test_tasks.py
+++ b/registrar/apps/enrollments/tests/test_tasks.py
@@ -16,8 +16,7 @@ from rest_framework.exceptions import ValidationError
 
 from registrar.apps.common.data import DiscoveryCourseRun, DiscoveryProgram
 from registrar.apps.common.tests.mixins import BaseTaskTestMixin
-from registrar.apps.core.constants import UPLOADS_PATH_PREFIX
-from registrar.apps.core.filestore import get_filestore
+from registrar.apps.core.filestore import get_enrollment_uploads_filestore
 from registrar.apps.core.models import Program
 from registrar.apps.enrollments import tasks
 from registrar.apps.enrollments.constants import (
@@ -32,7 +31,7 @@ FakeRequest = namedtuple('FakeRequest', ['url'])
 FakeResponse = namedtuple('FakeResponse', ['status_code'])
 
 
-uploads_filestore = get_filestore(UPLOADS_PATH_PREFIX)
+uploads_filestore = get_enrollment_uploads_filestore()
 
 
 class BaseEnrollmentTaskTestMixin(BaseTaskTestMixin):
@@ -210,7 +209,7 @@ class WriteEnrollmentTaskTestMixin(BaseEnrollmentTaskTestMixin):
         cls._s3_mock = moto.mock_s3()
         cls._s3_mock.start()
         conn = boto3.resource('s3')
-        conn.create_bucket(Bucket=settings.AWS_STORAGE_BUCKET_NAME)
+        conn.create_bucket(Bucket=settings.REGISTRAR_BUCKET)
 
     @classmethod
     def tearDownClass(cls):

--- a/registrar/settings/base.py
+++ b/registrar/settings/base.py
@@ -177,6 +177,8 @@ LOCALE_PATHS = (
 MEDIA_ROOT = root('media')
 MEDIA_URL = '/api/media/'
 DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
+REGISTRAR_BUCKET = 'registrar'
+PROGRAM_REPORTS_BUCKET = 'program-reports'
 
 # STATIC FILE CONFIGURATION
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#static-root
@@ -313,3 +315,4 @@ CACHES = {
 EDX_DRF_EXTENSIONS = {
     "OAUTH2_USER_INFO_URL": "http://127.0.0.1:8000/oauth2/user_info"
 }
+

--- a/registrar/settings/test.py
+++ b/registrar/settings/test.py
@@ -38,11 +38,12 @@ CELERY_IGNORE_RESULT = True
 
 # Media
 DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
-AWS_STORAGE_BUCKET_NAME = 'registrar-test'
 AWS_LOCATION = ''
 AWS_QUERYSTRING_AUTH = True
 AWS_QUERYSTRING_EXPIRE = 3600
 AWS_DEFAULT_ACL = None
+REGISTRAR_BUCKET = 'registrar-test'
+PROGRAM_REPORTS_BUCKET = 'program-reports-test'
 
 # Publicly-exposed base URLs for service and API, respectively
 API_ROOT = 'http://localhost/api'


### PR DESCRIPTION
## Description

When thinking about how to provide URLs to program reports, I realized that Registrar now needs to support reading from more than one bucket.

We currently use [Django Storages](https://django-storages.readthedocs.io/en/latest/) to interact with S3 using `S3Boto3Storage`, and we use its `FileSystemStorage` class for local development. That library supports multiple S3 buckets.

However, we wrap references to Django storages in an abstraction called `filestore`, which exists to handle some discrepancies with how download URLs are generated. `filestore` was designed with the assumption that there would only be one S3 bucket.

The aim of this PR is to make `filestore` work well with multiple buckets. Additionally, for local development, it would simulate having multiple buckets by putting each "bucket's" contents in a different folder.

## Meta
@edx/masters-devs 
Blocked by https://github.com/edx/edx-internal/pull/1348
Ticket: https://openedx.atlassian.net/browse/MST-58