### PR TITLE
Fix python requirements by pinning zipp to less than 2.0.0

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -19,3 +19,5 @@ django-storages<1.9
 
 # Requires: Python >=3.6
 mock<4.0.0
+
+zipp<2.0.0

--- a/requirements/devstack.txt
+++ b/requirements/devstack.txt
@@ -6,7 +6,7 @@
 #
 alabaster==0.7.12         # via sphinx
 amqp==1.4.9               # via kombu
-analytics-python==1.2.9   # via -r requirements/base.in (line 4)
+analytics-python==1.2.9   # via -r requirements/base.in
 anyjson==0.3.3            # via kombu
 appdirs==1.4.3            # via virtualenv
 astroid==2.3.3            # via pylint, pylint-celery
@@ -15,60 +15,60 @@ aws-sam-translator==1.21.0  # via cfn-lint
 aws-xray-sdk==2.4.3       # via moto
 babel==2.8.0              # via sphinx
 billiard==3.3.0.23        # via celery
-boto3==1.12.9             # via aws-sam-translator, moto
+boto3==1.12.11            # via aws-sam-translator, moto
 boto==2.49.0              # via moto
-botocore==1.15.9          # via aws-xray-sdk, boto3, moto, s3transfer
-celery==3.1.26.post2      # via -r requirements/base.in (line 5)
+botocore==1.15.11         # via aws-xray-sdk, boto3, moto, s3transfer
+celery==3.1.26.post2      # via -r requirements/base.in
 certifi==2019.11.28       # via requests
 cffi==1.14.0              # via cryptography
 cfn-lint==0.28.2          # via moto
 chardet==3.0.4            # via requests
 click-log==0.3.2          # via edx-lint
 click==7.0                # via click-log, code-annotations, edx-lint
-code-annotations==0.3.3   # via -r requirements/test.in (line 8)
+code-annotations==0.3.3   # via -r requirements/test.in
 configobj==5.0.6          # via ruamel.yaml.cmd
-coverage==5.0.3           # via -r requirements/test.in (line 6), pytest-cov
+coverage==5.0.3           # via -r requirements/test.in, pytest-cov
 cryptography==2.8         # via moto
-ddt==1.2.2                # via -r requirements/test.in (line 14)
+ddt==1.2.2                # via -r requirements/test.in
 defusedxml==0.6.0         # via python3-openid, social-auth-core
 distlib==0.3.0            # via virtualenv
-django-cors-headers==3.2.1  # via -r requirements/base.in (line 8)
-django-debug-toolbar==2.2  # via -r requirements/local.in (line 8)
-django-dynamic-fixture==3.0.2  # via -r requirements/test.in (line 7)
-django-extensions==2.2.8  # via -r requirements/base.in (line 9)
-django-guardian==2.0.0    # via -c requirements/constraints.txt (line 12), -r requirements/base.in (line 10)
-django-model-utils==3.2.0  # via -c requirements/constraints.txt (line 13), -r requirements/base.in (line 11), django-user-tasks
-django-mysql==3.3.0       # via -r requirements/base.in (line 12)
-django-simple-history==2.8.0  # via -r requirements/base.in (line 13)
-django-storages==1.8      # via -c requirements/constraints.txt (line 17), -r requirements/base.in (line 14)
-django-user-tasks==0.3.0  # via -r requirements/base.in (line 15)
-django-waffle==0.20.0     # via -r requirements/base.in (line 16), edx-django-utils, edx-drf-extensions
-django==1.11.28           # via -r requirements/base.in (line 6), code-annotations, django-cors-headers, django-debug-toolbar, django-model-utils, django-mysql, django-storages, djangorestframework, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-i18n-tools, rest-condition
+django-cors-headers==3.2.1  # via -r requirements/base.in
+django-debug-toolbar==2.2  # via -r requirements/local.in
+django-dynamic-fixture==3.0.2  # via -r requirements/test.in
+django-extensions==2.2.8  # via -r requirements/base.in
+django-guardian==2.0.0    # via -c requirements/constraints.txt, -r requirements/base.in
+django-model-utils==3.2.0  # via -c requirements/constraints.txt, -r requirements/base.in, django-user-tasks
+django-mysql==3.3.0       # via -r requirements/base.in
+django-simple-history==2.8.0  # via -r requirements/base.in
+django-storages==1.8      # via -c requirements/constraints.txt, -r requirements/base.in
+django-user-tasks==0.3.0  # via -r requirements/base.in
+django-waffle==0.20.0     # via -r requirements/base.in, edx-django-utils, edx-drf-extensions
+django==1.11.28           # via -r requirements/base.in, code-annotations, django-cors-headers, django-debug-toolbar, django-model-utils, django-mysql, django-storages, djangorestframework, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-i18n-tools, rest-condition
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
-djangorestframework==3.11.0  # via -r requirements/base.in (line 7), django-user-tasks, edx-drf-extensions, rest-condition
+djangorestframework==3.11.0  # via -r requirements/base.in, django-user-tasks, edx-drf-extensions, rest-condition
 docker==4.2.0             # via moto
 docopt==0.6.2             # via pipreqs
 docutils==0.15.2          # via botocore, sphinx
 ecdsa==0.15               # via python-jose
-edx-auth-backends==3.0.2  # via -r requirements/base.in (line 17)
-edx-django-release-util==0.3.6  # via -r requirements/base.in (line 18)
+edx-auth-backends==3.0.2  # via -r requirements/base.in
+edx-django-release-util==0.3.6  # via -r requirements/base.in
 edx-django-utils==3.0     # via edx-drf-extensions
-edx-drf-extensions==3.0.0  # via -r requirements/base.in (line 19)
-edx-i18n-tools==0.5.0     # via -r requirements/local.in (line 9)
-edx-lint==1.4.1           # via -r requirements/test.in (line 9)
+edx-drf-extensions==3.0.0  # via -r requirements/base.in
+edx-i18n-tools==0.5.0     # via -r requirements/local.in
+edx-lint==1.4.1           # via -r requirements/test.in
 edx-opaque-keys==2.0.1    # via edx-drf-extensions
-edx-rest-api-client==1.9.2  # via -r requirements/base.in (line 20)
-edx-sphinx-theme==1.5.0   # via -r requirements/docs.in (line 2)
-factory-boy==2.12.0       # via -r requirements/test.in (line 10)
-faker==4.0.1              # via -r requirements/test.in (line 11), factory-boy
+edx-rest-api-client==1.9.2  # via -r requirements/base.in
+edx-sphinx-theme==1.5.0   # via -r requirements/docs.in
+factory-boy==2.12.0       # via -r requirements/test.in
+faker==4.0.1              # via -r requirements/test.in, factory-boy
 filelock==3.0.12          # via tox, virtualenv
-freezegun==0.3.15         # via -r requirements/test.in (line 12)
+freezegun==0.3.15         # via -r requirements/test.in
 future==0.18.2            # via aws-xray-sdk, pyjwkest
 idna==2.8                 # via moto, requests
 imagesize==1.2.0          # via sphinx
 importlib-metadata==1.5.0  # via jsonschema, path, pluggy, pytest, tox, virtualenv
 importlib-resources==1.0.2  # via cfn-lint, virtualenv
-isort[requirements]==4.3.21  # via -r requirements/test.in (line 21), pylint
+isort[requirements]==4.3.21  # via -r requirements/test.in, pylint
 jinja2==2.11.1            # via code-annotations, moto, sphinx
 jmespath==0.9.5           # via boto3, botocore
 jsondiff==1.1.2           # via moto
@@ -80,15 +80,16 @@ kombu==3.0.37             # via celery
 lazy-object-proxy==1.4.3  # via astroid
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via pylint
-mock==3.0.5               # via -c requirements/constraints.txt (line 21), moto
+mock==3.0.5               # via -c requirements/constraints.txt, moto
 more-itertools==8.2.0     # via pytest
