### PR TITLE
Remove the code associated with PendingUserOrganizationGroup model

### DIFF
--- a/registrar/apps/core/models.py
+++ b/registrar/apps/core/models.py
@@ -233,43 +233,6 @@ class ProgramOrganizationGroup(Group):
         return 'ProgramOrganizationGroup: {} role={}'.format(self.program.title, self.role)  # pragma: no cover
 
 
-class PendingUserOrganizationGroup(TimeStampedModel):
-    """
-    PendingUserOrganizationGroup is now deprecated, and is replaced by PendingUserGroup
-    which supports both Organization Group and Program Group.
-
-    Organization Membership model for user who have not yet been created in the user table
-
-    .. pii:: stores the user email address field for pending users.
-             The pii data gets deleted after a real user gets created
-    .. pii_types:: email_address
-    .. pii_retirement:: local_api
-    """
-    class Meta(object):
-        ordering = ['created']
-        unique_together = ('user_email', 'organization_group')
-
-    user_email = models.EmailField()
-    organization_group = models.ForeignKey(OrganizationGroup, on_delete=models.CASCADE)
-
-    def __str__(self):
-        """
-        Return human-readable string representation
-        """
-        return "<PendingUserOrganizationGroup {ID}>: {organization_name} - {user_email} - {role}".format(
-            ID=self.id,
-            organization_name=self.organization_group.organization.name,
-            user_email=self.user_email,
-            role=self.organization_group.role,
-        )
-
-    def __repr__(self):
-        """
-        Return uniquely identifying string representation.
-        """
-        return self.__str__()  # pragma: no cover
-
-
 class PendingUserGroup(TimeStampedModel):
     """
     Membership model for user who have not yet been created in the user table

--- a/registrar/apps/core/signals.py
+++ b/registrar/apps/core/signals.py
@@ -3,10 +3,7 @@ Django signal handlers.
 """
 from logging import getLogger
 
-from registrar.apps.core.models import (
-    PendingUserGroup,
-    PendingUserOrganizationGroup,
-)
+from registrar.apps.core.models import PendingUserGroup
 
 
 logger = getLogger(__name__)
@@ -15,10 +12,6 @@ logger = getLogger(__name__)
 def handle_user_post_save(sender, **kwargs):  # pylint: disable=unused-argument
     """
     If a pending user group record exists, add the user to the group and delete the pending record.
-
-    Since PendingUserOrganizationGroup is deprecated and is replaced by PendingUserGroup, for backward
-    compatibility, if an existing PendingUserOrganizationGroup record exists, we shall still consume
-    it upon user's first-time login and delete the PendingUserOrganizationGroup record.
     """
     user_instance = kwargs.get("instance")
 
@@ -32,14 +25,3 @@ def handle_user_post_save(sender, **kwargs):  # pylint: disable=unused-argument
         user_instance.groups.add(pending_group.group)
 
     pending_groups.delete()
-
-    pending_org_groups = PendingUserOrganizationGroup.objects.filter(user_email=user_instance.email)
-    for pending_group in pending_org_groups:
-        logger.info(
-            'add user {} to organization_group {} '.format(
-                user_instance.email, pending_group.organization_group
-            )
-        )
-        user_instance.groups.add(pending_group.organization_group)
-
-    pending_org_groups.delete()

--- a/registrar/apps/core/tests/factories.py
+++ b/registrar/apps/core/tests/factories.py
@@ -13,7 +13,6 @@ from registrar.apps.core.models import (
     Organization,
     OrganizationGroup,
     PendingUserGroup,
-    PendingUserOrganizationGroup,
     Program,
     ProgramOrganizationGroup,
 )
@@ -126,9 +125,9 @@ class ProgramOrganizationGroupFactory(factory.DjangoModelFactory):
 
 class PendingUserOrganizationGroupFactory(factory.DjangoModelFactory):
     class Meta(object):
-        model = PendingUserOrganizationGroup
+        model = PendingUserGroup
 
-    organization_group = factory.SubFactory(OrganizationGroupFactory)
+    group = factory.SubFactory(OrganizationGroupFactory)
     user_email = factory.Faker('email')
 
 

