### PR TITLE
Add logging when filestore operations fail

### DIFF
--- a/registrar/apps/core/models.py
+++ b/registrar/apps/core/models.py
@@ -122,6 +122,8 @@ class OrganizationGroup(Group):
 
     .. no_pii::
     """
+    objects = models.Manager()
+
     class Meta(object):
         app_label = 'core'
         verbose_name = 'Organization Group'


### PR DESCRIPTION
#219 is bugged. If you try to download or upload enrollments on Stage, the job fails. Looking at Splunk, an AccessDenied is happening when trying to save to S3. I'm thinking that the bucket name might be misconfigured.

This PR adds logging to help diagnose it.

**Bonus:** Fixes our only RemoveInDjango20Warning