-moto==1.3.8               # via -r requirements/test.in (line 13)
-mysqlclient==1.3.14       # via -r requirements/nonlocal.in (line 3)
+moto==1.3.8               # via -r requirements/test.in
+mysqlclient==1.3.14       # via -r requirements/nonlocal.in
 newrelic==5.8.0.136       # via edx-django-utils
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 packaging==20.1           # via pytest, tox
 path.py==12.4.0           # via edx-i18n-tools
 path==13.1.0              # via path.py
+pathlib2==2.3.5           # via pytest
 pathspec==0.7.0           # via yamllint
 pbr==5.4.4                # via stevedore
 pip-api==0.0.13           # via isort
@@ -98,11 +99,11 @@ polib==1.1.0              # via edx-i18n-tools
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
 py==1.8.1                 # via pytest, tox
 pyasn1==0.4.8             # via python-jose, rsa
-pycodestyle==2.5.0        # via -r requirements/test.in (line 15)
+pycodestyle==2.5.0        # via -r requirements/test.in
 pycparser==2.19           # via cffi
 pycryptodomex==3.9.7      # via pyjwkest
 pygments==2.5.2           # via sphinx
-pyinotify==0.9.6          # via -r requirements/local.in (line 10)
+pyinotify==0.9.6          # via -r requirements/local.in
 pyjwkest==1.3.2           # via edx-drf-extensions
 pyjwt==1.7.1              # via djangorestframework-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint-celery==0.3        # via edx-lint
@@ -112,42 +113,42 @@ pylint==2.4.2             # via edx-lint, pylint-celery, pylint-django, pylint-p
 pymongo==3.10.1           # via edx-opaque-keys
 pyparsing==2.4.6          # via packaging
 pyrsistent==0.15.7        # via jsonschema
-pytest-cov==2.8.1         # via -r requirements/test.in (line 17)
-pytest-django==3.8.0      # via -r requirements/test.in (line 18)
-pytest==5.3.5             # via -r requirements/test.in (line 16), pytest-cov, pytest-django
+pytest-cov==2.8.1         # via -r requirements/test.in
+pytest-django==3.8.0      # via -r requirements/test.in
+pytest==5.3.5             # via -r requirements/test.in, pytest-cov, pytest-django
 python-dateutil==2.8.1    # via analytics-python, botocore, edx-drf-extensions, faker, freezegun, moto, ruamel.yaml.convert
 python-jose==3.1.0        # via moto
-python-memcached==1.59    # via -r requirements/nonlocal.in (line 4)
+python-memcached==1.59    # via -r requirements/nonlocal.in
 python-slugify==1.2.6     # via code-annotations, transifex-client
 python3-openid==3.1.0     # via social-auth-core
-pytz==2019.3              # via -r requirements/base.in (line 21), babel, celery, django, moto
+pytz==2019.3              # via -r requirements/base.in, babel, celery, django, moto
 pyyaml==5.3               # via cfn-lint, code-annotations, edx-django-release-util, edx-i18n-tools, moto, yamllint
-redis==2.8                # via -r requirements/base.in (line 22)
+redis==2.8                # via -r requirements/base.in
 requests-oauthlib==1.3.0  # via social-auth-core
 requests==2.23.0          # via analytics-python, docker, edx-drf-extensions, edx-rest-api-client, moto, pyjwkest, requests-oauthlib, responses, slumber, social-auth-core, sphinx, transifex-client, yarg
-responses==0.10.11        # via -r requirements/test.in (line 19), moto
+responses==0.10.11        # via -r requirements/test.in, moto
 rest-condition==1.0.3     # via edx-drf-extensions
 rsa==4.0                  # via python-jose
 ruamel.std.argparse==0.8.1  # via ruamel.yaml.cmd
 ruamel.yaml.clib==0.2.0   # via ruamel.yaml
-ruamel.yaml.cmd==0.5.5    # via -r requirements/local.in (line 11)
+ruamel.yaml.cmd==0.5.5    # via -r requirements/local.in
 ruamel.yaml.convert==0.3.2  # via ruamel.yaml.cmd
 ruamel.yaml==0.16.10      # via ruamel.yaml.cmd, ruamel.yaml.convert
 s3transfer==0.3.3         # via boto3
 semantic-version==2.8.4   # via edx-drf-extensions
-six==1.14.0               # via analytics-python, astroid, aws-sam-translator, cfn-lint, configobj, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, django-waffle, docker, ecdsa, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, freezegun, jsonschema, mock, moto, packaging, pyjwkest, python-dateutil, python-jose, python-memcached, responses, social-auth-app-django, social-auth-core, sphinx, stevedore, transifex-client, websocket-client
+six==1.14.0               # via analytics-python, astroid, aws-sam-translator, cfn-lint, configobj, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, django-waffle, docker, ecdsa, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, freezegun, jsonschema, mock, moto, packaging, pathlib2, pyjwkest, python-dateutil, python-jose, python-memcached, responses, social-auth-app-django, social-auth-core, sphinx, stevedore, tox, transifex-client, virtualenv, websocket-client
 slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==2.0.0    # via sphinx
-git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/github.in (line 5), edx-auth-backends
+git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/github.in, edx-auth-backends
 social-auth-core==3.2.0   # via edx-auth-backends, social-auth-app-django
-sphinx==1.6.7             # via -r requirements/docs.in (line 1), edx-sphinx-theme
+sphinx==1.6.7             # via -r requirements/docs.in, edx-sphinx-theme
 sphinxcontrib-websupport==1.2.0  # via sphinx
-sqlparse==0.3.0           # via django-debug-toolbar
+sqlparse==0.3.1           # via django-debug-toolbar
 stevedore==1.32.0         # via code-annotations, edx-opaque-keys
 text-unidecode==1.3       # via faker
 toml==0.10.0              # via tox
-tox==3.14.5               # via -r requirements/test.in (line 22)
-transifex-client==0.13.7  # via -r requirements/local.in (line 12)
+tox==3.14.5               # via -r requirements/test.in
+transifex-client==0.13.7  # via -r requirements/local.in
 typed-ast==1.4.1          # via astroid
 unidecode==1.1.1          # via python-slugify
 urllib3==1.25.8           # via botocore, requests, transifex-client
@@ -157,9 +158,9 @@ websocket-client==0.57.0  # via docker
 werkzeug==1.0.0           # via moto
 wrapt==1.11.2             # via astroid, aws-xray-sdk
 xmltodict==0.12.0         # via moto
-yamllint==1.20.0          # via -r requirements/test.in (line 20)
+yamllint==1.20.0          # via -r requirements/test.in
 yarg==0.1.9               # via pipreqs
-zipp==3.0.0               # via importlib-metadata
+zipp==1.2.0               # via -c requirements/constraints.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/django.txt
+++ b/requirements/django.txt
@@ -1,1 +1,1 @@
-django==1.11.28           # via -r requirements/base.in (line 6), django-cors-headers, django-model-utils, django-mysql, django-storages, djangorestframework, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition
+django==1.11.28           # via -r requirements/base.in, django-cors-headers, django-model-utils, django-mysql, django-storages, djangorestframework, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -6,7 +6,7 @@
 #
 alabaster==0.7.12         # via sphinx
 amqp==1.4.9               # via kombu
-analytics-python==1.2.9   # via -r requirements/base.in (line 4)
+analytics-python==1.2.9   # via -r requirements/base.in
 anyjson==0.3.3            # via kombu
 appdirs==1.4.3            # via virtualenv
 astroid==2.3.3            # via pylint, pylint-celery
@@ -15,60 +15,60 @@ aws-sam-translator==1.21.0  # via cfn-lint
 aws-xray-sdk==2.4.3       # via moto
 babel==2.8.0              # via sphinx
 billiard==3.3.0.23        # via celery
-boto3==1.12.9             # via aws-sam-translator, moto
+boto3==1.12.11            # via aws-sam-translator, moto
 boto==2.49.0              # via moto
