### PR TITLE
BOM-1286 : Upgrade social-auth-app to support django 2.2

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,4 +1,5 @@
 -c constraints.txt
+-r github.in              # Forks and other dependencies not yet on PyPI
 
 analytics-python<2.0
 celery<4.0

--- a/requirements/devstack.in
+++ b/requirements/devstack.in
@@ -1,5 +1,6 @@
 # Packages required for devstack development environment
 -c constraints.txt
+-r github.in              # Forks and other dependencies not yet on PyPI
 
 -r local.in
 -r nonlocal.in

--- a/requirements/devstack.txt
+++ b/requirements/devstack.txt
@@ -14,13 +14,13 @@ aws-sam-translator==1.20.1  # via cfn-lint
 aws-xray-sdk==2.4.3       # via moto
 babel==2.8.0              # via sphinx
 billiard==3.3.0.23        # via celery
-boto3==1.11.17            # via aws-sam-translator, moto
+boto3==1.12.1             # via aws-sam-translator, moto
 boto==2.49.0              # via moto
-botocore==1.14.17         # via aws-xray-sdk, boto3, moto, s3transfer
+botocore==1.15.1          # via aws-xray-sdk, boto3, moto, s3transfer
 celery==3.1.26.post2
 certifi==2019.11.28       # via requests
 cffi==1.14.0              # via cryptography
-cfn-lint==0.27.5          # via moto
+cfn-lint==0.28.1          # via moto
 chardet==3.0.4            # via requests
 click-log==0.3.2          # via edx-lint
 click==7.0                # via click-log, code-annotations, edx-lint
@@ -40,7 +40,7 @@ django-mysql==3.3.0
 django-simple-history==2.8.0
 django-storages==1.8
 django-user-tasks==0.3.0
-django-waffle==0.19.0
+django-waffle==0.20.0
 django==1.11.28
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.11.0
@@ -50,7 +50,7 @@ docutils==0.15.2          # via botocore, sphinx
 ecdsa==0.15               # via python-jose
 edx-auth-backends==3.0.2
 edx-django-release-util==0.3.6
-edx-django-utils==2.0.4   # via edx-drf-extensions
+edx-django-utils==3.0     # via edx-drf-extensions
 edx-drf-extensions==2.4.6
 edx-i18n-tools==0.5.0
 edx-lint==1.3.0
@@ -58,8 +58,8 @@ edx-opaque-keys==2.0.1    # via edx-drf-extensions
 edx-rest-api-client==1.9.2
 edx-sphinx-theme==1.5.0
 factory-boy==2.12.0
-faker==4.0.0
-freezegun==0.3.14
+faker==4.0.1
+freezegun==0.3.15
 future==0.18.2            # via aws-xray-sdk, pyjwkest
 idna==2.8                 # via moto, requests
 imagesize==1.2.0          # via sphinx
@@ -133,11 +133,11 @@ ruamel.yaml.convert==0.3.2  # via ruamel.yaml.cmd
 ruamel.yaml==0.16.10      # via ruamel.yaml.cmd, ruamel.yaml.convert
 s3transfer==0.3.3         # via boto3
 semantic-version==2.8.4   # via edx-drf-extensions
-six==1.14.0               # via analytics-python, astroid, aws-sam-translator, cfn-lint, configobj, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, django-waffle, docker, ecdsa, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, freezegun, jsonschema, mock, moto, packaging, pathlib2, pyjwkest, pylint, pyrsistent, python-dateutil, python-jose, python-memcached, responses, social-auth-app-django, social-auth-core, sphinx, stevedore, transifex-client, websocket-client
+six==1.14.0               # via analytics-python, astroid, aws-sam-translator, cfn-lint, configobj, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, django-waffle, docker, ecdsa, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, freezegun, jsonschema, mock, moto, packaging, pathlib2, pyjwkest, pylint, pyrsistent, python-dateutil, python-jose, python-memcached, responses, social-auth-core, sphinx, stevedore, transifex-client, websocket-client
 slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==2.0.0    # via sphinx
