### PR TITLE
Add workaround for pylint crash when using freeze_time

### DIFF
--- a/registrar/apps/api/v1/tests/test_views.py
+++ b/registrar/apps/api/v1/tests/test_views.py
@@ -16,7 +16,6 @@ from django.conf import settings
 from django.core.cache import cache
 from django.urls import reverse
 from faker import Faker
-from freezegun import freeze_time
 from guardian.shortcuts import assign_perm
 from rest_framework.test import APITestCase
 from user_tasks.models import UserTaskStatus
@@ -55,6 +54,7 @@ from registrar.apps.core.tests.factories import (
     ProgramOrganizationGroupFactory,
     UserFactory,
 )
+from registrar.apps.core.tests.freezegun_wrapper import freeze_time
 from registrar.apps.core.tests.utils import mock_oauth_login
 from registrar.apps.core.utils import serialize_to_csv
 from registrar.apps.enrollments.data import (

--- a/registrar/apps/core/tests/freezegun_wrapper.py
+++ b/registrar/apps/core/tests/freezegun_wrapper.py
@@ -1,0 +1,23 @@
+# pylint: skip-file
+
+import freezegun
+
+
+def freeze_time(*args, **kwargs):
+    """
+    Work around bug in pylint/pylint_django.
+
+    Some package in the Pylint ecosystem has an unresolved bug
+    (https://github.com/PyCQA/pylint-django/issues/105)
+    that makes pylint crash whenever we use `freezegun.freeze_time`.
+
+    My understanding is that something goes wrong when trying
+    to infer the type of the `@freezegun.freeze_time` decorator.
+    Having this wrapper function in a pylint-skipped file
+    seems to stop the crash from happening,
+    possibly by avoiding type inference on `@freezegun.freeze_time`.
+
+    This `@freeze_time` function can be used exactly like
+    the original `@freezegun.freeze_time` decorator.
+    """
+    return freezegun.freeze_time(*args, **kwargs)


### PR DESCRIPTION
@MichaelRoytman On my computer, this seems to successfully work around the pylint crash -- let's see if it's the same on Travis.

For PR #226 