### PR TITLE
mroytman/mst 199 enrollments disabled permissions

### DIFF
--- a/registrar/apps/api/serializers.py
+++ b/registrar/apps/api/serializers.py
@@ -8,7 +8,7 @@ from rest_framework import serializers
 from user_tasks.models import UserTaskStatus
 
 from registrar.apps.core.proxies import DiscoveryProgram
-from registrar.apps.core.utils import get_user_api_permissions
+from registrar.apps.core.utils import get_effective_user_program_api_permissions
 from registrar.apps.enrollments.constants import (
     COURSE_ENROLLMENT_STATUSES,
     PROGRAM_ENROLLMENT_STATUSES,
@@ -41,12 +41,8 @@ class DiscoveryProgramSerializer(serializers.ModelSerializer):
         """
         request = self.context.get('request')
         if request and hasattr(request, 'user'):
-            user = request.user
-            user_permissions = get_user_api_permissions(
-                user, program
-            ).union(
-                get_user_api_permissions(user, program.managing_organization)
-            )
+            user_permissions = get_effective_user_program_api_permissions(request.user, program)
+
             return sorted(permission.name for permission in user_permissions)
         else:
             return []

--- a/registrar/apps/api/tests/test_serializers.py
+++ b/registrar/apps/api/tests/test_serializers.py
@@ -36,21 +36,21 @@ class DiscoveryProgramSerializerTests(TestCase):
             PROGRAM_CACHE_KEY_TPL.format(uuid=self.program.discovery_uuid),
             {
                 'title': 'test-program',
-                'type': 'masters',
+                'type': 'Masters',
                 'curricula': [],
-            },
+            }
         )
 
-    @mock.patch('registrar.apps.api.serializers.get_user_api_permissions')
-    def test_get_user_permissions(self, fake_get_perms):
+    @mock.patch('registrar.apps.api.serializers.get_effective_user_program_api_permissions')
+    def test_serializer(self, fake_get_perms):
         """
-        Program permissions should be populated with the union of all
-        permissions assigned at that program and its managing organization
+        Test that the serializer should return output of get_effective_user_program_api_permissions
+        for permissions.
         """
-        fake_get_perms.side_effect = [
-            set([APIWriteEnrollmentsPermission]),  # mocked permissions on program
-            set([APIReadMetadataPermission]),  # mocked permissions on org
-        ]
+        fake_get_perms.return_value = {
+            APIWriteEnrollmentsPermission,
+            APIReadMetadataPermission,
+        }
         program = DiscoveryProgramSerializer(
             self.program,
             context={

--- a/registrar/apps/api/v1/views.py
+++ b/registrar/apps/api/v1/views.py
@@ -37,7 +37,7 @@ from registrar.apps.core.models import Organization
 from registrar.apps.core.permissions import APIReadMetadataPermission
 from registrar.apps.core.proxies import DiscoveryProgram
 from registrar.apps.core.utils import (
-    get_user_api_permissions,
+    get_effective_user_program_api_permissions,
     load_records_from_uploaded_csv,
 )
 from registrar.apps.enrollments.tasks import (
@@ -123,9 +123,7 @@ class ProgramListView(AuthMixin, TrackViewMixin, ListAPIView):
 
         programs = (
             program for program in programs
-            if required_permission in get_user_api_permissions(user, program).union(
-                get_user_api_permissions(user, program.managing_organization)
-            )
+            if required_permission in get_effective_user_program_api_permissions(user, program)
         )
         # Filter out programs with enrollments disabled if the user requested
         # permission filter to operate on enrollments

--- a/registrar/apps/core/utils.py
+++ b/registrar/apps/core/utils.py
@@ -5,6 +5,8 @@ from io import StringIO
 from guardian.shortcuts import get_perms
 from rest_framework.exceptions import ValidationError
 
+from registrar.apps.api.constants import ENROLLMENT_PERMISSIONS_LIST
+
 from .models import OrganizationGroup
 from .permissions import DB_TO_API_PERMISSION_MAPPING
 
@@ -26,12 +28,46 @@ def get_user_organizations(user):
     return user_organizations
 
 
+def get_effective_user_program_api_permissions(user, program):
+    """
+    Returns a set of all APIPermissions granted to the user on a
+    program  either in the context of a program or an organization.
+    This includes permissions granted though a global permission or role.
+
+    This will filter out APIPermissions for the program that are not valid
+    for the program. Currently, this only removes a user's read and/or write
+    enrollments permissions for a program that does not have enrollments enabled.
+    """
+    user_permissions = get_user_api_permissions(user, program).union(
+        get_user_api_permissions(user, program.managing_organization))
+
+    user_permissions = _remove_permissions_if_enrollments_disabled(program, user_permissions)
+
+    return user_permissions
+
+
+def _remove_permissions_if_enrollments_disabled(program, user_permissions):
+    """
+    If a program does not have enrollments enabled, remove the user's
+    permissions to read or write enrollments for that program.
+    """
+    if not program.is_enrollment_enabled:
+        return user_permissions - set(ENROLLMENT_PERMISSIONS_LIST)
+
+    return user_permissions
+
+
 def get_user_api_permissions(user, obj=None):
     """
     Returns a set of all APIPermissions granted to the user on a
     provided object instance. This includes permissions granted though a
     global permission or role. If no object is passed only global permissions
     will be returned.
+
+    You should not use this function directly if you want a set of a user's effective
+    APIPermissions, as this function does not account for programs for which enrollments
+    are disabled. Use the get_effective_user_program_api_permissions function for this
+    purpose instead.
     """
     user_object_permissions = get_perms(user, obj) if obj is not None else []
     user_global_permissions = list(user.get_all_permissions())


### PR DESCRIPTION
## Description

[JIRA ticket](https://openedx.atlassian.net/browse/MST-198)

> The /api/v2/programs endpoint, which is called by Program Console, should return a list of programs and a list of permissions available to the user for each program.
> Because MicroMaster’s programs are considered to have “enrollment disabled”, they should not return write_enrollments and read_enrollments in their list of permissions.
> However, if someone has write/read_enrollments permission assigned through a MM Program or an Organization that runs a MM program, the endpoint will report write/read_enrollments for that MM program.