-social-auth-app-django==3.1.0  # via edx-auth-backends
-social-auth-core==3.2.0   # via edx-auth-backends, social-auth-app-django
+git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django
+social-auth-core==3.2.0   # via edx-auth-backends
 sphinx==1.6.7
 sphinxcontrib-websupport==1.2.0  # via sphinx
 sqlparse==0.3.0           # via django-debug-toolbar
@@ -149,11 +149,11 @@ urllib3==1.25.8           # via botocore, requests, transifex-client
 wcwidth==0.1.8            # via pytest
 websocket-client==0.57.0  # via docker
 werkzeug==1.0.0           # via moto
-wrapt==1.11.2             # via astroid, aws-xray-sdk
+wrapt==1.12.0             # via astroid, aws-xray-sdk
 xmltodict==0.12.0         # via moto
 yamllint==1.20.0
 yarg==0.1.9               # via pipreqs
-zipp==1.1.0               # via importlib-metadata
+zipp==1.2.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/github.in
+++ b/requirements/github.in
@@ -1,0 +1,5 @@
+# Forks and other dependencies not yet on PyPI
+
+# Forked to get Django 2.2 support from unreleased master branch from social-app-django repo.
+# This can be removed once an official social-auth-app-django Pypi release with Django 2.2 support is available in the future.
+git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django

--- a/requirements/local.in
+++ b/requirements/local.in
@@ -1,5 +1,6 @@
 # Packages required for standalone local development
 -c constraints.txt
+-r github.in              # Forks and other dependencies not yet on PyPI
 
 -r test.in
 -r docs.in

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -14,13 +14,13 @@ aws-sam-translator==1.20.1  # via cfn-lint
 aws-xray-sdk==2.4.3       # via moto
 babel==2.8.0              # via sphinx
 billiard==3.3.0.23        # via celery
-boto3==1.11.17            # via aws-sam-translator, moto
+boto3==1.12.1             # via aws-sam-translator, moto
 boto==2.49.0              # via moto
-botocore==1.14.17         # via aws-xray-sdk, boto3, moto, s3transfer
+botocore==1.15.1          # via aws-xray-sdk, boto3, moto, s3transfer
 celery==3.1.26.post2
 certifi==2019.11.28       # via requests
 cffi==1.14.0              # via cryptography
-cfn-lint==0.27.5          # via moto
+cfn-lint==0.28.1          # via moto
 chardet==3.0.4            # via requests
 click-log==0.3.2          # via edx-lint
 click==7.0                # via click-log, code-annotations, edx-lint
@@ -40,7 +40,7 @@ django-mysql==3.3.0
 django-simple-history==2.8.0
 django-storages==1.8
 django-user-tasks==0.3.0
-django-waffle==0.19.0
+django-waffle==0.20.0
 django==1.11.28
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.11.0
@@ -50,7 +50,7 @@ docutils==0.15.2          # via botocore, sphinx
 ecdsa==0.15               # via python-jose
 edx-auth-backends==3.0.2
 edx-django-release-util==0.3.6
-edx-django-utils==2.0.4   # via edx-drf-extensions
+edx-django-utils==3.0     # via edx-drf-extensions
 edx-drf-extensions==2.4.6
 edx-i18n-tools==0.5.0
 edx-lint==1.3.0
@@ -58,8 +58,8 @@ edx-opaque-keys==2.0.1    # via edx-drf-extensions
 edx-rest-api-client==1.9.2
 edx-sphinx-theme==1.5.0
 factory-boy==2.12.0
-faker==4.0.0
-freezegun==0.3.14
+faker==4.0.1
+freezegun==0.3.15
 future==0.18.2            # via aws-xray-sdk, pyjwkest
 idna==2.8                 # via moto, requests
 imagesize==1.2.0          # via sphinx
@@ -131,11 +131,11 @@ ruamel.yaml.convert==0.3.2  # via ruamel.yaml.cmd
 ruamel.yaml==0.16.10      # via ruamel.yaml.cmd, ruamel.yaml.convert
 s3transfer==0.3.3         # via boto3
 semantic-version==2.8.4   # via edx-drf-extensions