-botocore==1.15.9          # via aws-xray-sdk, boto3, moto, s3transfer
-celery==3.1.26.post2      # via -r requirements/base.in (line 5)
+botocore==1.15.11         # via aws-xray-sdk, boto3, moto, s3transfer
+celery==3.1.26.post2      # via -r requirements/base.in
 certifi==2019.11.28       # via requests
 cffi==1.14.0              # via cryptography
 cfn-lint==0.28.2          # via moto
 chardet==3.0.4            # via requests
 click-log==0.3.2          # via edx-lint
 click==7.0                # via click-log, code-annotations, edx-lint
-code-annotations==0.3.3   # via -r requirements/test.in (line 8)
+code-annotations==0.3.3   # via -r requirements/test.in
 configobj==5.0.6          # via ruamel.yaml.cmd
-coverage==5.0.3           # via -r requirements/test.in (line 6), pytest-cov
+coverage==5.0.3           # via -r requirements/test.in, pytest-cov
 cryptography==2.8         # via moto
-ddt==1.2.2                # via -r requirements/test.in (line 14)
+ddt==1.2.2                # via -r requirements/test.in
 defusedxml==0.6.0         # via python3-openid, social-auth-core
 distlib==0.3.0            # via virtualenv
-django-cors-headers==3.2.1  # via -r requirements/base.in (line 8)
-django-debug-toolbar==2.2  # via -r requirements/local.in (line 8)
-django-dynamic-fixture==3.0.2  # via -r requirements/test.in (line 7)
-django-extensions==2.2.8  # via -r requirements/base.in (line 9)
-django-guardian==2.0.0    # via -c requirements/constraints.txt (line 12), -r requirements/base.in (line 10)
-django-model-utils==3.2.0  # via -c requirements/constraints.txt (line 13), -r requirements/base.in (line 11), django-user-tasks
-django-mysql==3.3.0       # via -r requirements/base.in (line 12)
-django-simple-history==2.8.0  # via -r requirements/base.in (line 13)
-django-storages==1.8      # via -c requirements/constraints.txt (line 17), -r requirements/base.in (line 14)
-django-user-tasks==0.3.0  # via -r requirements/base.in (line 15)
-django-waffle==0.20.0     # via -r requirements/base.in (line 16), edx-django-utils, edx-drf-extensions
-django==1.11.28           # via -r requirements/base.in (line 6), code-annotations, django-cors-headers, django-debug-toolbar, django-model-utils, django-mysql, django-storages, djangorestframework, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-i18n-tools, rest-condition
+django-cors-headers==3.2.1  # via -r requirements/base.in
+django-debug-toolbar==2.2  # via -r requirements/local.in
+django-dynamic-fixture==3.0.2  # via -r requirements/test.in
+django-extensions==2.2.8  # via -r requirements/base.in
+django-guardian==2.0.0    # via -c requirements/constraints.txt, -r requirements/base.in
+django-model-utils==3.2.0  # via -c requirements/constraints.txt, -r requirements/base.in, django-user-tasks
+django-mysql==3.3.0       # via -r requirements/base.in
+django-simple-history==2.8.0  # via -r requirements/base.in
+django-storages==1.8      # via -c requirements/constraints.txt, -r requirements/base.in
+django-user-tasks==0.3.0  # via -r requirements/base.in
+django-waffle==0.20.0     # via -r requirements/base.in, edx-django-utils, edx-drf-extensions
+django==1.11.28           # via -r requirements/base.in, code-annotations, django-cors-headers, django-debug-toolbar, django-model-utils, django-mysql, django-storages, djangorestframework, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-i18n-tools, rest-condition
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
-djangorestframework==3.11.0  # via -r requirements/base.in (line 7), django-user-tasks, edx-drf-extensions, rest-condition
+djangorestframework==3.11.0  # via -r requirements/base.in, django-user-tasks, edx-drf-extensions, rest-condition
 docker==4.2.0             # via moto
 docopt==0.6.2             # via pipreqs
 docutils==0.15.2          # via botocore, sphinx
 ecdsa==0.15               # via python-jose
-edx-auth-backends==3.0.2  # via -r requirements/base.in (line 17)
-edx-django-release-util==0.3.6  # via -r requirements/base.in (line 18)
+edx-auth-backends==3.0.2  # via -r requirements/base.in
+edx-django-release-util==0.3.6  # via -r requirements/base.in
 edx-django-utils==3.0     # via edx-drf-extensions
-edx-drf-extensions==3.0.0  # via -r requirements/base.in (line 19)
-edx-i18n-tools==0.5.0     # via -r requirements/local.in (line 9)
-edx-lint==1.4.1           # via -r requirements/test.in (line 9)
+edx-drf-extensions==3.0.0  # via -r requirements/base.in
+edx-i18n-tools==0.5.0     # via -r requirements/local.in
+edx-lint==1.4.1           # via -r requirements/test.in
 edx-opaque-keys==2.0.1    # via edx-drf-extensions
-edx-rest-api-client==1.9.2  # via -r requirements/base.in (line 20)
-edx-sphinx-theme==1.5.0   # via -r requirements/docs.in (line 2)
-factory-boy==2.12.0       # via -r requirements/test.in (line 10)
-faker==4.0.1              # via -r requirements/test.in (line 11), factory-boy
+edx-rest-api-client==1.9.2  # via -r requirements/base.in
+edx-sphinx-theme==1.5.0   # via -r requirements/docs.in
+factory-boy==2.12.0       # via -r requirements/test.in
+faker==4.0.1              # via -r requirements/test.in, factory-boy
 filelock==3.0.12          # via tox, virtualenv
-freezegun==0.3.15         # via -r requirements/test.in (line 12)
+freezegun==0.3.15         # via -r requirements/test.in
 future==0.18.2            # via aws-xray-sdk, pyjwkest
 idna==2.8                 # via moto, requests
 imagesize==1.2.0          # via sphinx
 importlib-metadata==1.5.0  # via jsonschema, path, pluggy, pytest, tox, virtualenv
 importlib-resources==1.0.2  # via cfn-lint, virtualenv
-isort[requirements]==4.3.21  # via -r requirements/test.in (line 21), pylint
+isort[requirements]==4.3.21  # via -r requirements/test.in, pylint
 jinja2==2.11.1            # via code-annotations, moto, sphinx
 jmespath==0.9.5           # via boto3, botocore
 jsondiff==1.1.2           # via moto
@@ -80,14 +80,15 @@ kombu==3.0.37             # via celery
 lazy-object-proxy==1.4.3  # via astroid
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via pylint
-mock==3.0.5               # via -c requirements/constraints.txt (line 21), moto
+mock==3.0.5               # via -c requirements/constraints.txt, moto
 more-itertools==8.2.0     # via pytest
-moto==1.3.8               # via -r requirements/test.in (line 13)
+moto==1.3.8               # via -r requirements/test.in
 newrelic==5.8.0.136       # via edx-django-utils
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 packaging==20.1           # via pytest, tox
 path.py==12.4.0           # via edx-i18n-tools
 path==13.1.0              # via path.py
+pathlib2==2.3.5           # via pytest
 pathspec==0.7.0           # via yamllint
 pbr==5.4.4                # via stevedore
 pip-api==0.0.13           # via isort
@@ -97,11 +98,11 @@ polib==1.1.0              # via edx-i18n-tools
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
 py==1.8.1                 # via pytest, tox
 pyasn1==0.4.8             # via python-jose, rsa
-pycodestyle==2.5.0        # via -r requirements/test.in (line 15)
+pycodestyle==2.5.0        # via -r requirements/test.in
 pycparser==2.19           # via cffi
 pycryptodomex==3.9.7      # via pyjwkest
 pygments==2.5.2           # via sphinx
-pyinotify==0.9.6          # via -r requirements/local.in (line 10)
+pyinotify==0.9.6          # via -r requirements/local.in
 pyjwkest==1.3.2           # via edx-drf-extensions
 pyjwt==1.7.1              # via djangorestframework-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint-celery==0.3        # via edx-lint
@@ -111,41 +112,41 @@ pylint==2.4.2             # via edx-lint, pylint-celery, pylint-django, pylint-p
 pymongo==3.10.1           # via edx-opaque-keys
 pyparsing==2.4.6          # via packaging
 pyrsistent==0.15.7        # via jsonschema
