### PR TITLE
Bulk-fetch programs from Discovery for performance

### DIFF
--- a/registrar/apps/api/v1/views.py
+++ b/registrar/apps/api/v1/views.py
@@ -108,6 +108,11 @@ class ProgramListView(AuthMixin, TrackViewMixin, ListAPIView):
     }
 
     def get_queryset(self):
+        """
+        Get list of programs to be serialized and returned as response to GET request.
+
+        Returns: list[DiscoveryProgram]
+        """
         programs = DiscoveryProgram.objects.all()
         user = self.request.user
 

--- a/registrar/apps/core/proxies.py
+++ b/registrar/apps/core/proxies.py
@@ -93,7 +93,7 @@ class DiscoveryProgram(Program):
         if not isinstance(program_details, dict):
             if settings.BULK_FETCH_DISCOVERY_PROGRAMS:
                 cls._bulk_load_program_details()
-                program_details = cache.get(key)
+                program_details = cache.get(key) or {}
             else:
                 program_details = cls._fetch_discovery_program_details(program_uuid)
                 cache_value = program_details if isinstance(program_details, dict) else {}

--- a/registrar/apps/core/rest_utils.py
+++ b/registrar/apps/core/rest_utils.py
@@ -39,6 +39,8 @@ def get_all_paginated_results(url, client=None):
     Builds a list of all results from a cursor-paginated endpoint.
 
     Repeatedly performs request on 'next' URL until 'next' is null.
+
+    Returns: list
     """
     if not client:  # pragma: no branch
         client = get_client(settings.LMS_BASE_URL)

--- a/registrar/apps/core/tests/test_proxies.py
+++ b/registrar/apps/core/tests/test_proxies.py
@@ -11,7 +11,11 @@ from django.conf import settings
 from django.core.cache import cache
 from django.test import TestCase
 
-from ..proxies import DISCOVERY_SINGLE_PROGRAM_API_TPL, DiscoveryProgram
+from ..proxies import (
+    DISCOVERY_MULTI_PROGRAM_API_TPL,
+    DISCOVERY_SINGLE_PROGRAM_API_TPL,
+    DiscoveryProgram,
+)
 from .factories import DiscoveryProgramFactory
 from .utils import mock_oauth_login, patch_discovery_program_details
 
@@ -41,9 +45,17 @@ class DiscoveryProgramTestCase(TestCase):
     Test DiscoveryProgram proxy model.
     """
     program_uuid = UUID("88888888-4444-2222-1111-000000000000")
+    other_program_uuid = UUID("88888888-4444-2222-1111-000000000001")
+
     discovery_url = urljoin(
         settings.DISCOVERY_BASE_URL,
         DISCOVERY_SINGLE_PROGRAM_API_TPL.format(program_uuid)
+    )
+    discovery_bulk_url = urljoin(
+        settings.DISCOVERY_BASE_URL,
+        DISCOVERY_MULTI_PROGRAM_API_TPL.format(
+            str(program_uuid) + "," + str(other_program_uuid)
+        )
     )
 
     inactive_curriculum_uuid = UUID("77777777-4444-2222-1111-000000000000")
@@ -53,6 +65,7 @@ class DiscoveryProgramTestCase(TestCase):
     make_course_run = make_course_run
 
     program_details = {
+        'uuid': str(program_uuid),
         'title': "Master's in CS",
         'marketing_url': "https://stem.edx.org/masters-in-cs",
         'type': "Masters",
@@ -83,11 +96,19 @@ class DiscoveryProgramTestCase(TestCase):
             },
         ],
     }
+    other_program_details = {
+        'uuid': str(other_program_uuid),
+    }
 
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
-        DiscoveryProgramFactory(key="masters-in-cs", discovery_uuid=cls.program_uuid)
+        DiscoveryProgramFactory(
+            key="masters-in-cs", discovery_uuid=cls.program_uuid
+        )
+        DiscoveryProgramFactory(
+            key="masters-in-orange-juice", discovery_uuid=cls.other_program_uuid
+        )
 
     def setUp(self):
         super().setUp()
