### PR TITLE
Refactor Disco cache to tolerate inter-service errors 

### DIFF
--- a/registrar/apps/api/serializers.py
+++ b/registrar/apps/api/serializers.py
@@ -7,7 +7,7 @@ in question should be moved to versioned sub-package.
 from rest_framework import serializers
 from user_tasks.models import UserTaskStatus
 
-from registrar.apps.core.models import Program
+from registrar.apps.core.data import DiscoveryProgram
 from registrar.apps.core.utils import get_user_api_permissions
 from registrar.apps.enrollments.constants import (
     COURSE_ENROLLMENT_STATUSES,
@@ -16,9 +16,9 @@ from registrar.apps.enrollments.constants import (
 
 
 # pylint: disable=abstract-method
-class ProgramSerializer(serializers.ModelSerializer):
+class DiscoveryProgramSerializer(serializers.ModelSerializer):
     """
-    Serializer for Programs.
+    Serializer for DiscoveryPrograms.
     """
     program_key = serializers.CharField(source='key')
     program_title = serializers.CharField(source='title')
@@ -26,8 +26,14 @@ class ProgramSerializer(serializers.ModelSerializer):
     permissions = serializers.SerializerMethodField(source='get_permissions')
 
     class Meta:
-        model = Program
-        fields = ('program_key', 'program_title', 'program_url', 'program_type', 'permissions')
+        model = DiscoveryProgram
+        fields = (
+            'program_key',
+            'program_title',
+            'program_url',
+            'program_type',
+            'permissions',
+        )
 
     def get_permissions(self, program):
         request = self.context.get('request')

--- a/registrar/apps/api/tests/test_serializers.py
+++ b/registrar/apps/api/tests/test_serializers.py
@@ -5,27 +5,26 @@ from django.core.cache import cache
 from django.test import TestCase
 from django.test.client import RequestFactory
 
-from registrar.apps.api.serializers import ProgramSerializer
+from registrar.apps.api.serializers import DiscoveryProgramSerializer
 from registrar.apps.core.constants import PROGRAM_CACHE_KEY_TPL
-from registrar.apps.core.data import DiscoveryProgram
 from registrar.apps.core.permissions import (
     APIReadMetadataPermission,
     APIWriteEnrollmentsPermission,
 )
 from registrar.apps.core.tests.factories import (
+    DiscoveryProgramFactory,
     OrganizationFactory,
-    ProgramFactory,
 )
 
 
-class ProgramSerializerTests(TestCase):
-    """ Tests the ProgramSerializer """
+class DiscoveryProgramSerializerTests(TestCase):
+    """ Tests the DiscoveryProgramSerializer """
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
 
         cls.org = OrganizationFactory()
-        cls.program = ProgramFactory(managing_organization=cls.org)
+        cls.program = DiscoveryProgramFactory(managing_organization=cls.org)
 
         cls.request = RequestFactory().get('/api/v1/programs')
         cls.request.user = AnonymousUser()
@@ -35,14 +34,11 @@ class ProgramSerializerTests(TestCase):
 
         cache.set(
             PROGRAM_CACHE_KEY_TPL.format(uuid=self.program.discovery_uuid),
-            DiscoveryProgram.from_json(
-                self.program.discovery_uuid,
-                {
-                    'title': 'test-program',
-                    'type': 'masters',
-                    'curricula': [],
-                }
-            )
+            {
+                'title': 'test-program',
+                'type': 'masters',
+                'curricula': [],
+            },
         )
 
     @mock.patch('registrar.apps.api.serializers.get_user_api_permissions')
@@ -55,7 +51,7 @@ class ProgramSerializerTests(TestCase):
             set([APIWriteEnrollmentsPermission]),  # mocked permissions on program
             set([APIReadMetadataPermission]),  # mocked permissions on org
         ]
-        program = ProgramSerializer(
+        program = DiscoveryProgramSerializer(
             self.program,
             context={
                 'request': self.request
@@ -71,5 +67,5 @@ class ProgramSerializerTests(TestCase):
         Serializer should return an empty list for permissions if invoked
         without a request context
         """
-        program = ProgramSerializer(self.program).data
+        program = DiscoveryProgramSerializer(self.program).data
         self.assertListEqual(program.get('permissions'), [])

--- a/registrar/apps/api/v1/mixins.py
+++ b/registrar/apps/api/v1/mixins.py
@@ -21,9 +21,9 @@ from rest_framework.status import (
 )
 
 from registrar.apps.core import permissions as perms
+from registrar.apps.core.data import DiscoveryProgram
 from registrar.apps.core.filestore import get_enrollment_uploads_filestore
 from registrar.apps.core.jobs import start_job
-from registrar.apps.core.models import Program
 from registrar.apps.enrollments.data import (
     write_course_run_enrollments,
     write_program_enrollments,
@@ -141,11 +141,14 @@ class ProgramSpecificViewMixin(AuthMixin):
     def program(self):
         """
         The program specified by the `program_key` URL parameter.
+
+        Loads a DiscoveryProgram, which gives access to fields from Discovery
+        such as title, program type, etc.
         """
         program_key = self.kwargs['program_key']
         try:
-            return Program.objects.get(key=program_key)
-        except Program.DoesNotExist:
+            return DiscoveryProgram.objects.get(key=program_key)
+        except DiscoveryProgram.DoesNotExist:
             self.add_tracking_data(failure='program_not_found')
             raise Http404()
 
@@ -174,7 +177,7 @@ class CourseSpecificViewMixin(ProgramSpecificViewMixin):
         parameter is not part of self.program.
         """
         provided_course_id = self.kwargs['course_id']
-        real_course_run = self.program.discovery_program.find_course_run(
+        real_course_run = self.program.find_course_run(
             provided_course_id
         )
         if not real_course_run:

--- a/registrar/apps/core/models.py
+++ b/registrar/apps/core/models.py
@@ -7,7 +7,6 @@ from guardian.shortcuts import remove_perm
 from model_utils.models import TimeStampedModel
 
 from . import permissions as perms
-from .data import DiscoveryProgram
 
 
 ACCESS_ADMIN = ('admin', 2)
@@ -100,35 +99,6 @@ class Program(TimeStampedModel):
     key = models.CharField(unique=True, max_length=255)
     discovery_uuid = models.UUIDField(db_index=True, null=True)
     managing_organization = models.ForeignKey(Organization, on_delete=models.CASCADE)
-
-    @property
-    def discovery_program(self):
-        return DiscoveryProgram.get(self.discovery_uuid)
-
-    @property
-    def title(self):
-        return self._get_cached_field('title')
-
-    @property
-    def url(self):
-        return self._get_cached_field('url')
-
-    @property
-    def program_type(self):
-        return self._get_cached_field('program_type')
-
-    @property
-    def is_enrollment_enabled(self):
-        return self.program_type == 'Masters'
-
-    def _get_cached_field(self, field):
-        """
-        Returns the specified field from a cached Discovery program.
-        If the program is not found in the cache it is loaded from discovery
-        """
-        discovery_program = DiscoveryProgram.get(self.discovery_uuid)
-        val = getattr(discovery_program, field)
-        return val
 
     def __str__(self):
         """

--- a/registrar/apps/core/tasks.py
+++ b/registrar/apps/core/tasks.py
@@ -6,8 +6,8 @@ from celery.utils.log import get_task_logger
 from user_tasks.models import UserTaskArtifact
 from user_tasks.tasks import UserTask
 
+from .data import DiscoveryProgram
 from .jobs import post_job_failure
-from .models import Program
 
 
 log = get_task_logger(__name__)
@@ -36,7 +36,7 @@ def _get_program(job_id, program_key):
     Load a Program by key. Fails job and returns None if key invalid.
     """
     try:
-        return Program.objects.get(key=program_key)
-    except Program.DoesNotExist:
+        return DiscoveryProgram.objects.get(key=program_key)
+    except DiscoveryProgram.DoesNotExist:
         post_job_failure(job_id, "Bad program key: {}".format(program_key))
         return None

--- a/registrar/apps/core/tests/factories.py
+++ b/registrar/apps/core/tests/factories.py
@@ -9,6 +9,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
 from guardian.shortcuts import assign_perm
 
+from ..data import DiscoveryProgram
 from ..models import (
     Organization,
     OrganizationGroup,
@@ -95,6 +96,11 @@ class ProgramFactory(factory.DjangoModelFactory):
     key = factory.Sequence(lambda n: 'test-program-{}'.format(n))  # pylint: disable=unnecessary-lambda
     discovery_uuid = factory.Faker('uuid4')
     managing_organization = factory.SubFactory(OrganizationFactory)
+
+
+class DiscoveryProgramFactory(ProgramFactory):
+    class Meta:
+        model = DiscoveryProgram
 
 
 class OrganizationGroupFactory(factory.DjangoModelFactory):

--- a/registrar/apps/core/tests/mixins.py
+++ b/registrar/apps/core/tests/mixins.py
@@ -7,7 +7,7 @@ import requests
 from user_tasks.models import UserTaskStatus
 
 from ..jobs import get_job_status
-from .factories import OrganizationFactory, ProgramFactory, UserFactory
+from .factories import DiscoveryProgramFactory, OrganizationFactory, UserFactory
 
 
 class BaseTaskTestMixin(object):
@@ -21,7 +21,7 @@ class BaseTaskTestMixin(object):
         super().setUpTestData()
         cls.user = UserFactory()
         org = OrganizationFactory(name='STEM Institute')
-        cls.program = ProgramFactory(managing_organization=org)
+        cls.program = DiscoveryProgramFactory(managing_organization=org)
 
     def spawn_task(self, program_key=None, **kwargs):
         """

--- a/registrar/apps/core/tests/test_data.py
+++ b/registrar/apps/core/tests/test_data.py
@@ -1,229 +1,167 @@
 """
 Test for common data functions
 """
-import uuid
-from datetime import datetime
+
 from posixpath import join as urljoin
+from uuid import UUID
 
 import ddt
-import mock
 import responses
 from django.conf import settings
 from django.core.cache import cache
-from django.http import Http404
 from django.test import TestCase
-from requests.exceptions import HTTPError
 
-from ..data import (
-    DISCOVERY_PROGRAM_API_TPL,
-    DiscoveryCourseRun,
-    DiscoveryProgram,
-)
-from .utils import mock_oauth_login
+from ..data import DISCOVERY_PROGRAM_API_TPL, DiscoveryProgram
+from .factories import DiscoveryProgramFactory
+from .utils import mock_oauth_login, patch_discovery_data
 
 
-class GetDiscoveryProgramTestCase(TestCase):
-    """ Test get_discovery_program function """
-    program_uuid = str(uuid.uuid4())
-    curriculum_uuid = str(uuid.uuid4())
-    discovery_url = urljoin(settings.DISCOVERY_BASE_URL, DISCOVERY_PROGRAM_API_TPL.format(program_uuid))
-    course_run_1 = {
-        'key': '0001',
-        'uuid': '0000-0001',
-        'title': 'Test Course 1',
-        'external_key': 'testorg-course-101',
-        'marketing_url': 'https://stem-institute.edx.org/masters-in-cs/test-course-1',
+def make_course_run(n, with_external_key=False):
+    """
+    Return a course run dictionary for testing.
+
+    If `with_external_key` is set to True, set ext key to testorg-course-${n}.
+    """
+    return {
+        'key': 'course-v1:TestRun+{}'.format(n),
+        'external_key': (
+            'testorg-course-{}'.format(n)
+            if with_external_key
+            else None
+        ),
+        'title': 'Test Course {}'.format(n),
+        'marketing_url': 'https://stem.edx.org/masters-in-cs/test-course-{}'.format(n),
+        'extraneous_data': ['blah blah blah'],
     }
-    program_title = "Master's in CS"
-    program_url = 'https://stem-institute.edx.org/masters-in-cs'
-    program_type = "Masters"
-    programs_response = {
-        'title': program_title,
-        'marketing_url': program_url,
-        'type': program_type,
-        'curricula': [{
-            'uuid': curriculum_uuid,
-            'is_active': True,
-            'courses': [{'course_runs': [course_run_1]}],
-        }],
-    }
-    expected_program = DiscoveryProgram(
-        version=0,
-        loaded=datetime.now(),
-        uuid=program_uuid,
-        title=program_title,
-        url=program_url,
-        program_type=program_type,
-        active_curriculum_uuid=curriculum_uuid,
-        course_runs=[
-            DiscoveryCourseRun(
-                course_run_1['key'],
-                course_run_1['external_key'],
-                course_run_1['title'],
-                course_run_1['marketing_url'],
-            ),
-        ],
+
+
+@ddt.ddt
+class DiscoveryProgramTestCase(TestCase):
+    """
+    Test DiscoveryProgram proxy model.
+    """
+    program_uuid = UUID("88888888-4444-2222-1111-000000000000")
+    discovery_url = urljoin(
+        settings.DISCOVERY_BASE_URL,
+        DISCOVERY_PROGRAM_API_TPL.format(program_uuid)
     )
+
+    inactive_curriculum_uuid = UUID("77777777-4444-2222-1111-000000000000")
+    active_curriculum_uuid = UUID("77777777-4444-2222-1111-000000000001")
+    ignored_active_curriculum_uuid = UUID("77777777-4444-2222-1111-000000000002")
+
+    make_course_run = make_course_run
+
+    program_data = {
+        'title': "Master's in CS",
+        'marketing_url': "https://stem.edx.org/masters-in-cs",
+        'type': "Masters",
+        'curricula': [
+            {
+                # Inactive curriculum. Should be ignored.
+                'uuid': str(inactive_curriculum_uuid),
+                'is_active': False,
+                'courses': [{'course_runs': [make_course_run(0, True)]}],
+            },
+            {
+                # Active curriculum. All three course runs should be aggregated.
+                'uuid': str(active_curriculum_uuid),
+                'is_active': True,
+                'courses': [
+                    {'course_runs': [make_course_run(1)]},
+                    {'course_runs': []},
+                    {'course_runs': [make_course_run(2, True), make_course_run(3)]},
+                    {'course_runs': [{'this course run': 'has the wrong format'}]},
+                ]
+            },
+            {
+                # Second active curriculum.
+                # In current implementation, should be ignored.
+                'uuid': str(ignored_active_curriculum_uuid),
+                'is_active': True,
+                'courses': [{'course_runs': [make_course_run(4, True)]}],
+            },
+        ],
+    }
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        DiscoveryProgramFactory(key="masters-in-cs", discovery_uuid=cls.program_uuid)
 
     def setUp(self):
         super().setUp()
         cache.clear()
 
-    def assert_discovery_programs_equal(self, this_program, that_program):
-        """ Asserts DiscoveryProgram equality, ignoring `loaded` field. """
-        self.assertEqual(this_program.version, 1)
-        self.assertEqual(this_program.uuid, that_program.uuid)
-        self.assertEqual(this_program.title, that_program.title)
-        self.assertEqual(this_program.url, that_program.url)
-        self.assertEqual(this_program.program_type, that_program.program_type)
-        self.assertEqual(this_program.active_curriculum_uuid, that_program.active_curriculum_uuid)
-        self.assertEqual(this_program.course_runs, that_program.course_runs)
+    @classmethod
+    def get_program(cls):
+        """
+        Loads the program with `cls.program_uuid`
+        """
+        return DiscoveryProgram.objects.get(discovery_uuid=cls.program_uuid)
 
     @mock_oauth_login
     @responses.activate
-    def test_get_discovery_program_success(self):
-        """
-        Verify initial call returns data from the discovery service and additional function
-        calls return from cache.
-
-        Note: TWO calls are initially made to discovery in order to obtain an auth token and then
-        request data.
-        """
+    @ddt.data(
+        (200, program_data, program_data),
+        (200, {}, {}),
+        (200, 'this is a string, but it should be a dict', {}),
+        (404, {'message': 'program not found'}, {}),
+        (500, {'message': 'everything is broken'}, {}),
+    )
+    @ddt.unpack
+    def test_discovery_program_get(self, disco_status, disco_data, expected_data):
         responses.add(
             responses.GET,
             self.discovery_url,
-            json=self.programs_response,
-            status=200
+            status=disco_status,
+            json=disco_data,
         )
-        loaded_program = DiscoveryProgram.get(self.program_uuid)
-        self.assert_discovery_programs_equal(loaded_program, self.expected_program)
+        loaded_program = self.get_program()
+        assert isinstance(loaded_program, DiscoveryProgram)
+        assert loaded_program.discovery_uuid == self.program_uuid
+        assert loaded_program.discovery_data == expected_data
         self.assertEqual(len(responses.calls), 2)
 
-        # this should return the same object from cache
-        loaded_program = DiscoveryProgram.get(self.program_uuid)
-        self.assert_discovery_programs_equal(loaded_program, self.expected_program)
+        # This should used the cached Discovery response.
+        reloaded_program = self.get_program()
+        assert isinstance(reloaded_program, DiscoveryProgram)
+        assert reloaded_program.discovery_uuid == self.program_uuid
+        assert reloaded_program.discovery_data == expected_data
         self.assertEqual(len(responses.calls), 2)
 
-    @mock_oauth_login
-    @responses.activate
-    def test_get_discovery_program_error(self):
-        """
-        Verify if an error occurs when requesting discovery data an exception is
-        thown and the cache is not polluted.
-        """
-        responses.add(
-            responses.GET,
-            self.discovery_url,
-            json={'message': 'everything is broken'},
-            status=500
-        )
+    @patch_discovery_data(program_data)
+    def test_active_curriculum(self):
+        program = self.get_program()
+        assert program.active_curriculum_uuid == self.active_curriculum_uuid
+        assert len(program.course_runs) == 4
+        assert program.course_runs[0].title == "Test Course 1"
+        assert program.course_runs[-1].title is None
 
-        with self.assertRaises(HTTPError):
-            DiscoveryProgram.get(self.program_uuid)
+    @patch_discovery_data({})
+    def test_no_active_curriculum(self):
+        program = self.get_program()
+        assert program.active_curriculum_uuid is None
+        assert not program.course_runs
 
-        responses.replace(
-            responses.GET,
-            self.discovery_url,
-            json=self.programs_response,
-            status=200
-        )
-        loaded_program = DiscoveryProgram.get(self.program_uuid)
-        self.assert_discovery_programs_equal(loaded_program, self.expected_program)
-
-        nonexistant_program_uuid = str(uuid.uuid4())
-        discovery_url = urljoin(
-            settings.DISCOVERY_BASE_URL,
-            DISCOVERY_PROGRAM_API_TPL.format(nonexistant_program_uuid)
-        )
-        responses.add(
-            responses.GET,
-            discovery_url,
-            json={'message': 'program not found!'},
-            status=404
-        )
-        with self.assertRaises(Http404):
-            DiscoveryProgram.get(nonexistant_program_uuid)
-
-    @mock_oauth_login
-    @responses.activate
-    def test_get_discovery_cache_versioning(self):
-        """
-        Verify that bumping the version of the cache invalidates old
-        entries.
-        """
-        responses.add(
-            responses.GET,
-            self.discovery_url,
-            json=self.programs_response,
-            status=200
-        )
-        DiscoveryProgram.get(self.program_uuid)
-        self.assertEqual(len(responses.calls), 2)
-        bumped_version = DiscoveryProgram.class_version + 1
-        with mock.patch.object(DiscoveryProgram, 'class_version', bumped_version):
-            DiscoveryProgram.get(self.program_uuid)
-        self.assertEqual(len(responses.calls), 4)
-
-
-@ddt.ddt
-class DiscoveryProgramTests(TestCase):
-    """ Tests for DiscoveryProgram methods """
-
-    def setUp(self):
-        super().setUp()
-        program_uuid = str(uuid.uuid4())
-        curriculum_uuid = str(uuid.uuid4())
-        program_title = "Master's in CS"
-        program_url = 'https://stem-institute.edx.org/masters-in-cs'
-        program_type = 'Micromasters'
-        self.program = DiscoveryProgram(
-            version=0,
-            loaded=datetime.now(),
-            uuid=program_uuid,
-            title=program_title,
-            url=program_url,
-            program_type=program_type,
-            active_curriculum_uuid=curriculum_uuid,
-            course_runs=[
-                self.make_course_run(i) for i in range(4)
-            ],
-        )
-
-    def make_course_run(self, counter):
-        """
-        Helper for making DiscoveryCourseRuns
-        """
-        key = 'course-{}'.format(counter)
-        external_key = 'external-key-course-{}'.format(counter)
-        title = 'Course {} Title'.format(counter)
-        url = 'www.courserun.url/{}/'.format(counter)
-        return DiscoveryCourseRun(key, external_key, title, url)
-
-    @ddt.data('key', 'external_key')
-    def test_get_key(self, attr):
-        for course_run in self.program.course_runs:
-            test_key = getattr(course_run, attr)
-            self.assertEqual(
-                self.program.get_course_key(test_key),
-                course_run.key
-            )
-
-    def test_get_key_not_found(self):
-        for i in [10, 101, 111, 123]:
-            not_in_program_run = self.make_course_run(i)
-            self.assertIsNone(self.program.get_course_key(not_in_program_run.key))
-            self.assertIsNone(self.program.get_course_key(not_in_program_run.external_key))
-
-    @ddt.data('key', 'external_key')
-    def test_get_external_key(self, attr):
-        for course_run in self.program.course_runs:
-            test_key = getattr(course_run, attr)
-            self.assertEqual(
-                self.program.get_external_course_key(test_key),
-                course_run.external_key
-            )
-
-    def test_get_external_key_not_found(self):
-        for i in [10, 101, 111, 123]:
-            not_in_program_run = self.make_course_run(i)
-            self.assertIsNone(self.program.get_external_course_key(not_in_program_run.key))
+    @patch_discovery_data(program_data)
+    @ddt.data(
+        # Non-existent course run.
+        ('non-existent', None, None),
+        # Real course run, but not in active curriculum.
+        ('course-v1:TestRun+0', None, None),
+        ('testorg-course-0', None, None),
+        # Real course run, in active curriculum, only has internal course key.
+        ('course-v1:TestRun+1', 'course-v1:TestRun+1', None),
+        ('testorg-course-1', None, None),
+        # Real course run, in active curriculum, has internal and external keys.
+        ('course-v1:TestRun+2', 'course-v1:TestRun+2', 'testorg-course-2'),
+        ('testorg-course-2', 'course-v1:TestRun+2', 'testorg-course-2'),
+    )
+    @ddt.unpack
+    def test_get_course_keys(self, argument, expected_course_key, expected_external_key):
+        program = self.get_program()
+        actual_course_key = program.get_course_key(argument)
+        assert actual_course_key == expected_course_key
+        actual_external_key = program.get_external_course_key(argument)
+        assert actual_external_key == expected_external_key

--- a/registrar/apps/core/tests/utils.py
+++ b/registrar/apps/core/tests/utils.py
@@ -5,6 +5,9 @@ from functools import wraps
 
 import responses
 from django.conf import settings
+from mock import patch
+
+from ..data import DiscoveryProgram
 
 
 def mock_oauth_login(fn):
@@ -22,3 +25,14 @@ def mock_oauth_login(fn):
         )
         return fn(self, *args, **kwargs)
     return inner
+
+
+def patch_discovery_data(disco_program_data):
+    """
+    Return a decorator that mocks the return value of DiscoveryProgram.discovery_data.
+    """
+    return patch.object(
+        DiscoveryProgram,
+        'get_program_data',
+        lambda *_, **__: disco_program_data,
+    )

--- a/registrar/apps/enrollments/data.py
+++ b/registrar/apps/enrollments/data.py
@@ -88,10 +88,11 @@ def write_program_enrollments(method, program_uuid, enrollments, client=None):
     Returns: See _write_enrollments.
     """
     url = _lms_program_enrollment_url(program_uuid)
-    curriculum_uuid = DiscoveryProgram.get(program_uuid).active_curriculum_uuid
+    program = DiscoveryProgram.objects.get(discovery_uuid=program_uuid)
+    curriculum_uuid_string = str(program.active_curriculum_uuid)
     enrollments = enrollments.copy()
     for enrollment in enrollments:
-        enrollment['curriculum_uuid'] = curriculum_uuid
+        enrollment['curriculum_uuid'] = curriculum_uuid_string
     return _write_enrollments(method, url, enrollments, client)
 
 

--- a/registrar/apps/enrollments/tasks.py
+++ b/registrar/apps/enrollments/tasks.py
@@ -143,7 +143,7 @@ def list_all_course_run_enrollments(self, job_id, user_id, file_format, program_
         return None
 
     results = []
-    for course_run in program.discovery_program.course_runs:
+    for course_run in program.course_runs:
         try:
             enrollments = data.get_course_run_enrollments(
                 program.discovery_uuid,
@@ -267,7 +267,7 @@ def write_course_run_enrollments(
     for requested_course_key, course_requests in requests_by_course_key.items():
         # we don't know if the requested key was an external key or internal key,
         # so convert it before making requests to the LMS.
-        internal_course_key = program.discovery_program.get_course_key(requested_course_key)
+        internal_course_key = program.get_course_key(requested_course_key)
 
         if internal_course_key:
             successes_in_course, failures_in_course, status_by_student_key = data.write_course_run_enrollments(

--- a/registrar/apps/grades/tests/test_tasks.py
+++ b/registrar/apps/grades/tests/test_tasks.py
@@ -7,11 +7,13 @@ from django.test import TestCase
 from rest_framework.exceptions import ValidationError
 
 from registrar.apps.core.tests.mixins import BaseTaskTestMixin
+from registrar.apps.core.tests.utils import patch_discovery_data
 
 from ..tasks import get_course_run_grades
 
 
 @ddt.ddt
+@patch_discovery_data({})
 class GetCourseRunGradesTest(BaseTaskTestMixin, TestCase):
     """ Error behavior tests for get_course_run_grades"""
     mock_base = 'registrar.apps.grades.data.'


### PR DESCRIPTION
@edx/masters-devs 

The goals of this PR are to:
* Make sure Registrar still has base-line functionality when Discovery is unavailable or is missing a program.
* Simplify the logic around Discovery caching.

Finally, here is a follow-up PR that does some fairly simple (but diff-heavy, hence the separation) reorganization: https://github.com/edx/registrar/pull/256

Ticket: https://openedx.atlassian.net/browse/MST-131