-pytest-cov==2.8.1         # via -r requirements/test.in (line 17)
-pytest-django==3.8.0      # via -r requirements/test.in (line 18)
-pytest==5.3.5             # via -r requirements/test.in (line 16), pytest-cov, pytest-django
+pytest-cov==2.8.1         # via -r requirements/test.in
+pytest-django==3.8.0      # via -r requirements/test.in
+pytest==5.3.5             # via -r requirements/test.in, pytest-cov, pytest-django
 python-dateutil==2.8.1    # via analytics-python, botocore, edx-drf-extensions, faker, freezegun, moto, ruamel.yaml.convert
 python-jose==3.1.0        # via moto
 python-slugify==1.2.6     # via code-annotations, transifex-client
 python3-openid==3.1.0     # via social-auth-core
-pytz==2019.3              # via -r requirements/base.in (line 21), babel, celery, django, moto
+pytz==2019.3              # via -r requirements/base.in, babel, celery, django, moto
 pyyaml==5.3               # via cfn-lint, code-annotations, edx-django-release-util, edx-i18n-tools, moto, yamllint
-redis==2.8                # via -r requirements/base.in (line 22)
+redis==2.8                # via -r requirements/base.in
 requests-oauthlib==1.3.0  # via social-auth-core
 requests==2.23.0          # via analytics-python, docker, edx-drf-extensions, edx-rest-api-client, moto, pyjwkest, requests-oauthlib, responses, slumber, social-auth-core, sphinx, transifex-client, yarg
-responses==0.10.11        # via -r requirements/test.in (line 19), moto
+responses==0.10.11        # via -r requirements/test.in, moto
 rest-condition==1.0.3     # via edx-drf-extensions
 rsa==4.0                  # via python-jose
 ruamel.std.argparse==0.8.1  # via ruamel.yaml.cmd
 ruamel.yaml.clib==0.2.0   # via ruamel.yaml
-ruamel.yaml.cmd==0.5.5    # via -r requirements/local.in (line 11)
+ruamel.yaml.cmd==0.5.5    # via -r requirements/local.in
 ruamel.yaml.convert==0.3.2  # via ruamel.yaml.cmd
 ruamel.yaml==0.16.10      # via ruamel.yaml.cmd, ruamel.yaml.convert
 s3transfer==0.3.3         # via boto3
 semantic-version==2.8.4   # via edx-drf-extensions
-six==1.14.0               # via analytics-python, astroid, aws-sam-translator, cfn-lint, configobj, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, django-waffle, docker, ecdsa, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, freezegun, jsonschema, mock, moto, packaging, pyjwkest, python-dateutil, python-jose, responses, social-auth-app-django, social-auth-core, sphinx, stevedore, transifex-client, websocket-client
+six==1.14.0               # via analytics-python, astroid, aws-sam-translator, cfn-lint, configobj, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, django-waffle, docker, ecdsa, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, freezegun, jsonschema, mock, moto, packaging, pathlib2, pyjwkest, python-dateutil, python-jose, responses, social-auth-app-django, social-auth-core, sphinx, stevedore, tox, transifex-client, virtualenv, websocket-client
 slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==2.0.0    # via sphinx
-git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/github.in (line 5), edx-auth-backends
+git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/github.in, edx-auth-backends
 social-auth-core==3.2.0   # via edx-auth-backends, social-auth-app-django
-sphinx==1.6.7             # via -r requirements/docs.in (line 1), edx-sphinx-theme
+sphinx==1.6.7             # via -r requirements/docs.in, edx-sphinx-theme
 sphinxcontrib-websupport==1.2.0  # via sphinx
-sqlparse==0.3.0           # via django-debug-toolbar
+sqlparse==0.3.1           # via django-debug-toolbar
 stevedore==1.32.0         # via code-annotations, edx-opaque-keys
 text-unidecode==1.3       # via faker
 toml==0.10.0              # via tox
-tox==3.14.5               # via -r requirements/test.in (line 22)
-transifex-client==0.13.7  # via -r requirements/local.in (line 12)
+tox==3.14.5               # via -r requirements/test.in
+transifex-client==0.13.7  # via -r requirements/local.in
 typed-ast==1.4.1          # via astroid
 unidecode==1.1.1          # via python-slugify
 urllib3==1.25.8           # via botocore, requests, transifex-client
@@ -155,9 +156,9 @@ websocket-client==0.57.0  # via docker
 werkzeug==1.0.0           # via moto
 wrapt==1.11.2             # via astroid, aws-xray-sdk
 xmltodict==0.12.0         # via moto
-yamllint==1.20.0          # via -r requirements/test.in (line 20)
+yamllint==1.20.0          # via -r requirements/test.in
 yarg==0.1.9               # via pipreqs
-zipp==3.0.0               # via importlib-metadata
+zipp==1.2.0               # via -c requirements/constraints.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/monitoring/requirements.txt
+++ b/requirements/monitoring/requirements.txt
@@ -6,7 +6,7 @@
 #
 alabaster==0.7.12         # via sphinx
 amqp==1.4.9               # via kombu
-analytics-python==1.2.9   # via -r requirements/monitoring/../base.in (line 4)
+analytics-python==1.2.9   # via -r requirements/monitoring/../base.in
 anyjson==0.3.3            # via kombu
 appdirs==1.4.3            # via virtualenv
 astroid==2.3.3            # via pylint, pylint-celery
@@ -15,63 +15,63 @@ aws-sam-translator==1.21.0  # via cfn-lint
 aws-xray-sdk==2.4.3       # via moto
 babel==2.8.0              # via sphinx
 billiard==3.3.0.23        # via celery
-boto3==1.12.9             # via -r requirements/monitoring/../production.in (line 7), aws-sam-translator, moto
+boto3==1.12.11            # via -r requirements/monitoring/../production.in, aws-sam-translator, moto
 boto==2.49.0              # via moto
-botocore==1.15.9          # via aws-xray-sdk, boto3, moto, s3transfer
-celery==3.1.26.post2      # via -r requirements/monitoring/../base.in (line 5)
+botocore==1.15.11         # via aws-xray-sdk, boto3, moto, s3transfer
+celery==3.1.26.post2      # via -r requirements/monitoring/../base.in
 certifi==2019.11.28       # via requests
 cffi==1.14.0              # via cryptography
 cfn-lint==0.28.2          # via moto
 chardet==3.0.4            # via requests
 click-log==0.3.2          # via edx-lint
 click==7.0                # via click-log, code-annotations, edx-lint
-code-annotations==0.3.3   # via -r requirements/monitoring/../test.in (line 8)
+code-annotations==0.3.3   # via -r requirements/monitoring/../test.in
 configobj==5.0.6          # via ruamel.yaml.cmd
-coverage==5.0.3           # via -r requirements/monitoring/../test.in (line 6), pytest-cov
+coverage==5.0.3           # via -r requirements/monitoring/../test.in, pytest-cov
 cryptography==2.8         # via moto
-ddt==1.2.2                # via -r requirements/monitoring/../test.in (line 14)
+ddt==1.2.2                # via -r requirements/monitoring/../test.in
 defusedxml==0.6.0         # via python3-openid, social-auth-core
 distlib==0.3.0            # via virtualenv
