### PR TITLE
Pin the library django-model-utils to older version

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -10,3 +10,4 @@
 
 # These packages are pinned because their next version would require django 2.0.0
 django-guardian==2.0.0
+django-model-utils<4.0.0


### PR DESCRIPTION
The new version for library django-model-utils 4.0.0 requires django 2.0 or above. This causes failure when trying to upgrade request of the libraries requirements. Fix this by pinning django-model-utils to version less than 4.0.0

@edx/masters-devs 