-six==1.14.0               # via analytics-python, astroid, aws-sam-translator, cfn-lint, configobj, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, django-waffle, docker, ecdsa, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, freezegun, jsonschema, mock, moto, packaging, pathlib2, pyjwkest, pylint, pyrsistent, python-dateutil, python-jose, responses, social-auth-app-django, social-auth-core, sphinx, stevedore, transifex-client, websocket-client
+six==1.14.0               # via analytics-python, astroid, aws-sam-translator, cfn-lint, configobj, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, django-waffle, docker, ecdsa, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, freezegun, jsonschema, mock, moto, packaging, pathlib2, pyjwkest, pylint, pyrsistent, python-dateutil, python-jose, responses, social-auth-core, sphinx, stevedore, transifex-client, websocket-client
 slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==2.0.0    # via sphinx
-social-auth-app-django==3.1.0  # via edx-auth-backends
-social-auth-core==3.2.0   # via edx-auth-backends, social-auth-app-django
+git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django
+social-auth-core==3.2.0   # via edx-auth-backends
 sphinx==1.6.7
 sphinxcontrib-websupport==1.2.0  # via sphinx
 sqlparse==0.3.0           # via django-debug-toolbar
@@ -147,11 +147,11 @@ urllib3==1.25.8           # via botocore, requests, transifex-client
 wcwidth==0.1.8            # via pytest
 websocket-client==0.57.0  # via docker
 werkzeug==1.0.0           # via moto
-wrapt==1.11.2             # via astroid, aws-xray-sdk
+wrapt==1.12.0             # via astroid, aws-xray-sdk
 xmltodict==0.12.0         # via moto
 yamllint==1.20.0
 yarg==0.1.9               # via pipreqs
-zipp==1.1.0               # via importlib-metadata
+zipp==1.2.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/monitoring/requirements.txt
+++ b/requirements/monitoring/requirements.txt
@@ -14,13 +14,13 @@ aws-sam-translator==1.20.1  # via cfn-lint
 aws-xray-sdk==2.4.3       # via moto
 babel==2.8.0              # via sphinx
 billiard==3.3.0.23        # via celery
-boto3==1.11.17
+boto3==1.12.1
 boto==2.49.0              # via moto
-botocore==1.14.17         # via aws-xray-sdk, boto3, moto, s3transfer
+botocore==1.15.1          # via aws-xray-sdk, boto3, moto, s3transfer
 celery==3.1.26.post2
 certifi==2019.11.28       # via requests
 cffi==1.14.0              # via cryptography
-cfn-lint==0.27.5          # via moto
+cfn-lint==0.28.1          # via moto
 chardet==3.0.4            # via requests
 click-log==0.3.2          # via edx-lint
 click==7.0                # via click-log, code-annotations, edx-lint
@@ -40,7 +40,7 @@ django-mysql==3.3.0
 django-simple-history==2.8.0
 django-storages==1.8
 django-user-tasks==0.3.0
-django-waffle==0.19.0
+django-waffle==0.20.0
 django==1.11.28
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.11.0
@@ -50,7 +50,7 @@ docutils==0.15.2          # via botocore, sphinx
 ecdsa==0.15               # via python-jose
 edx-auth-backends==3.0.2
 edx-django-release-util==0.3.6
-edx-django-utils==2.0.4   # via edx-drf-extensions
+edx-django-utils==3.0     # via edx-drf-extensions
 edx-drf-extensions==2.4.6
 edx-i18n-tools==0.5.0
 edx-lint==1.3.0
@@ -58,8 +58,8 @@ edx-opaque-keys==2.0.1    # via edx-drf-extensions
 edx-rest-api-client==1.9.2
 edx-sphinx-theme==1.5.0
 factory-boy==2.12.0
-faker==4.0.0
-freezegun==0.3.14
+faker==4.0.1
+freezegun==0.3.15
 future==0.18.2            # via aws-xray-sdk, pyjwkest
 gevent==1.4.0
 greenlet==0.4.15          # via gevent
@@ -136,11 +136,11 @@ ruamel.yaml.convert==0.3.2  # via ruamel.yaml.cmd
 ruamel.yaml==0.16.10      # via ruamel.yaml.cmd, ruamel.yaml.convert
 s3transfer==0.3.3         # via boto3
 semantic-version==2.8.4   # via edx-drf-extensions