-django-cors-headers==3.2.1  # via -r requirements/monitoring/../base.in (line 8)
-django-debug-toolbar==2.2  # via -r requirements/monitoring/../local.in (line 8)
-django-dynamic-fixture==3.0.2  # via -r requirements/monitoring/../test.in (line 7)
-django-extensions==2.2.8  # via -r requirements/monitoring/../base.in (line 9)
-django-guardian==2.0.0    # via -c requirements/monitoring/../constraints.txt (line 12), -r requirements/monitoring/../base.in (line 10)
-django-model-utils==3.2.0  # via -c requirements/monitoring/../constraints.txt (line 13), -r requirements/monitoring/../base.in (line 11), django-user-tasks
-django-mysql==3.3.0       # via -r requirements/monitoring/../base.in (line 12)
-django-simple-history==2.8.0  # via -r requirements/monitoring/../base.in (line 13)
-django-storages==1.8      # via -c requirements/monitoring/../constraints.txt (line 17), -r requirements/monitoring/../base.in (line 14)
-django-user-tasks==0.3.0  # via -r requirements/monitoring/../base.in (line 15)
-django-waffle==0.20.0     # via -r requirements/monitoring/../base.in (line 16), edx-django-utils, edx-drf-extensions
-django==1.11.28           # via -r requirements/monitoring/../base.in (line 6), code-annotations, django-cors-headers, django-debug-toolbar, django-model-utils, django-mysql, django-storages, djangorestframework, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-i18n-tools, rest-condition
+django-cors-headers==3.2.1  # via -r requirements/monitoring/../base.in
+django-debug-toolbar==2.2  # via -r requirements/monitoring/../local.in
+django-dynamic-fixture==3.0.2  # via -r requirements/monitoring/../test.in
+django-extensions==2.2.8  # via -r requirements/monitoring/../base.in
+django-guardian==2.0.0    # via -c requirements/monitoring/../constraints.txt, -r requirements/monitoring/../base.in
+django-model-utils==3.2.0  # via -c requirements/monitoring/../constraints.txt, -r requirements/monitoring/../base.in, django-user-tasks
+django-mysql==3.3.0       # via -r requirements/monitoring/../base.in
+django-simple-history==2.8.0  # via -r requirements/monitoring/../base.in
+django-storages==1.8      # via -c requirements/monitoring/../constraints.txt, -r requirements/monitoring/../base.in
+django-user-tasks==0.3.0  # via -r requirements/monitoring/../base.in
+django-waffle==0.20.0     # via -r requirements/monitoring/../base.in, edx-django-utils, edx-drf-extensions
+django==1.11.28           # via -r requirements/monitoring/../base.in, code-annotations, django-cors-headers, django-debug-toolbar, django-model-utils, django-mysql, django-storages, djangorestframework, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-i18n-tools, rest-condition
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
-djangorestframework==3.11.0  # via -r requirements/monitoring/../base.in (line 7), django-user-tasks, edx-drf-extensions, rest-condition
+djangorestframework==3.11.0  # via -r requirements/monitoring/../base.in, django-user-tasks, edx-drf-extensions, rest-condition
 docker==4.2.0             # via moto
 docopt==0.6.2             # via pipreqs
 docutils==0.15.2          # via botocore, sphinx
 ecdsa==0.15               # via python-jose
-edx-auth-backends==3.0.2  # via -r requirements/monitoring/../base.in (line 17)
-edx-django-release-util==0.3.6  # via -r requirements/monitoring/../base.in (line 18)
+edx-auth-backends==3.0.2  # via -r requirements/monitoring/../base.in
+edx-django-release-util==0.3.6  # via -r requirements/monitoring/../base.in
 edx-django-utils==3.0     # via edx-drf-extensions
-edx-drf-extensions==3.0.0  # via -r requirements/monitoring/../base.in (line 19)
-edx-i18n-tools==0.5.0     # via -r requirements/monitoring/../local.in (line 9)
-edx-lint==1.4.1           # via -r requirements/monitoring/../test.in (line 9)
+edx-drf-extensions==3.0.0  # via -r requirements/monitoring/../base.in
+edx-i18n-tools==0.5.0     # via -r requirements/monitoring/../local.in
+edx-lint==1.4.1           # via -r requirements/monitoring/../test.in
 edx-opaque-keys==2.0.1    # via edx-drf-extensions
-edx-rest-api-client==1.9.2  # via -r requirements/monitoring/../base.in (line 20)
-edx-sphinx-theme==1.5.0   # via -r requirements/monitoring/../docs.in (line 2)
-factory-boy==2.12.0       # via -r requirements/monitoring/../test.in (line 10)
-faker==4.0.1              # via -r requirements/monitoring/../test.in (line 11), factory-boy
+edx-rest-api-client==1.9.2  # via -r requirements/monitoring/../base.in
+edx-sphinx-theme==1.5.0   # via -r requirements/monitoring/../docs.in
+factory-boy==2.12.0       # via -r requirements/monitoring/../test.in
+faker==4.0.1              # via -r requirements/monitoring/../test.in, factory-boy
 filelock==3.0.12          # via tox, virtualenv
-freezegun==0.3.15         # via -r requirements/monitoring/../test.in (line 12)
+freezegun==0.3.15         # via -r requirements/monitoring/../test.in
 future==0.18.2            # via aws-xray-sdk, pyjwkest
-gevent==1.4.0             # via -r requirements/monitoring/../production.in (line 8)
+gevent==1.4.0             # via -r requirements/monitoring/../production.in
 greenlet==0.4.15          # via gevent
-gunicorn==20.0.4          # via -r requirements/monitoring/../production.in (line 9)
+gunicorn==20.0.4          # via -r requirements/monitoring/../production.in
 idna==2.8                 # via moto, requests
 imagesize==1.2.0          # via sphinx
 importlib-metadata==1.5.0  # via jsonschema, path, pluggy, pytest, tox, virtualenv
 importlib-resources==1.0.2  # via cfn-lint, virtualenv
-isort[requirements]==4.3.21  # via -r requirements/monitoring/../test.in (line 21), pylint
+isort[requirements]==4.3.21  # via -r requirements/monitoring/../test.in, pylint
 jinja2==2.11.1            # via code-annotations, moto, sphinx
 jmespath==0.9.5           # via boto3, botocore
 jsondiff==1.1.2           # via moto
@@ -83,15 +83,16 @@ kombu==3.0.37             # via celery
 lazy-object-proxy==1.4.3  # via astroid
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via pylint
-mock==3.0.5               # via -c requirements/monitoring/../constraints.txt (line 21), moto
+mock==3.0.5               # via -c requirements/monitoring/../constraints.txt, moto
 more-itertools==8.2.0     # via pytest
-moto==1.3.8               # via -r requirements/monitoring/../test.in (line 13)
-mysqlclient==1.3.14       # via -r requirements/monitoring/../nonlocal.in (line 3), -r requirements/monitoring/../production.in (line 10)
-newrelic==5.8.0.136       # via -r requirements/monitoring/../optional.in (line 1), edx-django-utils
+moto==1.3.8               # via -r requirements/monitoring/../test.in
+mysqlclient==1.3.14       # via -r requirements/monitoring/../nonlocal.in, -r requirements/monitoring/../production.in
+newrelic==5.8.0.136       # via -r requirements/monitoring/../optional.in, edx-django-utils
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 packaging==20.1           # via pytest, tox
 path.py==12.4.0           # via edx-i18n-tools
 path==13.1.0              # via path.py
+pathlib2==2.3.5           # via pytest
 pathspec==0.7.0           # via yamllint
 pbr==5.4.4                # via stevedore
 pip-api==0.0.13           # via isort
@@ -101,11 +102,11 @@ polib==1.1.0              # via edx-i18n-tools
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
 py==1.8.1                 # via pytest, tox
 pyasn1==0.4.8             # via python-jose, rsa
-pycodestyle==2.5.0        # via -r requirements/monitoring/../test.in (line 15)
+pycodestyle==2.5.0        # via -r requirements/monitoring/../test.in
 pycparser==2.19           # via cffi
 pycryptodomex==3.9.7      # via pyjwkest
 pygments==2.5.2           # via sphinx
-pyinotify==0.9.6          # via -r requirements/monitoring/../local.in (line 10)
+pyinotify==0.9.6          # via -r requirements/monitoring/../local.in
 pyjwkest==1.3.2           # via edx-drf-extensions
 pyjwt==1.7.1              # via djangorestframework-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint-celery==0.3        # via edx-lint
@@ -115,42 +116,42 @@ pylint==2.4.2             # via edx-lint, pylint-celery, pylint-django, pylint-p
 pymongo==3.10.1           # via edx-opaque-keys
 pyparsing==2.4.6          # via packaging
 pyrsistent==0.15.7        # via jsonschema