@@ -99,6 +120,13 @@ class DiscoveryProgramTestCase(TestCase):
         Loads the program with `cls.program_uuid`
         """
         return DiscoveryProgram.objects.get(discovery_uuid=cls.program_uuid)
+
+    @classmethod
+    def get_other_program(cls):
+        """
+        Loads the program with `cls.other_program_uuid`
+        """
+        return DiscoveryProgram.objects.get(discovery_uuid=cls.other_program_uuid)
 
     @mock_oauth_login
     @responses.activate
@@ -128,6 +156,45 @@ class DiscoveryProgramTestCase(TestCase):
         assert isinstance(reloaded_program, DiscoveryProgram)
         assert reloaded_program.discovery_uuid == self.program_uuid
         assert reloaded_program.discovery_details == expected_details
+        self.assertEqual(len(responses.calls), 2)
+
+    @mock_oauth_login
+    @responses.activate
+    @ddt.data(
+        (200, program_details, program_details),
+        (200, {}, {}),
+        (200, 'this is a string, but it should be a dict', {}),
+        (404, {'message': 'program not found'}, {}),
+        (500, {'message': 'everything is broken'}, {}),
+    )
+    @ddt.unpack
+    def test_discovery_program_get_using_bulk_fetch(
+            self, disco_status, program_details_data, expected_details
+    ):
+        responses.add(
+            responses.GET,
+            self.discovery_bulk_url,
+            status=disco_status,
+            json={"results": [program_details_data, self.other_program_details]},
+        )
+        loaded_program = self.get_program()
+        assert isinstance(loaded_program, DiscoveryProgram)
+        assert loaded_program.discovery_uuid == self.program_uuid
+        assert loaded_program.discovery_details == expected_details
+        self.assertEqual(len(responses.calls), 2)
+
+        # This should used the cached Discovery response.
+        reloaded_program = self.get_program()
+        assert isinstance(reloaded_program, DiscoveryProgram)
+        assert reloaded_program.discovery_uuid == self.program_uuid
+        assert reloaded_program.discovery_details == expected_details
+        self.assertEqual(len(responses.calls), 2)
+
+        # Even for a different program, this should used the cached Discovery response.
+        reloaded_program = self.get_other_program()
+        assert isinstance(reloaded_program, DiscoveryProgram)
+        assert reloaded_program.discovery_uuid == self.other_program_uuid
+        assert reloaded_program.discovery_details == self.other_program_details
         self.assertEqual(len(responses.calls), 2)
 
     @patch_discovery_program_details(program_details)

--- a/registrar/apps/core/tests/test_proxies.py
+++ b/registrar/apps/core/tests/test_proxies.py
@@ -11,7 +11,7 @@ from django.conf import settings
 from django.core.cache import cache
 from django.test import TestCase
 
-from ..proxies import DISCOVERY_PROGRAM_API_TPL, DiscoveryProgram
+from ..proxies import DISCOVERY_SINGLE_PROGRAM_API_TPL, DiscoveryProgram
 from .factories import DiscoveryProgramFactory
 from .utils import mock_oauth_login, patch_discovery_program_details
 
@@ -43,7 +43,7 @@ class DiscoveryProgramTestCase(TestCase):
     program_uuid = UUID("88888888-4444-2222-1111-000000000000")
     discovery_url = urljoin(
         settings.DISCOVERY_BASE_URL,
-        DISCOVERY_PROGRAM_API_TPL.format(program_uuid)
+        DISCOVERY_SINGLE_PROGRAM_API_TPL.format(program_uuid)
     )
 
     inactive_curriculum_uuid = UUID("77777777-4444-2222-1111-000000000000")

--- a/registrar/settings/base.py
+++ b/registrar/settings/base.py
@@ -319,3 +319,9 @@ EDX_DRF_EXTENSIONS = {
     "OAUTH2_USER_INFO_URL": "http://127.0.0.1:8000/oauth2/user_info"
 }
 
+# Potential fix for MST-191.
+# If enabled, we bulk-fetch and cache program details from Discovery service
+# when handling `GET /api/vX/programs/` in order to avoid repeated calls
+# to Discovery service.
+# Defaults to disabled.
+BULK_FETCH_DISCOVERY_PROGRAMS = False

--- a/registrar/settings/devstack.py
+++ b/registrar/settings/devstack.py
@@ -81,3 +81,5 @@ if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):
     from .private import *  # pylint: disable=import-error
 
 API_ROOT = 'http://localhost:18734/api'
+
+BULK_FETCH_DISCOVERY_PROGRAMS = True

--- a/registrar/settings/test.py
+++ b/registrar/settings/test.py
@@ -47,3 +47,5 @@ PROGRAM_REPORTS_BUCKET = 'program-reports-test'
 
 # Publicly-exposed base URLs for service and API, respectively
 API_ROOT = 'http://localhost/api'
+
+BULK_FETCH_DISCOVERY_PROGRAMS = True


### PR DESCRIPTION
*work-in-progress*

Currently, when the program details cache is cold,
we repeatedly call Course Discovery to fetch program
details.

This PR, instead, makes it so we fetch all non-cached
programs at once using the `uuids` filter on Discovery's
/api/v1/programs endpoint.

https;//openedx.atlassian.net/MST-191