-six==1.14.0               # via analytics-python, astroid, aws-sam-translator, cfn-lint, configobj, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, django-waffle, docker, ecdsa, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, freezegun, jsonschema, mock, moto, packaging, pathlib2, pyjwkest, pylint, pyrsistent, python-dateutil, python-jose, python-memcached, responses, social-auth-app-django, social-auth-core, sphinx, stevedore, transifex-client, websocket-client
+six==1.14.0               # via analytics-python, astroid, aws-sam-translator, cfn-lint, configobj, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, django-waffle, docker, ecdsa, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, freezegun, jsonschema, mock, moto, packaging, pathlib2, pyjwkest, pylint, pyrsistent, python-dateutil, python-jose, python-memcached, responses, social-auth-core, sphinx, stevedore, transifex-client, websocket-client
 slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==2.0.0    # via sphinx
-social-auth-app-django==3.1.0  # via edx-auth-backends
-social-auth-core==3.2.0   # via edx-auth-backends, social-auth-app-django
+git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django
+social-auth-core==3.2.0   # via edx-auth-backends
 sphinx==1.6.7
 sphinxcontrib-websupport==1.2.0  # via sphinx
 sqlparse==0.3.0           # via django-debug-toolbar
@@ -152,11 +152,11 @@ urllib3==1.25.8           # via botocore, requests, transifex-client
 wcwidth==0.1.8            # via pytest
 websocket-client==0.57.0  # via docker
 werkzeug==1.0.0           # via moto
-wrapt==1.11.2             # via astroid, aws-xray-sdk
+wrapt==1.12.0             # via astroid, aws-xray-sdk
 xmltodict==0.12.0         # via moto
 yamllint==1.20.0
 yarg==0.1.9               # via pipreqs
-zipp==1.1.0               # via importlib-metadata
+zipp==1.2.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -8,8 +8,8 @@ amqp==1.4.9               # via kombu
 analytics-python==1.2.9
 anyjson==0.3.3            # via kombu
 billiard==3.3.0.23        # via celery
-boto3==1.11.17
-botocore==1.14.17         # via boto3, s3transfer
+boto3==1.12.1
+botocore==1.15.1          # via boto3, s3transfer
 celery==3.1.26.post2
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
@@ -22,14 +22,14 @@ django-mysql==3.3.0
 django-simple-history==2.8.0
 django-storages==1.8
 django-user-tasks==0.3.0
-django-waffle==0.19.0
+django-waffle==0.20.0
 django==1.11.28
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.11.0
 docutils==0.15.2          # via botocore
 edx-auth-backends==3.0.2
 edx-django-release-util==0.3.6
-edx-django-utils==2.0.4   # via edx-drf-extensions
+edx-django-utils==3.0     # via edx-drf-extensions
 edx-drf-extensions==2.4.6
 edx-opaque-keys==2.0.1    # via edx-drf-extensions
 edx-rest-api-client==1.9.2
@@ -60,10 +60,10 @@ requests==2.22.0          # via analytics-python, edx-drf-extensions, edx-rest-a
 rest-condition==1.0.3     # via edx-drf-extensions
 s3transfer==0.3.3         # via boto3
 semantic-version==2.8.4   # via edx-drf-extensions
-six==1.14.0               # via analytics-python, django-extensions, django-simple-history, django-waffle, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-opaque-keys, pyjwkest, python-dateutil, python-memcached, social-auth-app-django, social-auth-core, stevedore
+six==1.14.0               # via analytics-python, django-extensions, django-simple-history, django-waffle, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-opaque-keys, pyjwkest, python-dateutil, python-memcached, social-auth-core, stevedore
 slumber==0.7.1            # via edx-rest-api-client
-social-auth-app-django==3.1.0  # via edx-auth-backends
-social-auth-core==3.2.0   # via edx-auth-backends, social-auth-app-django
+git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django
+social-auth-core==3.2.0   # via edx-auth-backends
 stevedore==1.32.0         # via edx-opaque-keys
 urllib3==1.25.8           # via botocore, requests
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -12,13 +12,13 @@ attrs==19.3.0             # via jsonschema, pytest
 aws-sam-translator==1.20.1  # via cfn-lint
 aws-xray-sdk==2.4.3       # via moto
 billiard==3.3.0.23        # via celery