-pytest-cov==2.8.1         # via -r requirements/monitoring/../test.in (line 17)
-pytest-django==3.8.0      # via -r requirements/monitoring/../test.in (line 18)
-pytest==5.3.5             # via -r requirements/monitoring/../test.in (line 16), pytest-cov, pytest-django
+pytest-cov==2.8.1         # via -r requirements/monitoring/../test.in
+pytest-django==3.8.0      # via -r requirements/monitoring/../test.in
+pytest==5.3.5             # via -r requirements/monitoring/../test.in, pytest-cov, pytest-django
 python-dateutil==2.8.1    # via analytics-python, botocore, edx-drf-extensions, faker, freezegun, moto, ruamel.yaml.convert
 python-jose==3.1.0        # via moto
-python-memcached==1.59    # via -r requirements/monitoring/../nonlocal.in (line 4)
+python-memcached==1.59    # via -r requirements/monitoring/../nonlocal.in
 python-slugify==1.2.6     # via code-annotations, transifex-client
 python3-openid==3.1.0     # via social-auth-core
-pytz==2019.3              # via -r requirements/monitoring/../base.in (line 21), babel, celery, django, moto
-pyyaml==5.1               # via -r requirements/monitoring/../production.in (line 11), cfn-lint, code-annotations, edx-django-release-util, edx-i18n-tools, moto, yamllint
-redis==2.8                # via -r requirements/monitoring/../base.in (line 22)
+pytz==2019.3              # via -r requirements/monitoring/../base.in, babel, celery, django, moto
+pyyaml==5.1               # via -r requirements/monitoring/../production.in, cfn-lint, code-annotations, edx-django-release-util, edx-i18n-tools, moto, yamllint
+redis==2.8                # via -r requirements/monitoring/../base.in
 requests-oauthlib==1.3.0  # via social-auth-core
 requests==2.23.0          # via analytics-python, docker, edx-drf-extensions, edx-rest-api-client, moto, pyjwkest, requests-oauthlib, responses, slumber, social-auth-core, sphinx, transifex-client, yarg
-responses==0.10.11        # via -r requirements/monitoring/../test.in (line 19), moto
+responses==0.10.11        # via -r requirements/monitoring/../test.in, moto
 rest-condition==1.0.3     # via edx-drf-extensions
 rsa==4.0                  # via python-jose
 ruamel.std.argparse==0.8.1  # via ruamel.yaml.cmd
 ruamel.yaml.clib==0.2.0   # via ruamel.yaml
-ruamel.yaml.cmd==0.5.5    # via -r requirements/monitoring/../local.in (line 11)
+ruamel.yaml.cmd==0.5.5    # via -r requirements/monitoring/../local.in
 ruamel.yaml.convert==0.3.2  # via ruamel.yaml.cmd
 ruamel.yaml==0.16.10      # via ruamel.yaml.cmd, ruamel.yaml.convert
 s3transfer==0.3.3         # via boto3
 semantic-version==2.8.4   # via edx-drf-extensions
-six==1.14.0               # via analytics-python, astroid, aws-sam-translator, cfn-lint, configobj, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, django-waffle, docker, ecdsa, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, freezegun, jsonschema, mock, moto, packaging, pyjwkest, python-dateutil, python-jose, python-memcached, responses, social-auth-app-django, social-auth-core, sphinx, stevedore, transifex-client, websocket-client
+six==1.14.0               # via analytics-python, astroid, aws-sam-translator, cfn-lint, configobj, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, django-waffle, docker, ecdsa, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, freezegun, jsonschema, mock, moto, packaging, pathlib2, pyjwkest, python-dateutil, python-jose, python-memcached, responses, social-auth-app-django, social-auth-core, sphinx, stevedore, tox, transifex-client, virtualenv, websocket-client
 slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==2.0.0    # via sphinx
-git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/monitoring/../github.in (line 5), edx-auth-backends
+git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/monitoring/../github.in, edx-auth-backends
 social-auth-core==3.2.0   # via edx-auth-backends, social-auth-app-django
-sphinx==1.6.7             # via -r requirements/monitoring/../docs.in (line 1), edx-sphinx-theme
+sphinx==1.6.7             # via -r requirements/monitoring/../docs.in, edx-sphinx-theme
 sphinxcontrib-websupport==1.2.0  # via sphinx
-sqlparse==0.3.0           # via django-debug-toolbar
+sqlparse==0.3.1           # via django-debug-toolbar
 stevedore==1.32.0         # via code-annotations, edx-opaque-keys
 text-unidecode==1.3       # via faker
 toml==0.10.0              # via tox
-tox==3.14.5               # via -r requirements/monitoring/../test.in (line 22)
-transifex-client==0.13.7  # via -r requirements/monitoring/../local.in (line 12)
+tox==3.14.5               # via -r requirements/monitoring/../test.in
+transifex-client==0.13.7  # via -r requirements/monitoring/../local.in
 typed-ast==1.4.1          # via astroid
 unidecode==1.1.1          # via python-slugify
 urllib3==1.25.8           # via botocore, requests, transifex-client
@@ -160,9 +161,9 @@ websocket-client==0.57.0  # via docker
 werkzeug==1.0.0           # via moto
 wrapt==1.11.2             # via astroid, aws-xray-sdk
 xmltodict==0.12.0         # via moto
-yamllint==1.20.0          # via -r requirements/monitoring/../test.in (line 20)
+yamllint==1.20.0          # via -r requirements/monitoring/../test.in
 yarg==0.1.9               # via pipreqs
-zipp==3.0.0               # via importlib-metadata
+zipp==1.2.0               # via -c requirements/monitoring/../constraints.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -5,5 +5,5 @@
 #    pip-compile --output-file=requirements/pip-tools.txt requirements/pip-tools.in
 #
 click==7.0                # via pip-tools
-pip-tools==4.5.1          # via -r requirements/pip-tools.in (line 4)
+pip-tools==4.5.1          # via -r requirements/pip-tools.in
 six==1.14.0               # via pip-tools

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -5,42 +5,42 @@
 #    pip-compile --output-file=requirements/production.txt requirements/production.in
 #
 amqp==1.4.9               # via kombu
-analytics-python==1.2.9   # via -r requirements/base.in (line 4)
+analytics-python==1.2.9   # via -r requirements/base.in
 anyjson==0.3.3            # via kombu
 billiard==3.3.0.23        # via celery
-boto3==1.12.9             # via -r requirements/production.in (line 7)
-botocore==1.15.9          # via boto3, s3transfer
-celery==3.1.26.post2      # via -r requirements/base.in (line 5)
+boto3==1.12.11            # via -r requirements/production.in
+botocore==1.15.11         # via boto3, s3transfer
+celery==3.1.26.post2      # via -r requirements/base.in
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
 defusedxml==0.6.0         # via python3-openid, social-auth-core
-django-cors-headers==3.2.1  # via -r requirements/base.in (line 8)
-django-extensions==2.2.8  # via -r requirements/base.in (line 9)
-django-guardian==2.0.0    # via -c requirements/constraints.txt (line 12), -r requirements/base.in (line 10)
-django-model-utils==3.2.0  # via -c requirements/constraints.txt (line 13), -r requirements/base.in (line 11), django-user-tasks
-django-mysql==3.3.0       # via -r requirements/base.in (line 12)
-django-simple-history==2.8.0  # via -r requirements/base.in (line 13)
-django-storages==1.8      # via -c requirements/constraints.txt (line 17), -r requirements/base.in (line 14)
-django-user-tasks==0.3.0  # via -r requirements/base.in (line 15)
-django-waffle==0.20.0     # via -r requirements/base.in (line 16), edx-django-utils, edx-drf-extensions
-django==1.11.28           # via -r requirements/base.in (line 6), django-cors-headers, django-model-utils, django-mysql, django-storages, djangorestframework, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition
+django-cors-headers==3.2.1  # via -r requirements/base.in
+django-extensions==2.2.8  # via -r requirements/base.in
+django-guardian==2.0.0    # via -c requirements/constraints.txt, -r requirements/base.in
+django-model-utils==3.2.0  # via -c requirements/constraints.txt, -r requirements/base.in, django-user-tasks
+django-mysql==3.3.0       # via -r requirements/base.in
+django-simple-history==2.8.0  # via -r requirements/base.in
+django-storages==1.8      # via -c requirements/constraints.txt, -r requirements/base.in
+django-user-tasks==0.3.0  # via -r requirements/base.in
+django-waffle==0.20.0     # via -r requirements/base.in, edx-django-utils, edx-drf-extensions
+django==1.11.28           # via -r requirements/base.in, django-cors-headers, django-model-utils, django-mysql, django-storages, djangorestframework, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
-djangorestframework==3.11.0  # via -r requirements/base.in (line 7), django-user-tasks, edx-drf-extensions, rest-condition
+djangorestframework==3.11.0  # via -r requirements/base.in, django-user-tasks, edx-drf-extensions, rest-condition
 docutils==0.15.2          # via botocore
