### PR TITLE
BOM-1279

### DIFF
--- a/registrar/settings/local.py
+++ b/registrar/settings/local.py
@@ -36,7 +36,7 @@ if os.environ.get('ENABLE_DJANGO_TOOLBAR', False):
         'debug_toolbar',
     )
 
-    MIDDLEWARE_CLASSES += (
+    MIDDLEWARE += (
         'debug_toolbar.middleware.DebugToolbarMiddleware',
     )
 

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -15,3 +15,7 @@ django-model-utils<4.0.0
 
 # django-storages version 1.9 drops support for boto storage backend.
 django-storages<1.9
+
+
+# Requires: Python >=3.6
+mock<4.0.0

--- a/requirements/devstack.txt
+++ b/requirements/devstack.txt
@@ -14,9 +14,9 @@ aws-sam-translator==1.20.1  # via cfn-lint
 aws-xray-sdk==2.4.3       # via moto
 babel==2.8.0              # via sphinx
 billiard==3.3.0.23        # via celery
-boto3==1.11.16            # via aws-sam-translator, moto
+boto3==1.11.17            # via aws-sam-translator, moto
 boto==2.49.0              # via moto
-botocore==1.14.16         # via aws-xray-sdk, boto3, moto, s3transfer
+botocore==1.14.17         # via aws-xray-sdk, boto3, moto, s3transfer
 celery==3.1.26.post2
 certifi==2019.11.28       # via requests
 cffi==1.14.0              # via cryptography
@@ -70,7 +70,7 @@ jinja2==2.11.1            # via code-annotations, moto, sphinx
 jmespath==0.9.4           # via boto3, botocore
 jsondiff==1.1.2           # via moto
 jsonpatch==1.25           # via cfn-lint
-jsonpickle==1.2           # via aws-xray-sdk
+jsonpickle==1.3           # via aws-xray-sdk
 jsonpointer==2.0          # via jsonpatch
 jsonschema==3.2.0         # via aws-sam-translator, cfn-lint
 kombu==3.0.37             # via celery

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -14,9 +14,9 @@ aws-sam-translator==1.20.1  # via cfn-lint
 aws-xray-sdk==2.4.3       # via moto
 babel==2.8.0              # via sphinx
 billiard==3.3.0.23        # via celery
-boto3==1.11.16            # via aws-sam-translator, moto
+boto3==1.11.17            # via aws-sam-translator, moto
 boto==2.49.0              # via moto
-botocore==1.14.16         # via aws-xray-sdk, boto3, moto, s3transfer
+botocore==1.14.17         # via aws-xray-sdk, boto3, moto, s3transfer
 celery==3.1.26.post2
 certifi==2019.11.28       # via requests
 cffi==1.14.0              # via cryptography
@@ -70,7 +70,7 @@ jinja2==2.11.1            # via code-annotations, moto, sphinx
 jmespath==0.9.4           # via boto3, botocore
 jsondiff==1.1.2           # via moto
 jsonpatch==1.25           # via cfn-lint
-jsonpickle==1.2           # via aws-xray-sdk
+jsonpickle==1.3           # via aws-xray-sdk
 jsonpointer==2.0          # via jsonpatch
 jsonschema==3.2.0         # via aws-sam-translator, cfn-lint
 kombu==3.0.37             # via celery

--- a/requirements/monitoring/requirements.txt
+++ b/requirements/monitoring/requirements.txt
@@ -14,9 +14,9 @@ aws-sam-translator==1.20.1  # via cfn-lint
 aws-xray-sdk==2.4.3       # via moto
 babel==2.8.0              # via sphinx
 billiard==3.3.0.23        # via celery
-boto3==1.11.16
+boto3==1.11.17
 boto==2.49.0              # via moto
-botocore==1.14.16         # via aws-xray-sdk, boto3, moto, s3transfer
+botocore==1.14.17         # via aws-xray-sdk, boto3, moto, s3transfer
 celery==3.1.26.post2
 certifi==2019.11.28       # via requests
 cffi==1.14.0              # via cryptography
@@ -73,7 +73,7 @@ jinja2==2.11.1            # via code-annotations, moto, sphinx
 jmespath==0.9.4           # via boto3, botocore
 jsondiff==1.1.2           # via moto
 jsonpatch==1.25           # via cfn-lint
-jsonpickle==1.2           # via aws-xray-sdk
+jsonpickle==1.3           # via aws-xray-sdk
 jsonpointer==2.0          # via jsonpatch
 jsonschema==3.2.0         # via aws-sam-translator, cfn-lint
 kombu==3.0.37             # via celery

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -8,8 +8,8 @@ amqp==1.4.9               # via kombu
 analytics-python==1.2.9
 anyjson==0.3.3            # via kombu
 billiard==3.3.0.23        # via celery
-boto3==1.11.16
-botocore==1.14.16         # via boto3, s3transfer
+boto3==1.11.17
+botocore==1.14.17         # via boto3, s3transfer
 celery==3.1.26.post2
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -12,9 +12,9 @@ attrs==19.3.0             # via jsonschema, pytest
 aws-sam-translator==1.20.1  # via cfn-lint
 aws-xray-sdk==2.4.3       # via moto
 billiard==3.3.0.23        # via celery
-boto3==1.11.16            # via aws-sam-translator, moto
+boto3==1.11.17            # via aws-sam-translator, moto
 boto==2.49.0              # via moto
-botocore==1.14.16         # via aws-xray-sdk, boto3, moto, s3transfer
+botocore==1.14.17         # via aws-xray-sdk, boto3, moto, s3transfer
 celery==3.1.26.post2
 certifi==2019.11.28       # via requests
 cffi==1.14.0              # via cryptography
@@ -63,7 +63,7 @@ jinja2==2.11.1            # via code-annotations, moto
 jmespath==0.9.4           # via boto3, botocore
 jsondiff==1.1.2           # via moto
 jsonpatch==1.25           # via cfn-lint
-jsonpickle==1.2           # via aws-xray-sdk
+jsonpickle==1.3           # via aws-xray-sdk
 jsonpointer==2.0          # via jsonpatch
 jsonschema==3.2.0         # via aws-sam-translator, cfn-lint
 kombu==3.0.37             # via celery


### PR DESCRIPTION
Update Middleware settings in local.py.

Added constrain for mock.
On travis bot upgrade job fails due to mock version > 4.0, which requires requires: Python >=3.6.

## Description

TODO: Include a detailed description of the changes in the body of the PR