--- a/registrar/apps/core/tests/test_models.py
+++ b/registrar/apps/core/tests/test_models.py
@@ -12,7 +12,6 @@ from registrar.apps.core.models import (
     Organization,
     OrganizationGroup,
     PendingUserGroup,
-    PendingUserOrganizationGroup,
     Program,
     ProgramOrganizationGroup,
     User,
@@ -157,6 +156,21 @@ class OrganizationGroupTests(TestCase):
         self.assertTrue(self.user.has_perm(metdata_permission, org2))
         self.assertTrue(self.user.has_perm(write_permission, org2))
 
+    @ddt.data(
+        perm.OrganizationReadMetadataRole,
+        perm.OrganizationReadEnrollmentsRole,
+        perm.OrganizationReadWriteEnrollmentsRole,
+    )
+    def test_string(self, role):
+        org_group = OrganizationGroup.objects.create(
+            role=role.name,
+            organization=self.organization,
+        )
+        org_group_string = str(org_group)
+        self.assertIn('OrganizationGroup', org_group_string)
+        self.assertIn(self.organization.name, org_group_string)
+        self.assertIn(role.name, org_group_string)
+
 
 @ddt.ddt
 class ProgramOrganizationGroupTests(TestCase):
@@ -255,27 +269,6 @@ class ProgramOrganizationGroupTests(TestCase):
         self.assertFalse(self.user.has_perm(write_permission, program1))
         self.assertTrue(self.user.has_perm(metdata_permission, program2))
         self.assertTrue(self.user.has_perm(write_permission, program2))
-
-
-class PendingUserOrganizationGroupTests(TestCase):
-    """ Tests for PendingUserOrganizationGroup model """
-
-    def setUp(self):
-        super(PendingUserOrganizationGroupTests, self).setUp()
-        self.organization = OrganizationFactory()
-        self.organization_group = OrganizationGroupFactory(organization=self.organization)
-
-    def test_string(self):
-        user_email = 'test@example.com'
-        pending_user_org_group = PendingUserOrganizationGroup.objects.create(
-            user_email=user_email,
-            organization_group=self.organization_group,
-        )
-        pending_user_org_group_string = str(pending_user_org_group)
-        self.assertIn('PendingUserOrganizationGroup', pending_user_org_group_string)
-        self.assertIn(user_email, pending_user_org_group_string)
-        self.assertIn(self.organization.name, pending_user_org_group_string)
-        self.assertIn(self.organization_group.role, pending_user_org_group_string)
 
 
 class PendingUserGroupTests(TestCase):

--- a/registrar/apps/core/tests/test_signals.py
+++ b/registrar/apps/core/tests/test_signals.py
@@ -6,7 +6,7 @@ from django.apps import apps
 from django.test import TestCase
 
 from registrar.apps.core import permissions as perms
-from registrar.apps.core.models import PendingUserOrganizationGroup, User
+from registrar.apps.core.models import PendingUserGroup, User
 from registrar.apps.core.tests.factories import (
     OrganizationGroupFactory,
     PendingUserOrganizationGroupFactory,
@@ -27,7 +27,7 @@ class HandleUserPostSaveTests(TestCase):
         self.user_email = 'test@edx.org'
         self.user_password = 'password'
         self.pending_user_org_group = PendingUserOrganizationGroupFactory(
-            organization_group=self.organization_group,
+            group=self.organization_group,
             user_email=self.user_email
         )
         self.pending_user_program_group = PendingUserProgramGroupFactory(
@@ -43,7 +43,6 @@ class HandleUserPostSaveTests(TestCase):
             password=self.user_password
         )
         self._assert_group_membership(user, self.organization_group.name)
-        self._assert_deletion()
 
     def test_single_pending_program_group(self):
         user = User.objects.create(
@@ -65,7 +64,7 @@ class HandleUserPostSaveTests(TestCase):
         )
         PendingUserOrganizationGroupFactory(
             user_email=self.user_email,
-            organization_group=another_group,
+            group=another_group,
         )
         user = User.objects.create(
             username=self.user_email,
@@ -88,7 +87,7 @@ class HandleUserPostSaveTests(TestCase):
         self._assert_deletion()
         PendingUserOrganizationGroupFactory(
             user_email=self.user_email,
-            organization_group=self.organization_group,
+            group=self.organization_group,
         )
         PendingUserProgramGroupFactory(
             user_email=self.user_email,
@@ -111,8 +110,8 @@ class HandleUserPostSaveTests(TestCase):
         self.assertEqual(len(user.groups.all()), 0)
 
     def _assert_deletion(self):
-        with self.assertRaises(PendingUserOrganizationGroup.DoesNotExist):
-            PendingUserOrganizationGroup.objects.get(
+        with self.assertRaises(PendingUserGroup.DoesNotExist):
+            PendingUserGroup.objects.get(
                 user_email=self.user_email
             )
 


### PR DESCRIPTION
## Description
Remove the no longer used PendingUserOrganizationGroup model. All the data that was in this table in production, are now already moved to the new PendingUserGroup model.
This PR do not include any migration. So this is 1 out of 2 PRs I will create. This one will be deployed first.
@edx/masters-devs Please help review