### PR TITLE
add constant to define role management waffle flag

### DIFF
--- a/registrar/apps/api/constants.py
+++ b/registrar/apps/api/constants.py
@@ -7,6 +7,9 @@ from registrar.apps.core import permissions as perms
 ENROLLMENT_WRITE_MAX_SIZE = 25
 UPLOAD_FILE_MAX_SIZE = 5 * 1024 * 1024
 
+# Waffle flag to allow assigning a CourseAccessRole when uploading enrollments
+ENABLE_COURSE_ROLE_MANAGEMENT_WAFFLE = 'enable_course_role_management'
+
 TRACKING_CATEGORY = 'Registrar API'
 
 # To be deprecated with upcoming program manager changes (01/2020)


### PR DESCRIPTION
Just adds a constant to reference for future development on role management.  This flag has been added to stage and prod and is enabled for superusers only for now.  I've tested that we can enable this for an Organization or Program group.