-edx-auth-backends==3.0.2  # via -r requirements/base.in (line 17)
-edx-django-release-util==0.3.6  # via -r requirements/base.in (line 18)
+edx-auth-backends==3.0.2  # via -r requirements/base.in
+edx-django-release-util==0.3.6  # via -r requirements/base.in
 edx-django-utils==3.0     # via edx-drf-extensions
-edx-drf-extensions==3.0.0  # via -r requirements/base.in (line 19)
+edx-drf-extensions==3.0.0  # via -r requirements/base.in
 edx-opaque-keys==2.0.1    # via edx-drf-extensions
-edx-rest-api-client==1.9.2  # via -r requirements/base.in (line 20)
+edx-rest-api-client==1.9.2  # via -r requirements/base.in
 future==0.18.2            # via pyjwkest
-gevent==1.4.0             # via -r requirements/production.in (line 8)
+gevent==1.4.0             # via -r requirements/production.in
 greenlet==0.4.15          # via gevent
-gunicorn==20.0.4          # via -r requirements/production.in (line 9)
+gunicorn==20.0.4          # via -r requirements/production.in
 idna==2.9                 # via requests
 jmespath==0.9.5           # via boto3, botocore
 kombu==3.0.37             # via celery
-mysqlclient==1.3.14       # via -r requirements/nonlocal.in (line 3), -r requirements/production.in (line 10)
+mysqlclient==1.3.14       # via -r requirements/nonlocal.in, -r requirements/production.in
 newrelic==5.8.0.136       # via edx-django-utils
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 pbr==5.4.4                # via stevedore
@@ -50,11 +50,11 @@ pyjwkest==1.3.2           # via edx-drf-extensions
 pyjwt==1.7.1              # via djangorestframework-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pymongo==3.10.1           # via edx-opaque-keys
 python-dateutil==2.8.1    # via analytics-python, botocore, edx-drf-extensions
-python-memcached==1.59    # via -r requirements/nonlocal.in (line 4)
+python-memcached==1.59    # via -r requirements/nonlocal.in
 python3-openid==3.1.0     # via social-auth-core
-pytz==2019.3              # via -r requirements/base.in (line 21), celery, django
-pyyaml==5.1               # via -r requirements/production.in (line 11), edx-django-release-util
-redis==2.8                # via -r requirements/base.in (line 22)
+pytz==2019.3              # via -r requirements/base.in, celery, django
+pyyaml==5.1               # via -r requirements/production.in, edx-django-release-util
+redis==2.8                # via -r requirements/base.in
 requests-oauthlib==1.3.0  # via social-auth-core
 requests==2.23.0          # via analytics-python, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via edx-drf-extensions
@@ -62,7 +62,7 @@ s3transfer==0.3.3         # via boto3
 semantic-version==2.8.4   # via edx-drf-extensions
 six==1.14.0               # via analytics-python, django-extensions, django-simple-history, django-waffle, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-opaque-keys, pyjwkest, python-dateutil, python-memcached, social-auth-app-django, social-auth-core, stevedore
 slumber==0.7.1            # via edx-rest-api-client
-git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/github.in (line 5), edx-auth-backends
+git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/github.in, edx-auth-backends
 social-auth-core==3.2.0   # via edx-auth-backends, social-auth-app-django
 stevedore==1.32.0         # via edx-opaque-keys
 urllib3==1.25.8           # via botocore, requests

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,7 +5,7 @@
 #    pip-compile --output-file=requirements/test.txt requirements/test.in
 #
 amqp==1.4.9               # via kombu
-analytics-python==1.2.9   # via -r requirements/base.in (line 4)
+analytics-python==1.2.9   # via -r requirements/base.in
 anyjson==0.3.3            # via kombu
 appdirs==1.4.3            # via virtualenv
 astroid==2.3.3            # via pylint, pylint-celery
@@ -13,54 +13,54 @@ attrs==19.3.0             # via jsonschema, pytest
 aws-sam-translator==1.21.0  # via cfn-lint
 aws-xray-sdk==2.4.3       # via moto
 billiard==3.3.0.23        # via celery
-boto3==1.12.9             # via aws-sam-translator, moto
+boto3==1.12.11            # via aws-sam-translator, moto
 boto==2.49.0              # via moto
-botocore==1.15.9          # via aws-xray-sdk, boto3, moto, s3transfer
-celery==3.1.26.post2      # via -r requirements/base.in (line 5)
+botocore==1.15.11         # via aws-xray-sdk, boto3, moto, s3transfer
+celery==3.1.26.post2      # via -r requirements/base.in
 certifi==2019.11.28       # via requests
 cffi==1.14.0              # via cryptography
 cfn-lint==0.28.2          # via moto
 chardet==3.0.4            # via requests
 click-log==0.3.2          # via edx-lint
 click==7.0                # via click-log, code-annotations, edx-lint
-code-annotations==0.3.3   # via -r requirements/test.in (line 8)
-coverage==5.0.3           # via -r requirements/test.in (line 6), pytest-cov
+code-annotations==0.3.3   # via -r requirements/test.in
+coverage==5.0.3           # via -r requirements/test.in, pytest-cov
 cryptography==2.8         # via moto
-ddt==1.2.2                # via -r requirements/test.in (line 14)
+ddt==1.2.2                # via -r requirements/test.in
 defusedxml==0.6.0         # via python3-openid, social-auth-core
 distlib==0.3.0            # via virtualenv
-django-cors-headers==3.2.1  # via -r requirements/base.in (line 8)
-django-dynamic-fixture==3.0.2  # via -r requirements/test.in (line 7)
-django-extensions==2.2.8  # via -r requirements/base.in (line 9)
-django-guardian==2.0.0    # via -c requirements/constraints.txt (line 12), -r requirements/base.in (line 10)
-django-model-utils==3.2.0  # via -c requirements/constraints.txt (line 13), -r requirements/base.in (line 11), django-user-tasks
-django-mysql==3.3.0       # via -r requirements/base.in (line 12)
-django-simple-history==2.8.0  # via -r requirements/base.in (line 13)
-django-storages==1.8      # via -c requirements/constraints.txt (line 17), -r requirements/base.in (line 14)
-django-user-tasks==0.3.0  # via -r requirements/base.in (line 15)
-django-waffle==0.20.0     # via -r requirements/base.in (line 16), edx-django-utils, edx-drf-extensions
+django-cors-headers==3.2.1  # via -r requirements/base.in
+django-dynamic-fixture==3.0.2  # via -r requirements/test.in
+django-extensions==2.2.8  # via -r requirements/base.in
+django-guardian==2.0.0    # via -c requirements/constraints.txt, -r requirements/base.in
+django-model-utils==3.2.0  # via -c requirements/constraints.txt, -r requirements/base.in, django-user-tasks
+django-mysql==3.3.0       # via -r requirements/base.in
+django-simple-history==2.8.0  # via -r requirements/base.in
+django-storages==1.8      # via -c requirements/constraints.txt, -r requirements/base.in
+django-user-tasks==0.3.0  # via -r requirements/base.in
+django-waffle==0.20.0     # via -r requirements/base.in, edx-django-utils, edx-drf-extensions
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
-djangorestframework==3.11.0  # via -r requirements/base.in (line 7), django-user-tasks, edx-drf-extensions, rest-condition
+djangorestframework==3.11.0  # via -r requirements/base.in, django-user-tasks, edx-drf-extensions, rest-condition
 docker==4.2.0             # via moto
 docopt==0.6.2             # via pipreqs
 docutils==0.15.2          # via botocore
 ecdsa==0.15               # via python-jose
