### PR TITLE
Expose Program Permissions

### DIFF
--- a/registrar/apps/api/constants.py
+++ b/registrar/apps/api/constants.py
@@ -9,7 +9,8 @@ UPLOAD_FILE_MAX_SIZE = 5 * 1024 * 1024
 
 TRACKING_CATEGORY = 'Registrar API'
 
-PERMISSION_QUERY_PARAM_MAP = {
+# To be deprecated with upcoming program manager changes (01/2020)
+LEGACY_PERMISSION_QUERY_PARAMS = {
     'metadata': perms.APIReadMetadataPermission,
     'read': perms.APIReadEnrollmentsPermission,
     'write': perms.APIWriteEnrollmentsPermission,

--- a/registrar/apps/api/serializers.py
+++ b/registrar/apps/api/serializers.py
@@ -38,7 +38,7 @@ class ProgramSerializer(serializers.ModelSerializer):
             ).union(
                 get_user_api_permissions(user, program.managing_organization)
             )
-            return [permission.name for permission in user_permissions]
+            return sorted([permission.name for permission in user_permissions])
         else:
             return []
 

--- a/registrar/apps/api/serializers.py
+++ b/registrar/apps/api/serializers.py
@@ -4,9 +4,7 @@ should be created here. As the API evolves, serializers may become more
 specific to a particular version of the API. In this case, the serializers
 in question should be moved to versioned sub-package.
 """
-from guardian.shortcuts import get_perms
 from rest_framework import serializers
-from rest_framework.fields import CurrentUserDefault
 from user_tasks.models import UserTaskStatus
 
 from registrar.apps.core.models import Program
@@ -35,7 +33,11 @@ class ProgramSerializer(serializers.ModelSerializer):
         request = self.context.get('request')
         if request and hasattr(request, 'user'):
             user = request.user
-            user_permissions = get_user_api_permissions(user, program).union(get_user_api_permissions(user, program.managing_organization))
+            user_permissions = get_user_api_permissions(
+                user, program
+            ).union(
+                get_user_api_permissions(user, program.managing_organization)
+            )
             return [permission.name for permission in user_permissions]
         else:
             return []

--- a/registrar/apps/api/serializers.py
+++ b/registrar/apps/api/serializers.py
@@ -38,7 +38,7 @@ class ProgramSerializer(serializers.ModelSerializer):
             ).union(
                 get_user_api_permissions(user, program.managing_organization)
             )
-            return sorted([permission.name for permission in user_permissions])
+            return sorted(permission.name for permission in user_permissions)
         else:
             return []
 

--- a/registrar/apps/api/tests/test_serializers.py
+++ b/registrar/apps/api/tests/test_serializers.py
@@ -49,7 +49,7 @@ class ProgramSerializerTests(TestCase):
     def test_get_user_permissions(self, fake_get_perms):
         """
         Program permissions should be populated with the union of all
-        assingned at that program or its managing organization
+        permissions assigned at that program and its managing organization
         """
         fake_get_perms.side_effect = [
             set([APIWriteEnrollmentsPermission]),  # mocked permissions on program

--- a/registrar/apps/api/tests/test_serializers.py
+++ b/registrar/apps/api/tests/test_serializers.py
@@ -1,0 +1,75 @@
+""" Test API Serializers """
+import mock
+from django.contrib.auth.models import AnonymousUser
+from django.core.cache import cache
+from django.test import TestCase
+from django.test.client import RequestFactory
+
+from registrar.apps.api.serializers import ProgramSerializer
+from registrar.apps.common.constants import PROGRAM_CACHE_KEY_TPL
+from registrar.apps.common.data import DiscoveryProgram
+from registrar.apps.core.permissions import (
+    APIReadMetadataPermission,
+    APIWriteEnrollmentsPermission,
+)
+from registrar.apps.core.tests.factories import (
+    OrganizationFactory,
+    ProgramFactory,
+)
+
+
+class ProgramSerializerTests(TestCase):
+    """ Tests the ProgramSerializer """
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.org = OrganizationFactory()
+        cls.program = ProgramFactory(managing_organization=cls.org)
+
+        cls.request = RequestFactory().get('/api/v1/programs')
+        cls.request.user = AnonymousUser()
+
+    def setUp(self):
+        super().setUp()
+
+        cache.set(
+            PROGRAM_CACHE_KEY_TPL.format(uuid=self.program.discovery_uuid),
+            DiscoveryProgram.from_json(
+                self.program.discovery_uuid,
+                {
+                    'title': 'test-program',
+                    'type': 'masters',
+                    'curricula': [],
+                }
+            )
+        )
+
+    @mock.patch('registrar.apps.api.serializers.get_user_api_permissions')
+    def test_get_user_permissions(self, fake_get_perms):
+        """
+        Program permissions should be populated with the union of all
+        assingned at that program or its managing organization
+        """
+        fake_get_perms.side_effect = [
+            set([APIWriteEnrollmentsPermission]),  # mocked permissions on program
+            set([APIReadMetadataPermission]),  # mocked permissions on org
+        ]
+        program = ProgramSerializer(
+            self.program,
+            context={
+                'request': self.request
+            }
+        ).data
+        self.assertListEqual(
+            program.get('permissions'),
+            [APIReadMetadataPermission.name, APIWriteEnrollmentsPermission.name]
+        )
+
+    def test_permissions_no_request_context(self):
+        """
+        Serializer should return an empty list for permissions if invoked
+        without a request context
+        """
+        program = ProgramSerializer(self.program).data
+        self.assertListEqual(program.get('permissions'), [])

--- a/registrar/apps/api/v1/tests/test_views.py
+++ b/registrar/apps/api/v1/tests/test_views.py
@@ -44,6 +44,7 @@ from registrar.apps.core.models import (
     Organization,
     OrganizationGroup,
     ProgramOrganizationGroup,
+    User,
 )
 from registrar.apps.core.permissions import JOB_GLOBAL_READ
 from registrar.apps.core.tests.factories import (
@@ -149,9 +150,9 @@ class RegistrarAPITestCase(TrackTestMixin, APITestCase):
         cls.hum_admin.groups.add(cls.hum_admin_group)  # pylint: disable=no-member
         cls.hum_admin.groups.add(cls.hum_data_op_group)  # pylint: disable=no-member
 
-        cls.program_user = UserFactory(username='program-admin')
+        cls.program_user = UserFactory(username='english-program-user')
         cls.program_group = ProgramOrganizationGroupFactory(
-            name='program-users',
+            name='english-program-users',
             program=cls.english_program,
             role=perms.ProgramReadMetadataRole.name
         )
@@ -286,24 +287,28 @@ class ProgramListViewTests(RegistrarAPITestCase, AuthRequestMixin):
                     'program_title': 'masters in cs',
                     'program_url': 'http://registrar-test-data.edx.org/masters-in-cs/',
                     'program_type': 'Masters',
+                    'permissions': ['read_metadata'],
                 },
                 {
                     'program_key': 'masters-in-english',
                     'program_title': 'masters in english',
                     'program_url': 'http://registrar-test-data.edx.org/masters-in-english/',
                     'program_type': 'Masters',
+                    'permissions': ['read_metadata'],
                 },
                 {
                     'program_key': 'masters-in-me',
                     'program_title': 'masters in me',
                     'program_url': 'http://registrar-test-data.edx.org/masters-in-me/',
                     'program_type': 'Masters',
+                    'permissions': ['read_metadata'],
                 },
                 {
                     'program_key': 'masters-in-philosophy',
                     'program_title': 'masters in philosophy',
                     'program_url': 'http://registrar-test-data.edx.org/masters-in-philosophy/',
                     'program_type': 'Masters',
+                    'permissions': ['read_metadata'],
                 },
             ]
         )
@@ -322,6 +327,7 @@ class ProgramListViewTests(RegistrarAPITestCase, AuthRequestMixin):
                     'program_title': 'masters in english',
                     'program_url': 'http://registrar-test-data.edx.org/masters-in-english/',
                     'program_type': 'Masters',
+                    'permissions': ['read_metadata'],
                 }
             ]
         )
@@ -349,7 +355,7 @@ class ProgramListViewTests(RegistrarAPITestCase, AuthRequestMixin):
         # If you use only an org filter, and you only have access to one program in that org,
         # then you get only that program.
         {
-            'groups': {'program-users'},
+            'groups': {'english-program-users'},
             'org_filter': 'humanities-college',
             'expect_hum_program': True,
             'test_program_group': True,
@@ -359,43 +365,49 @@ class ProgramListViewTests(RegistrarAPITestCase, AuthRequestMixin):
         # the programs you have access to (which may be an empty list).
         {
             'groups': set(),
-            'perm_filter': 'metadata',
+            'perm_filter': 'read_metadata',
         },
         {
             'groups': set(),
-            'perm_filter': 'read',
+            'perm_filter': 'read_enrollments',
         },
         {
             'groups': set(),
-            'perm_filter': 'write',
+            'perm_filter': 'write_enrollments',
         },
         {
             'groups': set(),
-            'perm_filter': 'write',
+            'perm_filter': 'write_enrollments',
             'global_perm': True,
             'expect_stem_programs': True,
             'expect_hum_programs': True,
         },
         {
             'groups': {'stem-users', 'hum-ops'},
-            'perm_filter': 'write',
+            'perm_filter': 'write_enrollments',
         },
         {
             'groups': {'stem-admins', 'hum-ops'},
-            'perm_filter': 'write',
+            'perm_filter': 'write_enrollments',
             'expect_stem_programs': True,
         },
         {
             'groups': {'stem-admins', 'hum-ops'},
-            'perm_filter': 'read',
+            'perm_filter': 'read_enrollments',
             'expect_stem_programs': True,
             'expect_hum_programs': True,
         },
         {
             'groups': {'hum-admins', 'hum-users'},
-            'perm_filter': 'write',
+            'perm_filter': 'write_enrollments',
             'expect_hum_programs': True,
         },
+        {
+            'groups': {'hum-admins', 'hum-users'},
+            'perm_filter': 'read_metadata',
+            'expect_hum_programs': True,
+        },
+        # Validate old permissions filter (to be deprecated)
         {
             'groups': {'hum-admins', 'hum-users'},
             'perm_filter': 'metadata',
@@ -405,19 +417,19 @@ class ProgramListViewTests(RegistrarAPITestCase, AuthRequestMixin):
         # Finally, the filters may be combined
         {
             'groups': {'stem-admins', 'hum-ops'},
-            'perm_filter': 'read',
+            'perm_filter': 'read_enrollments',
             'org_filter': 'humanities-college',
             'expect_hum_programs': True,
         },
         {
             'groups': {'stem-admins', 'hum-ops'},
-            'perm_filter': 'write',
+            'perm_filter': 'write_enrollments',
             'org_filter': 'stem-institute',
             'expect_stem_programs': True,
         },
         {
             'groups': {'stem-admins', 'hum-ops'},
-            'perm_filter': 'write',
+            'perm_filter': 'write_enrollments',
             'org_filter': 'humanities-college',
         },
     )
@@ -481,7 +493,7 @@ class ProgramListViewTests(RegistrarAPITestCase, AuthRequestMixin):
     @ddt.data(
         {
             'groups': set(),
-            'perm_filter': 'write',
+            'perm_filter': 'write_enrollments',
             'expected_programs': {
                 'masters-in-cs',
                 'masters-in-me',
@@ -491,7 +503,7 @@ class ProgramListViewTests(RegistrarAPITestCase, AuthRequestMixin):
         },
         {
             'groups': set(),
-            'perm_filter': 'read',
+            'perm_filter': 'read_enrollments',
             'expected_programs': {
                 'masters-in-cs',
                 'masters-in-me',
@@ -501,7 +513,7 @@ class ProgramListViewTests(RegistrarAPITestCase, AuthRequestMixin):
         },
         {
             'groups': set(),
-            'perm_filter': 'metadata',
+            'perm_filter': 'read_metadata',
             'expected_programs': {
                 'masters-in-cs',
                 'masters-in-me',
@@ -512,17 +524,17 @@ class ProgramListViewTests(RegistrarAPITestCase, AuthRequestMixin):
         },
         {
             'groups': {'hum-admins'},
-            'perm_filter': 'write',
+            'perm_filter': 'write_enrollments',
             'expected_programs': {'masters-in-philosophy'},
         },
         {
             'groups': {'hum-ops'},
-            'perm_filter': 'read',
+            'perm_filter': 'read_enrollments',
             'expected_programs': {'masters-in-philosophy'},
         },
         {
             'groups': {'hum-users'},
-            'perm_filter': 'metadata',
+            'perm_filter': 'read_metadata',
             'expected_programs': {'masters-in-english', 'masters-in-philosophy'},
         },
     )
@@ -555,7 +567,7 @@ class ProgramListViewTests(RegistrarAPITestCase, AuthRequestMixin):
         # Bad org filter, no perm filter
         ('intergalactic-univ', None, 'org_not_found'),
         # Bad org filter, good perm filter
-        ('intergalactic-univ', 'write', 'org_not_found'),
+        ('intergalactic-univ', 'write_enrollments', 'org_not_found'),
         # No org filter, bad perm filter
         (None, 'right', 'no_such_perm'),
         # Good org filter, bad perm filter
@@ -605,12 +617,23 @@ class ProgramRetrieveViewTests(RegistrarAPITestCase, AuthRequestMixin):
     path = 'programs/masters-in-english'
     event = 'registrar.v1.get_program_detail'
 
-    @ddt.data(True, False)
-    def test_get_program(self, is_staff):
-        user = self.edx_admin if is_staff else self.hum_admin
+    @ddt.data(
+        ('edx-admin', ['read_metadata']),
+        ('english-program-user', ['read_metadata']),
+        ('humanities-college-admin', [
+            'read_metadata',
+            'read_enrollments',
+            'write_enrollments',
+        ]),
+    )
+    @ddt.unpack
+    def test_get_program(self, username, api_permissions):
+        user = User.objects.get(username=username)
         with self.assert_tracking(user=user, program_key='masters-in-english'):
             response = self.get('programs/masters-in-english', user)
         self.assertEqual(response.status_code, 200)
+        response.data['permissions'] = sorted(response.data['permissions'])
+        api_permissions = sorted(api_permissions)
         self.assertDictEqual(
             response.data,
             {
@@ -618,6 +641,7 @@ class ProgramRetrieveViewTests(RegistrarAPITestCase, AuthRequestMixin):
                 'program_title': 'masters in english',
                 'program_url': 'http://registrar-test-data.edx.org/masters-in-english/',
                 'program_type': 'Masters',
+                'permissions': api_permissions,
             },
         )
 

--- a/registrar/apps/api/v1/tests/test_views.py
+++ b/registrar/apps/api/v1/tests/test_views.py
@@ -622,6 +622,7 @@ class ProgramRetrieveViewTests(RegistrarAPITestCase, AuthRequestMixin):
         ('english-program-user', ['read_metadata']),
         ('humanities-college-admin', [
             'read_metadata',
+            'read_reports',
             'read_enrollments',
             'write_enrollments',
         ]),

--- a/registrar/apps/api/v1/views.py
+++ b/registrar/apps/api/v1/views.py
@@ -592,7 +592,7 @@ class ReportsListView(ProgramSpecificViewMixin, APIView):
         'program_key': 'program_key',
         'min_created_date': 'min_created_date',
     }
-    permission_required = [perms.APIReadReportPermission]
+    permission_required = [perms.APIReadReportsPermission]
 
     def get(self, request, *args, **kwargs):
         """

--- a/registrar/apps/api/v1/views.py
+++ b/registrar/apps/api/v1/views.py
@@ -166,11 +166,17 @@ class ProgramListView(AuthMixin, TrackViewMixin, ListAPIView):
         perm_query_param = self.request.GET.get('user_has_perm', None)
         if not perm_query_param:
             return None
-        elif perm_query_param in PERMISSION_QUERY_PARAM_MAP:
-            return PERMISSION_QUERY_PARAM_MAP[perm_query_param]
-        else:
-            self.add_tracking_data(failure='no_such_perm')
-            raise Http404()
+
+        try:
+            return next(p for p in perms.API_PERMISSIONS if p.name == perm_query_param)
+        except StopIteration:
+            # maintains functionality with the currently deployed version of the UI
+            # and can be removed once these query params are no loger in use
+            if perm_query_param in PERMISSION_QUERY_PARAM_MAP:
+                return PERMISSION_QUERY_PARAM_MAP[perm_query_param]
+            else:
+                self.add_tracking_data(failure='no_such_perm')
+                raise Http404()
 
 
 class ProgramRetrieveView(ProgramSpecificViewMixin, RetrieveAPIView):

--- a/registrar/apps/api/v1/views.py
+++ b/registrar/apps/api/v1/views.py
@@ -23,7 +23,7 @@ from rest_framework.views import APIView
 
 from registrar.apps.api.constants import (
     ENROLLMENT_PERMISSIONS_LIST,
-    PERMISSION_QUERY_PARAM_MAP,
+    LEGACY_PERMISSION_QUERY_PARAMS,
     UPLOAD_FILE_MAX_SIZE,
 )
 from registrar.apps.api.exceptions import FileTooLarge
@@ -158,8 +158,8 @@ class ProgramListView(AuthMixin, TrackViewMixin, ListAPIView):
     @cached_property
     def permission_filter(self):
         """
-        Return the user permissions by which results will be filtered,
-        or None if on filter specified.
+        Return a list of ApiPermissionBase by which results will be filtered,
+        or None if no filter specified.
 
         Raises 404 for bad permission query param.
         """
@@ -172,8 +172,8 @@ class ProgramListView(AuthMixin, TrackViewMixin, ListAPIView):
         except StopIteration:
             # maintains functionality with the currently deployed version of the UI
             # and can be removed once these query params are no loger in use
-            if perm_query_param in PERMISSION_QUERY_PARAM_MAP:
-                return PERMISSION_QUERY_PARAM_MAP[perm_query_param]
+            if perm_query_param in LEGACY_PERMISSION_QUERY_PARAMS:
+                return LEGACY_PERMISSION_QUERY_PARAMS[perm_query_param]
             else:
                 self.add_tracking_data(failure='no_such_perm')
                 raise Http404()

--- a/registrar/apps/core/permissions.py
+++ b/registrar/apps/core/permissions.py
@@ -2,6 +2,8 @@
 This module defines constants for permission codenames
 and sets of permissions that can be used as roles.
 """
+import re
+
 from guardian.shortcuts import assign_perm
 
 
@@ -258,3 +260,22 @@ PROGRAM_ROLES = [
     ProgramReadWriteEnrollmentsRole,
     ProgramReadReportRole,
 ]
+
+
+def _build_db_to_api_permissions():
+    """
+    Return a dict mappping a database permission (with app prefix stripped) to
+    a corresponding APIPermission.
+    """
+    permission_map = {}
+    for api_permission in API_PERMISSIONS:
+        for db_perm in api_permission.permissions:
+            # strip app name from permission
+            match = re.match(r'\w+\.(\w+)', db_perm)
+            if match:  # pragma: no branch
+                db_perm = match.groups()[0]
+                permission_map[db_perm] = api_permission
+    return permission_map
+
+
+DB_TO_API_PERMISSION_MAPPING = _build_db_to_api_permissions()

--- a/registrar/apps/core/permissions.py
+++ b/registrar/apps/core/permissions.py
@@ -231,7 +231,7 @@ class APIWriteEnrollmentsPermission(APIPermissionBase):
     permissions = [ORGANIZATION_WRITE_ENROLLMENTS, PROGRAM_WRITE_ENROLLMENTS]
 
 
-class APIReadReportPermission(APIPermissionBase):
+class APIReadReportsPermission(APIPermissionBase):
     name = 'read_reports'
     permissions = [ORGANIZATION_READ_REPORTS, PROGRAM_READ_REPORTS]
 
@@ -240,7 +240,7 @@ API_PERMISSIONS = [
     APIReadMetadataPermission,
     APIReadEnrollmentsPermission,
     APIWriteEnrollmentsPermission,
-    APIReadReportPermission
+    APIReadReportsPermission
 ]
 
 

--- a/registrar/apps/core/permissions.py
+++ b/registrar/apps/core/permissions.py
@@ -264,13 +264,16 @@ PROGRAM_ROLES = [
 
 def _build_db_to_api_permissions():
     """
-    Return a dict mappping a database permission (with app prefix stripped) to
-    a corresponding APIPermission.
+    Return a dict mappping a each permission string to a corresponding
+    APIPermission. Two versions of each string are mapped, one with the app
+    prefix (used by django functions) and another without (used by guardian)
     """
     permission_map = {}
     for api_permission in API_PERMISSIONS:
         for db_perm in api_permission.permissions:
-            # strip app name from permission
+            # map permission string that includes app name
+            permission_map[db_perm] = api_permission
+            # strip app name from permission to match guardian's usage
             match = re.match(r'\w+\.(\w+)', db_perm)
             if match:  # pragma: no branch
                 db_perm = match.groups()[0]

--- a/registrar/apps/core/permissions.py
+++ b/registrar/apps/core/permissions.py
@@ -217,19 +217,31 @@ class APIPermissionBase(object):
 
 
 class APIReadMetadataPermission(APIPermissionBase):
+    name = 'read_metadata'
     permissions = [ORGANIZATION_READ_METADATA, PROGRAM_READ_METADATA]
 
 
 class APIReadEnrollmentsPermission(APIPermissionBase):
+    name = 'read_enrollments'
     permissions = [ORGANIZATION_READ_ENROLLMENTS, PROGRAM_READ_ENROLLMENTS]
 
 
 class APIWriteEnrollmentsPermission(APIPermissionBase):
+    name = 'write_enrollments'
     permissions = [ORGANIZATION_WRITE_ENROLLMENTS, PROGRAM_WRITE_ENROLLMENTS]
 
 
 class APIReadReportPermission(APIPermissionBase):
+    name = 'read_reports'
     permissions = [ORGANIZATION_READ_REPORTS, PROGRAM_READ_REPORTS]
+
+
+API_PERMISSIONS = [
+    APIReadMetadataPermission,
+    APIReadEnrollmentsPermission,
+    APIWriteEnrollmentsPermission,
+    APIReadReportPermission
+]
 
 
 ORGANIZATION_ROLES = [

--- a/registrar/apps/core/tests/test_utils.py
+++ b/registrar/apps/core/tests/test_utils.py
@@ -6,8 +6,10 @@ from guardian.shortcuts import assign_perm
 from rest_framework.exceptions import ValidationError
 
 from registrar.apps.core.permissions import (
+    ORGANIZATION_READ_ENROLLMENTS,
     ORGANIZATION_READ_METADATA,
     ORGANIZATION_READ_REPORTS,
+    ORGANIZATION_WRITE_ENROLLMENTS,
     APIReadEnrollmentsPermission,
     APIReadMetadataPermission,
     APIReadReportsPermission,
@@ -79,6 +81,10 @@ class GetUserAPIPermissionsTests(TestCase):
             role=OrganizationReadWriteEnrollmentsRole.name
         )
 
+        cls.global_readwrite_enrollments = GroupFactory(
+            permissions=[ORGANIZATION_READ_ENROLLMENTS, ORGANIZATION_WRITE_ENROLLMENTS]
+        )
+
         cls.org2 = OrganizationFactory()
         cls.org3 = OrganizationFactory()
 
@@ -106,6 +112,14 @@ class GetUserAPIPermissionsTests(TestCase):
         # request only permissions assigned globally
         perms = get_user_api_permissions(self.user)
         self.assertSetEqual(perms, set([APIReadMetadataPermission]))
+
+        # validate permissions assigned globally by a django group
+        user = UserFactory(groups=[self.global_readwrite_enrollments])
+        perms = get_user_api_permissions(user)
+        self.assertSetEqual(perms, set([
+            APIReadEnrollmentsPermission,
+            APIWriteEnrollmentsPermission,
+        ]))
 
 
 def _create_food(name, is_fruit, rating, color):

--- a/registrar/apps/core/tests/test_utils.py
+++ b/registrar/apps/core/tests/test_utils.py
@@ -103,6 +103,10 @@ class GetUserAPIPermissionsTests(TestCase):
         perms = get_user_api_permissions(self.user, self.org3)
         self.assertSetEqual(perms, set([APIReadReportsPermission, APIReadMetadataPermission]))
 
+        # request only permissions assigned globally
+        perms = get_user_api_permissions(self.user)
+        self.assertSetEqual(perms, set([APIReadMetadataPermission]))
+
 
 def _create_food(name, is_fruit, rating, color):
     return {

--- a/registrar/apps/core/tests/test_utils.py
+++ b/registrar/apps/core/tests/test_utils.py
@@ -7,8 +7,10 @@ from rest_framework.exceptions import ValidationError
 
 from registrar.apps.core.permissions import (
     ORGANIZATION_READ_METADATA,
+    ORGANIZATION_READ_REPORTS,
     APIReadEnrollmentsPermission,
     APIReadMetadataPermission,
+    APIReadReportsPermission,
     APIWriteEnrollmentsPermission,
     OrganizationReadWriteEnrollmentsRole,
 )
@@ -78,12 +80,14 @@ class GetUserAPIPermissionsTests(TestCase):
         )
 
         cls.org2 = OrganizationFactory()
+        cls.org3 = OrganizationFactory()
 
         cls.user = UserFactory(groups=[org1_readwrite])
         assign_perm(ORGANIZATION_READ_METADATA, cls.user)
+        assign_perm(ORGANIZATION_READ_REPORTS, cls.user, cls.org3)
 
     def test_get_api_permissions(self):
-        # validate permissions assigned at the object
+        # validate permissions assigned by a group
         perms = get_user_api_permissions(self.user, self.org1)
         self.assertSetEqual(perms, set([
             APIReadMetadataPermission,
@@ -94,6 +98,10 @@ class GetUserAPIPermissionsTests(TestCase):
         # validate permissions assigned globally
         perms = get_user_api_permissions(self.user, self.org2)
         self.assertSetEqual(perms, set([APIReadMetadataPermission]))
+
+        # validate permissions assigned directly on the object
+        perms = get_user_api_permissions(self.user, self.org3)
+        self.assertSetEqual(perms, set([APIReadReportsPermission, APIReadMetadataPermission]))
 
 
 def _create_food(name, is_fruit, rating, color):

--- a/registrar/apps/core/utils.py
+++ b/registrar/apps/core/utils.py
@@ -34,13 +34,13 @@ def get_user_api_permissions(user, obj=None):
     will be returned.
     """
     user_object_permissions = get_perms(user, obj) if obj is not None else []
-    user_global_permissions = list(user.user_permissions.all().values_list('codename', flat=True))
+    user_global_permissions = list(user.get_all_permissions())
 
     user_api_permissions = set()
 
     for db_perm in user_object_permissions + user_global_permissions:
         if db_perm in DB_TO_API_PERMISSION_MAPPING:  # pragma: no branch
-            user_api_permissions.add(DB_TO_API_PERMISSION_MAPPING.get(db_perm))
+            user_api_permissions.add(DB_TO_API_PERMISSION_MAPPING[db_perm])
 
     return user_api_permissions
 

--- a/registrar/apps/core/utils.py
+++ b/registrar/apps/core/utils.py
@@ -43,12 +43,12 @@ def get_user_api_permissions(user, obj):
         for db_perm in api_permission.permissions:
             # strip app name from permission
             match = re.match(r'\w+\.(\w+)', db_perm)
-            if match:
+            if match:  # pragma: no branch
                 db_perm = match.groups()[0]
                 api_permission_map[db_perm] = api_permission
 
     for db_perm in user_object_permissions + user_global_permissions:
-        if db_perm in api_permission_map:
+        if db_perm in api_permission_map:  # pragma: no branch
             user_api_permissions.add(api_permission_map.get(db_perm))
 
     return user_api_permissions

--- a/registrar/apps/core/utils.py
+++ b/registrar/apps/core/utils.py
@@ -30,7 +30,8 @@ def get_user_api_permissions(user, obj=None):
     """
     Returns a set of all APIPermissions granted to the user on a
     provided object instance. This includes permissions granted though a
-    global permission or role.
+    global permission or role. If no object is passed only global permissions
+    will be returned.
     """
     user_object_permissions = get_perms(user, obj) if obj is not None else []
     user_global_permissions = list(user.user_permissions.all().values_list('codename', flat=True))


### PR DESCRIPTION
@edx/masters-devs 

- Adds a list of user APIPermissions to Program get/list endpoints
- `user_has_perm` query parameters now accept an APIPermission string.
- See [ADR on API Permissions](https://github.com/edx/registrar/blob/master/docs/decisions/0006-api-permissions.mdn)
