### PR TITLE
Prevent mysterious celery routing by explicitly specifying default q

### DIFF
--- a/registrar/apps/core/jobs.py
+++ b/registrar/apps/core/jobs.py
@@ -16,6 +16,7 @@ import logging
 import uuid
 from collections import namedtuple
 
+from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from user_tasks.models import UserTaskArtifact, UserTaskStatus
 
@@ -54,7 +55,12 @@ def start_job(user, task_fn, *args, **kwargs):
         *args/**kwargs: Additional arguments to pass to task_fn.
     """
     job_id = kwargs.pop('job_id') if 'job_id' in kwargs else str(uuid.uuid4())
-    task_fn.apply_async([job_id, user.id] + list(args), kwargs, task_id=job_id)
+    task_fn.apply_async(
+        [job_id, user.id] + list(args),
+        kwargs,
+        task_id=job_id,
+        queue=settings.CELERY_DEFAULT_QUEUE,
+    )
     return job_id
 
 


### PR DESCRIPTION
JIRA:MST-196

## Description

Registrar is ending up putting tasks in a queue it ostensibly hasn't been configured to use as its default for quite a while on edX's staging environment. This is an attempt to address that, but should smell a little like "I can't believe it's not butter" because it will be a bit unclear why it worked.