-edx-auth-backends==3.0.2  # via -r requirements/base.in (line 17)
-edx-django-release-util==0.3.6  # via -r requirements/base.in (line 18)
+edx-auth-backends==3.0.2  # via -r requirements/base.in
+edx-django-release-util==0.3.6  # via -r requirements/base.in
 edx-django-utils==3.0     # via edx-drf-extensions
-edx-drf-extensions==3.0.0  # via -r requirements/base.in (line 19)
-edx-lint==1.4.1           # via -r requirements/test.in (line 9)
+edx-drf-extensions==3.0.0  # via -r requirements/base.in
+edx-lint==1.4.1           # via -r requirements/test.in
 edx-opaque-keys==2.0.1    # via edx-drf-extensions
-edx-rest-api-client==1.9.2  # via -r requirements/base.in (line 20)
-factory-boy==2.12.0       # via -r requirements/test.in (line 10)
-faker==4.0.1              # via -r requirements/test.in (line 11), factory-boy
+edx-rest-api-client==1.9.2  # via -r requirements/base.in
+factory-boy==2.12.0       # via -r requirements/test.in
+faker==4.0.1              # via -r requirements/test.in, factory-boy
 filelock==3.0.12          # via tox, virtualenv
-freezegun==0.3.15         # via -r requirements/test.in (line 12)
+freezegun==0.3.15         # via -r requirements/test.in
 future==0.18.2            # via aws-xray-sdk, pyjwkest
 idna==2.8                 # via moto, requests
 importlib-metadata==1.5.0  # via jsonschema, pluggy, pytest, tox, virtualenv
 importlib-resources==1.0.2  # via cfn-lint, virtualenv
-isort[requirements]==4.3.21  # via -r requirements/test.in (line 21), pylint
+isort[requirements]==4.3.21  # via -r requirements/test.in, pylint
 jinja2==2.11.1            # via code-annotations, moto
 jmespath==0.9.5           # via boto3, botocore
 jsondiff==1.1.2           # via moto
@@ -72,12 +72,13 @@ kombu==3.0.37             # via celery
 lazy-object-proxy==1.4.3  # via astroid
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via pylint
-mock==3.0.5               # via -c requirements/constraints.txt (line 21), moto
+mock==3.0.5               # via -c requirements/constraints.txt, moto
 more-itertools==8.2.0     # via pytest
-moto==1.3.8               # via -r requirements/test.in (line 13)
+moto==1.3.8               # via -r requirements/test.in
 newrelic==5.8.0.136       # via edx-django-utils
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
-packaging==20.1           # via pytest
+packaging==20.1           # via pytest, tox
+pathlib2==2.3.5           # via pytest
 pathspec==0.7.0           # via yamllint
 pbr==5.4.4                # via stevedore
 pip-api==0.0.13           # via isort
@@ -86,7 +87,7 @@ pluggy==0.13.1            # via pytest, tox
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
 py==1.8.1                 # via pytest, tox
 pyasn1==0.4.8             # via python-jose, rsa
-pycodestyle==2.5.0        # via -r requirements/test.in (line 15)
+pycodestyle==2.5.0        # via -r requirements/test.in
 pycparser==2.19           # via cffi
 pycryptodomex==3.9.7      # via pyjwkest
 pyjwkest==1.3.2           # via edx-drf-extensions
@@ -98,31 +99,31 @@ pylint==2.4.2             # via edx-lint, pylint-celery, pylint-django, pylint-p
 pymongo==3.10.1           # via edx-opaque-keys
 pyparsing==2.4.6          # via packaging
 pyrsistent==0.15.7        # via jsonschema
-pytest-cov==2.8.1         # via -r requirements/test.in (line 17)
-pytest-django==3.8.0      # via -r requirements/test.in (line 18)
-pytest==5.3.5             # via -r requirements/test.in (line 16), pytest-cov, pytest-django
+pytest-cov==2.8.1         # via -r requirements/test.in
+pytest-django==3.8.0      # via -r requirements/test.in
+pytest==5.3.5             # via -r requirements/test.in, pytest-cov, pytest-django
 python-dateutil==2.8.1    # via analytics-python, botocore, edx-drf-extensions, faker, freezegun, moto
 python-jose==3.1.0        # via moto
 python-slugify==4.0.0     # via code-annotations
 python3-openid==3.1.0     # via social-auth-core
-pytz==2019.3              # via -r requirements/base.in (line 21), celery, django, moto
+pytz==2019.3              # via -r requirements/base.in, celery, django, moto
 pyyaml==5.3               # via cfn-lint, code-annotations, edx-django-release-util, moto, yamllint
-redis==2.8                # via -r requirements/base.in (line 22)
+redis==2.8                # via -r requirements/base.in
 requests-oauthlib==1.3.0  # via social-auth-core
 requests==2.23.0          # via analytics-python, docker, edx-drf-extensions, edx-rest-api-client, moto, pyjwkest, requests-oauthlib, responses, slumber, social-auth-core, yarg
-responses==0.10.11        # via -r requirements/test.in (line 19), moto
+responses==0.10.11        # via -r requirements/test.in, moto
 rest-condition==1.0.3     # via edx-drf-extensions
 rsa==4.0                  # via python-jose
 s3transfer==0.3.3         # via boto3
 semantic-version==2.8.4   # via edx-drf-extensions
-six==1.14.0               # via analytics-python, astroid, aws-sam-translator, cfn-lint, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, django-waffle, docker, ecdsa, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-lint, edx-opaque-keys, freezegun, jsonschema, mock, moto, packaging, pyjwkest, python-dateutil, python-jose, responses, social-auth-app-django, social-auth-core, stevedore, websocket-client
+six==1.14.0               # via analytics-python, astroid, aws-sam-translator, cfn-lint, cryptography, django-dynamic-fixture, django-extensions, django-simple-history, django-waffle, docker, ecdsa, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-lint, edx-opaque-keys, freezegun, jsonschema, mock, moto, packaging, pathlib2, pyjwkest, python-dateutil, python-jose, responses, social-auth-app-django, social-auth-core, stevedore, tox, virtualenv, websocket-client
 slumber==0.7.1            # via edx-rest-api-client
-git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/github.in (line 5), edx-auth-backends
+git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/github.in, edx-auth-backends
 social-auth-core==3.2.0   # via edx-auth-backends, social-auth-app-django
 stevedore==1.32.0         # via code-annotations, edx-opaque-keys
 text-unidecode==1.3       # via faker, python-slugify
 toml==0.10.0              # via tox
-tox==3.14.5               # via -r requirements/test.in (line 22)
+tox==3.14.5               # via -r requirements/test.in
 typed-ast==1.4.1          # via astroid
 urllib3==1.25.8           # via botocore, requests
 virtualenv==20.0.7        # via tox
@@ -131,9 +132,9 @@ websocket-client==0.57.0  # via docker
 werkzeug==1.0.0           # via moto
 wrapt==1.11.2             # via astroid, aws-xray-sdk
 xmltodict==0.12.0         # via moto
-yamllint==1.20.0          # via -r requirements/test.in (line 20)
+yamllint==1.20.0          # via -r requirements/test.in
 yarg==0.1.9               # via pipreqs
-zipp==3.0.0               # via importlib-metadata
+zipp==1.2.0               # via -c requirements/constraints.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip


### PR DESCRIPTION
## Description

Try to fix the python requirements PR failure from the jenkins job by pinning zipp library to 2.0,0