### PR TITLE
Increase Discovery cache timeout to 24 hours

### DIFF
--- a/registrar/apps/api/v1/tests/test_views.py
+++ b/registrar/apps/api/v1/tests/test_views.py
@@ -1606,7 +1606,7 @@ class JobStatusRetrieveViewTests(S3MockMixin, RegistrarAPITestCase, AuthRequestM
 @shared_task(base=UserTask, bind=True)
 def _succeeding_job(self, job_id, user_id, *args, **kwargs):  # pylint: disable=unused-argument
     """ A job that just succeeds, posting an empty JSON list as its result. """
-    fake_data = Faker().pystruct(20, str, int, bool)
+    fake_data = Faker().pystruct(count=20, value_types=(str, int, bool))
     post_job_success(job_id, json.dumps(fake_data), 'json')
 
 

--- a/registrar/apps/core/constants.py
+++ b/registrar/apps/core/constants.py
@@ -29,4 +29,3 @@ JOB_ID_PATTERN = r'(?P<job_id>[0-9a-f-]+)'
 ORGANIZATION_KEY_PATTERN = r'[A-Za-z0-9-_]+'
 
 PROGRAM_CACHE_KEY_TPL = 'program:{uuid}'
-PROGRAM_CACHE_TIMEOUT = 120

--- a/registrar/apps/core/proxies.py
+++ b/registrar/apps/core/proxies.py
@@ -10,7 +10,7 @@ from django.conf import settings
 from django.core.cache import cache
 from requests.exceptions import HTTPError
 
-from .constants import PROGRAM_CACHE_KEY_TPL, PROGRAM_CACHE_TIMEOUT
+from .constants import PROGRAM_CACHE_KEY_TPL
 from .models import Program
 from .rest_utils import make_request
 
@@ -28,7 +28,7 @@ class DiscoveryProgram(Program):
     """
     Proxy to Program model that is enriched with details available from Discovery service.
 
-    Data from Discovery is cached for `PROGRAM_CACHE_TIMEOUT` seconds.
+    Data from Discovery is cached for `settings.PROGRAM_CACHE_TIMEOUT` seconds.
     If Discovery data cannot be loaded, we fall back to default values.
 
     Get an instance of this class just like you would an instance of `Program`:
@@ -64,7 +64,7 @@ class DiscoveryProgram(Program):
 
         Returns an empty dict if not found or other HTTP error.
 
-        Queries a cache with timeout of `PROGRAM_CACHE_TIMEOUT`
+        Queries a cache with timeout of `settings.PROGRAM_CACHE_TIMEOUT`
         before hitting Discovery to load the authoritative data.
 
         Note that the "not-founded-ness" of programs will also be cached
@@ -91,7 +91,7 @@ class DiscoveryProgram(Program):
         if not isinstance(program_details, dict):
             program_details = cls._fetch_discovery_program_details(program_uuid)
             cache_value = program_details if isinstance(program_details, dict) else {}
-            cache.set(key, cache_value, PROGRAM_CACHE_TIMEOUT)
+            cache.set(key, cache_value, settings.PROGRAM_CACHE_TIMEOUT)
         return program_details
 
     @classmethod

--- a/registrar/settings/base.py
+++ b/registrar/settings/base.py
@@ -319,3 +319,6 @@ EDX_DRF_EXTENSIONS = {
     "OAUTH2_USER_INFO_URL": "http://127.0.0.1:8000/oauth2/user_info"
 }
 
+# How long (in seconds) we keep program details from Discovery in the cache.
+# Defaults to 24 hours.
+PROGRAM_CACHE_TIMEOUT = 60 * 60 * 24


### PR DESCRIPTION
```
It was previously only 2 minutes due to belief
that the delay between modifying an external
course key in Publisher and seeing the result in
the Registrar API needed to be low.

However, the performance issues on Program Console
are currently a larger concern. We believe that
increasing this timeout will work as a stop-gap
to optimize the /api/v2/programs/ endpoint, which
Program Console relies upon for the initial page load.

MST-255
```
@edx/masters-devs-cosmonauts 
https://openedx.atlassian.net/browse/MST-255

This also fix an unrelated deprecation warning coming from Faker (which we use to make test data).