-boto3==1.11.17            # via aws-sam-translator, moto
+boto3==1.12.1             # via aws-sam-translator, moto
 boto==2.49.0              # via moto
-botocore==1.14.17         # via aws-xray-sdk, boto3, moto, s3transfer
+botocore==1.15.1          # via aws-xray-sdk, boto3, moto, s3transfer
 celery==3.1.26.post2
 certifi==2019.11.28       # via requests
 cffi==1.14.0              # via cryptography
-cfn-lint==0.27.5          # via moto
+cfn-lint==0.28.1          # via moto
 chardet==3.0.4            # via requests
 click-log==0.3.2          # via edx-lint
 click==7.0                # via click-log, code-annotations, edx-lint
@@ -36,7 +36,7 @@ django-mysql==3.3.0
 django-simple-history==2.8.0
 django-storages==1.8
 django-user-tasks==0.3.0
-django-waffle==0.19.0
+django-waffle==0.20.0
 django==1.11.28
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.11.0
@@ -46,14 +46,14 @@ docutils==0.15.2          # via botocore
 ecdsa==0.15               # via python-jose
 edx-auth-backends==3.0.2
 edx-django-release-util==0.3.6
-edx-django-utils==2.0.4   # via edx-drf-extensions
+edx-django-utils==3.0     # via edx-drf-extensions
 edx-drf-extensions==2.4.6
 edx-lint==1.3.0
 edx-opaque-keys==2.0.1    # via edx-drf-extensions
 edx-rest-api-client==1.9.2
 factory-boy==2.12.0
-faker==4.0.0
-freezegun==0.3.14
+faker==4.0.1
+freezegun==0.3.15
 future==0.18.2            # via aws-xray-sdk, pyjwkest
 idna==2.8                 # via moto, requests
 importlib-metadata==1.5.0  # via jsonschema, pluggy, pytest
@@ -114,21 +114,21 @@ rest-condition==1.0.3     # via edx-drf-extensions
 rsa==4.0                  # via python-jose
 s3transfer==0.3.3         # via boto3
 semantic-version==2.8.4   # via edx-drf-extensions
-six==1.14.0               # via analytics-python, astroid, aws-sam-translator, cfn-lint, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, django-waffle, docker, ecdsa, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-lint, edx-opaque-keys, freezegun, jsonschema, mock, moto, packaging, pathlib2, pyjwkest, pylint, pyrsistent, python-dateutil, python-jose, responses, social-auth-app-django, social-auth-core, stevedore, websocket-client
+six==1.14.0               # via analytics-python, astroid, aws-sam-translator, cfn-lint, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, django-waffle, docker, ecdsa, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-lint, edx-opaque-keys, freezegun, jsonschema, mock, moto, packaging, pathlib2, pyjwkest, pylint, pyrsistent, python-dateutil, python-jose, responses, social-auth-core, stevedore, websocket-client
 slumber==0.7.1            # via edx-rest-api-client
-social-auth-app-django==3.1.0  # via edx-auth-backends
-social-auth-core==3.2.0   # via edx-auth-backends, social-auth-app-django
+git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django
+social-auth-core==3.2.0   # via edx-auth-backends
 stevedore==1.32.0         # via code-annotations, edx-opaque-keys
 text-unidecode==1.3       # via faker, python-slugify
 urllib3==1.25.8           # via botocore, requests
 wcwidth==0.1.8            # via pytest
 websocket-client==0.57.0  # via docker
 werkzeug==1.0.0           # via moto
-wrapt==1.11.2             # via astroid, aws-xray-sdk
+wrapt==1.12.0             # via astroid, aws-xray-sdk
 xmltodict==0.12.0         # via moto
 yamllint==1.20.0
 yarg==0.1.9               # via pipreqs
-zipp==1.1.0               # via importlib-metadata
+zipp==1.2.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip


### PR DESCRIPTION
Related JIRA Link : [https://openedx.atlassian.net/browse/BOM-1286](https://openedx.atlassian.net/browse/BOM-1286)