### PR TITLE
Further cache Program.details using @cached_property

### DIFF
--- a/registrar/apps/core/models.py
+++ b/registrar/apps/core/models.py
@@ -2,6 +2,7 @@
 
 from django.contrib.auth.models import AbstractUser, Group
 from django.db import models
+from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
 from guardian.shortcuts import remove_perm
 from model_utils.models import TimeStampedModel
@@ -115,7 +116,7 @@ class Program(TimeStampedModel):
             type(self).__name__, self.key, self.discovery_uuid, self.managing_organization.key
         )
 
-    @property
+    @cached_property
     def details(self):
         """
         Load the ProgramDetails instance for this program.


### PR DESCRIPTION
```
It's already cached in memcached, but we're hitting
memcached repeatedly for the same program. By using
Django's cached_property decorator on Program.details,
the blob loaded from memcached will also be cached
in-memory on a per-request basis, which I think will
reduce memcached usage.
```

After deploying https://github.com/edx/registrar/pull/319, performance of `/api/v1/programs` seems to have improved by 25% for global staff, but memcached usage by the endpoint has spiked. I have a hunch that this PR will bring memcached usage down to normal levels, which will make the improvement to `/api/v1/programs` more dramatic.

![registrar-memcached](https://user-images.githubusercontent.com/3628148/85615021-981a5b80-b629-11ea-9acd-a6c877f2e527.png)

The first bump is a request before my PR deployed. The second and third bumps are after the deployment. Brown indicates time spent loading data from Memcached.

@edx/masters-devs-cosmonauts 