### PR TITLE
Travis: only build master branch (PRs will still build)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+branches:
+  only:
+  - master
+
 language: python
 python:
     - 3.5.2


### PR DESCRIPTION
Travis is configured to build all pull requests on Registrar. We also have it configured to run on every branch of Registrar, separately. This is why you see two seemingly-identical succeeded/failed Travis statuses and two succeeded/failed Codecov statuses on every single PR.

This PR would change it so only _Pull Requests_ and the _master branch_ are build, whereas all other branches aren't. PRs will still get tested as always, but they will only have one status each for Travis and Codecov.

__Why does it matter?__

It probably doesn't, other than potential confusion and excess power consumption somewhere.

@edx/masters-devs-cosmonauts 