### PR TITLE
Add Django setting for reports folder

### DIFF
--- a/registrar/apps/core/filestore.py
+++ b/registrar/apps/core/filestore.py
@@ -183,7 +183,7 @@ def get_program_reports_filestore():
     """
     Get filestore instance for program analytics reports.
     """
-    return get_filestore(settings.PROGRAM_REPORTS_BUCKET, 'reports')
+    return get_filestore(settings.PROGRAM_REPORTS_BUCKET, settings.PROGRAM_REPORTS_FOLDER)
 
 
 def get_filestore(bucket, path_prefix):

--- a/registrar/settings/base.py
+++ b/registrar/settings/base.py
@@ -181,6 +181,7 @@ MEDIA_URL = '/api/media/'
 DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
 REGISTRAR_BUCKET = 'change-me-to-registrar-bucket'
 PROGRAM_REPORTS_BUCKET = 'change-me-to-program-reports-bucket'
+PROGRAM_REPORTS_FOLDER = 'reports_v2'
 
 # STATIC FILE CONFIGURATION
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#static-root


### PR DESCRIPTION
## [MST-280](https://openedx.atlassian.net/browse/MST-280)

Created Django setting for new reports folder in S3. 

Pre-merge checklist:
- [x] Sufficient number of reports (7 days worth) in new S3 folder
- [x] [warehouse-transforms PR 583](https://github.com/edx/warehouse-transforms/pull/583) is resolved
