### PR TITLE
MST-380 Sync with Discovery on Orgs and Programs

### DIFF
--- a/registrar/apps/core/api_client.py
+++ b/registrar/apps/core/api_client.py
@@ -1,0 +1,92 @@
+"""
+Utility objects for communicating with other web services
+"""
+import logging
+from posixpath import join as urljoin
+
+from django.conf import settings
+from requests.exceptions import HTTPError
+
+from .rest_utils import get_all_paginated_results, make_request
+
+
+logger = logging.getLogger(__name__)
+DISCOVERY_API_TPL = 'api/v1/{}/{}'
+
+
+class DiscoveryServiceClient:
+    """ The Discovery service API client to make the RESTFul API call """
+    @classmethod
+    def get_program(cls, uuid):
+        """
+        Fetch a JSON representation of a program from the Discovery service.
+
+        Returns None if not found or other HTTP error.
+
+        Arguments:
+            * uuid (UUID)
+
+        Returns: dict|None
+        """
+        url = urljoin(
+            settings.DISCOVERY_BASE_URL,
+            DISCOVERY_API_TPL.format('programs', uuid)
+        )
+        try:
+            return make_request('GET', url, client=None).json()
+        except HTTPError:
+            logger.exception(
+                "Failed to load program with uuid %s from Discovery service.",
+                uuid,
+            )
+            return None
+
+    @classmethod
+    def get_programs_by_types(cls, types):
+        """
+        Fetch a JSON representation of programs of specified types from the Discovery service.
+
+        Returns empty if not found or other HTTP error.
+
+        Arguments:
+            * types: [program_types]
+
+        Returns: [programs] | []
+        """
+        url = urljoin(
+            settings.DISCOVERY_BASE_URL,
+            DISCOVERY_API_TPL.format('programs', '')
+        )
+        url += '?types={}'.format(','.join(types))
+        try:
+            return get_all_paginated_results(url)
+        except HTTPError:
+            logger.exception(
+                "Failed to load programs with program_types %s from Discovery service.",
+                ','.join(types),
+            )
+            return []
+
+    @classmethod
+    def get_organizations(cls):
+        """
+        Fetch a JSON representation of organizations from the Discovery service.
+
+        Returns None if not found or other HTTP error.
+
+        Arguments:
+            * None
+
+        Returns: [organization] | []
+        """
+        url = urljoin(
+            settings.DISCOVERY_BASE_URL,
+            DISCOVERY_API_TPL.format('organizations', '')
+        )
+        try:
+            return get_all_paginated_results(url)
+        except HTTPError:
+            logger.exception(
+                "Failed to load organizations from Discovery service.",
+            )
+            return []

--- a/registrar/apps/core/management/commands/sync_with_discovery.py
+++ b/registrar/apps/core/management/commands/sync_with_discovery.py
@@ -1,0 +1,197 @@
+""" Management command to synchronize the organization and programs with Discovery service """
+import logging
+
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from registrar.apps.core.api_client import DiscoveryServiceClient
+from registrar.apps.core.models import (
+    Organization,
+    OrganizationGroup,
+    Program,
+    ProgramOrganizationGroup,
+)
+from registrar.apps.core.permissions import (
+    OrganizationReadReportRole,
+    ProgramReadReportRole,
+)
+
+
+logger = logging.getLogger(__name__)
+
+PROGRAM_TYPES_TO_SYNC = ['micromasters', 'masters', 'professional-certificate', 'microbachelors']
+
+
+class Command(BaseCommand):
+    """class for command updates data from discovery service"""
+    help = 'Adds Organizations and Programs based on data in Discovery Service. Will also update Organizations'
+
+    @transaction.atomic
+    def handle(self, *args, **options):
+        """
+        The main logic and entry point of the management command
+        """
+        # First make api call to discovery service to get list of organizations available
+        self.sync_organizations()
+        self.sync_programs(PROGRAM_TYPES_TO_SYNC)
+
+    def sync_organizations(self):
+        """
+        Make API call to discovery service and get latest organizations list
+        Then update the registrar organizations by adding new ones and
+        updating the existing data
+        """
+        discovery_organizations = DiscoveryServiceClient.get_organizations()
+        existing_org_dictionary = {}
+        orgs_to_create = []
+        orgs_to_update = []
+
+        for org in Organization.objects.all():
+            existing_org_dictionary[str(org.discovery_uuid)] = org
+
+        logger.info('Start sync Discovery organizations...')
+        for discovery_org in discovery_organizations:
+            existing_org = existing_org_dictionary.get(discovery_org.get('uuid'))
+            if not existing_org:
+                orgs_to_create.append(Organization(
+                    discovery_uuid=discovery_org.get('uuid'),
+                    name=discovery_org.get('name'),
+                    key=discovery_org.get('key'),
+                ))
+                logger.info('Creating %s', discovery_org.get('key'))
+            elif existing_org.name != discovery_org.get('name') or existing_org.key != discovery_org.get('key'):
+                existing_org.name = discovery_org.get('name')
+                existing_org.key = discovery_org.get('key')
+                orgs_to_update.append(existing_org)
+                logger.info(
+                    'Updating %s to have %s and %s',
+                    existing_org.discovery_uuid,
+                    existing_org.key,
+                    existing_org.name,
+                )
+
+        if not orgs_to_create and not orgs_to_update:
+            logger.info('Sync complete. No changes made to Registrar service')
+
+        if orgs_to_create:
+            # Bulk create those new organizations
+            Organization.objects.bulk_create(orgs_to_create)
+            self.create_org_groups(orgs_to_create)
+
+        if orgs_to_update:
+            # Bulk update those organizations needs updating
+            Organization.objects.bulk_update(orgs_to_update, ['name', 'key'])
+            self.update_org_groups(orgs_to_update)
+
+        logger.info('Sync Organizations Success!')
+
+    def sync_programs(self, program_types):
+        """
+        Make API call to discovery service and get latest programs list
+        with pre-defined program-types
+        Then update the registrar programs by adding new ones and
+        updating the existing data
+        """
+        existing_org_dictionary = {}
+
+        for org in Organization.objects.all():
+            existing_org_dictionary[str(org.discovery_uuid)] = org
+
+        discovery_programs = DiscoveryServiceClient.get_programs_by_types(program_types)
+        existing_program_dictionary = {}
+        programs_to_create = []
+
+        for program in Program.objects.all():
+            existing_program_dictionary[str(program.discovery_uuid)] = program
+
+        logger.info('Start sync Discovery programs...')
+        for discovery_program in discovery_programs:
+            cur_program = existing_program_dictionary.get(discovery_program.get('uuid'))
+            first_discovery_authoring_org = next(iter(discovery_program.get('authoring_organizations')), None)
+            first_auth_org = None
+            if first_discovery_authoring_org:
+                first_auth_org = existing_org_dictionary.get(first_discovery_authoring_org.get('uuid'))
+
+            if not cur_program and first_auth_org:
+                programs_to_create.append(Program(
+                    discovery_uuid=discovery_program.get('uuid'),
+                    managing_organization=first_auth_org,
+                    key=discovery_program.get('marketing_slug'),
+                ))
+                logger.info('Creating %s', discovery_program.get('marketing_slug'))
+
+        if not programs_to_create:
+            logger.info('Sync complete. No changes made to Registrar service')
+            return
+
+        # Bulk create those new programs
+        Program.objects.bulk_create(programs_to_create)
+        self.create_program_org_groups(programs_to_create)
+
+        logger.info('Sync Programs Success!')
+
+    def update_org_groups(self, updated_orgs):
+        """
+        Update the existing OrganizationGroups to match the up to date name of the organization
+        """
+        existing_org_groups = OrganizationGroup.objects.select_related('organization').filter(
+            organization__discovery_uuid__in=[org.discovery_uuid for org in updated_orgs]
+        )
+        org_group_to_update = []
+        for org_group in existing_org_groups:
+            org_group.name = '{}_ReadOrganizationReports'.format(org_group.organization.key)
+            org_group_to_update.append(org_group)
+
+        OrganizationGroup.objects.bulk_update(org_group_to_update, ['name'])
+
+    def create_org_groups(self, new_orgs):
+        """
+        Create new org groups based on the new orgs passed in.
+        Then we save each new org group one by one. This is inefficient but necessary
+        each new org group save() function includes a lot of logic we cannot bulk create
+        """
+        newly_created_orgs = Organization.objects.filter(
+            discovery_uuid__in=[org.discovery_uuid for org in new_orgs]
+        )
+        for new_org in newly_created_orgs:
+            new_org_group = OrganizationGroup(
+                name='{}_ReadOrganizationReports'.format(new_org.key),
+                organization=new_org,
+                role=OrganizationReadReportRole.name,
+            )
+            new_org_group.save()
+            logger.info(
+                'Created new org group for org %s and permission %s. org_group_id: %s',
+                new_org.key,
+                OrganizationReadReportRole.name,
+                new_org_group.id
+            )
+
+    def create_program_org_groups(self, new_programs):
+        """
+        Create new program org groups based on the new programs passed in.
+        Then we save each new program org group one by one. This is inefficient but necessary
+        each new program org group save() function includes a lot of logic we cannot bulk create
+        """
+
+        newly_created_programs = Program.objects.select_related('managing_organization').filter(
+            discovery_uuid__in=[program.discovery_uuid for program in new_programs]
+        )
+        for new_program in newly_created_programs:
+            new_program_org_group = ProgramOrganizationGroup(
+                name='{}_{}_ReadProgramReports'.format(
+                    new_program.managing_organization.key,
+                    new_program.key,
+                ),
+                granting_organization=new_program.managing_organization,
+                program=new_program,
+                role=ProgramReadReportRole.name
+            )
+            new_program_org_group.save()
+            logger.info(
+                'Created new program_org group for org %s, program %s and permission %s. program_org_group_id: %s',
+                new_program.managing_organization.key,
+                new_program.key,
+                ProgramReadReportRole.name,
+                new_program_org_group.id
+            )

--- a/registrar/apps/core/management/commands/test/test_sync_with_discovery.py
+++ b/registrar/apps/core/management/commands/test/test_sync_with_discovery.py
@@ -1,0 +1,352 @@
+""" Tests for sync_with_discovery management command """
+import ddt
+from django.core.management import call_command
+from django.test import TestCase
+from mock import patch
+
+from registrar.apps.core.api_client import DiscoveryServiceClient
+from registrar.apps.core.models import (
+    Organization,
+    OrganizationGroup,
+    Program,
+    ProgramOrganizationGroup,
+)
+from registrar.apps.core.permissions import (
+    OrganizationReadReportRole,
+    ProgramReadReportRole,
+)
+from registrar.apps.core.tests.factories import (
+    OrganizationFactory,
+    OrganizationGroupFactory,
+    ProgramFactory,
+    ProgramOrganizationGroupFactory,
+)
+
+
+class TestSyncWithDiscoveryCommandBase(TestCase):
+    """ Test sync_with_discovery command """
+
+    command = 'sync_with_discovery'
+
+    def setUp(self):
+        super().setUp()
+        get_organizations_patcher = patch.object(DiscoveryServiceClient, 'get_organizations')
+        get_programs_by_types_patcher = patch.object(DiscoveryServiceClient, 'get_programs_by_types')
+        self.mock_get_organizations_patcher = get_organizations_patcher.start()
+        self.mock_get_programs_by_types_patcher = get_programs_by_types_patcher.start()
+        self.addCleanup(get_organizations_patcher.stop)
+        self.addCleanup(get_programs_by_types_patcher.stop)
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.org = OrganizationFactory()
+        cls.other_org = OrganizationFactory()
+        cls.org_read_reports_group = OrganizationGroupFactory(
+            name='{}_ReadOrganizationReports'.format(cls.org.key),
+            organization=cls.org,
+            role=OrganizationReadReportRole.name
+        )
+        cls.other_org_read_reports_group = OrganizationGroupFactory(
+            name='{}_ReadOrganizationReports'.format(cls.other_org.key),
+            organization=cls.other_org,
+            role=OrganizationReadReportRole.name
+        )
+
+
+class TestSyncOrganizationsWithDiscoveryCommand(TestSyncWithDiscoveryCommandBase):
+    """
+    All the test cases for making sure Organizations objects are
+    properly created or updated based on data from Discovery service
+    """
+    @classmethod
+    def discovery_organization_dict(cls, uuid, key, name):
+        return {
+            'key': key,
+            'uuid': str(uuid),
+            'name': name,
+        }
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.new_discovery_org_uuid = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+        cls.new_discovery_organization = cls.discovery_organization_dict(
+            cls.new_discovery_org_uuid,
+            'letterX',
+            'Letter University',
+        )
+        cls.updating_discovery_organization = cls.discovery_organization_dict(
+            cls.org.discovery_uuid,
+            'updateX',
+            'Updating University',
+        )
+        cls.discovery_org = cls.discovery_organization_dict(
+            cls.org.discovery_uuid,
+            cls.org.key,
+            cls.org.name,
+        )
+        cls.discovery_other_org = cls.discovery_organization_dict(
+            cls.other_org.discovery_uuid,
+            cls.other_org.key,
+            cls.other_org.name,
+        )
+
+    def assert_org_nonexistant(self, expected_uuid):
+        """
+        Make sure the passed in org uuids do not exists in the database
+        """
+        with self.assertRaises(Organization.DoesNotExist):
+            Organization.objects.get(discovery_uuid=expected_uuid)
+
+    def assert_organizations(self, orgs_expected, query_count_expected):
+        """
+        Make sure the database state is what is expected.
+        Also ensure the query count of the management command is expected
+        """
+        self.mock_get_organizations_patcher.return_value = orgs_expected
+        self.mock_get_programs_by_types_patcher.return_value = []
+        with self.assertNumQueries(query_count_expected):
+            call_command(self.command)
+
+        for org in orgs_expected:
+            self.assertTrue(Organization.objects.get(discovery_uuid=org['uuid'], key=org['key'], name=org['name']))
+            existing_org_group = OrganizationGroup.objects.get(
+                organization__discovery_uuid=org['uuid'],
+                role=OrganizationReadReportRole.name
+            )
+            self.assertTrue(existing_org_group)
+            expected_org_group_name = '{}_ReadOrganizationReports'.format(org['key'])
+            self.assertEqual(existing_org_group.name, expected_org_group_name)
+
+    def test_sync_organization_create_and_update(self):
+        orgs_to_sync = [
+            self.new_discovery_organization,
+            self.updating_discovery_organization,
+            self.discovery_other_org,
+        ]
+        self.assert_org_nonexistant(self.new_discovery_org_uuid)
+
+        self.assert_organizations(orgs_to_sync, 32)
+
+    def test_sync_organization_create_only(self):
+        other_new_org_uuid = '99999999-2222-2222-3333-555555555555'
+        other_new_org = self.discovery_organization_dict(
+            other_new_org_uuid,
+            'languageX',
+            'Language University',
+        )
+        orgs_to_sync = [
+            self.new_discovery_organization,
+            other_new_org,
+            self.discovery_other_org,
+            self.discovery_org,
+        ]
+        self.assert_org_nonexistant(self.new_discovery_org_uuid)
+        self.assert_org_nonexistant(other_new_org_uuid)
+
+        self.assert_organizations(orgs_to_sync, 47)
+
+    def test_sync_organization_update_only(self):
+        orgs_to_sync = [
+            self.updating_discovery_organization,
+            self.discovery_other_org
+        ]
+
+        self.assert_organizations(orgs_to_sync, 10)
+
+    def test_sync_no_change(self):
+        orgs_to_sync = [
+            self.discovery_org,
+            self.discovery_other_org,
+        ]
+        self.assert_organizations(orgs_to_sync, 5)
+
+
+@ddt.ddt
+class TestSyncProgramsWithDiscoveryCommand(TestSyncWithDiscoveryCommandBase):
+    """
+    All the test cases for making sure Program objects are
+    properly created based on data from Discovery service
+    """
+    @classmethod
+    def discovery_program_dict(cls, org_uuid, uuid, slug):
+        return {
+            'authoring_organizations': [{'uuid': str(org_uuid)}] if org_uuid else [],
+            'uuid': uuid,
+            'marketing_slug': slug,
+        }
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.english_uuid = '11111111-2222-3333-4444-555555555555'
+        cls.german_uuid = '22222222-2222-3333-4444-555555555555'
+        cls.russian_uuid = '33333333-2222-3333-4444-555555555555'
+        cls.arabic_uuid = '44444444-2222-3333-4444-555555555555'
+
+        cls.english_program = ProgramFactory(
+            key='masters-in-english',
+            discovery_uuid=cls.english_uuid,
+            managing_organization=cls.org
+        )
+        cls.german_program = ProgramFactory(
+            key='masters-in-german',
+            discovery_uuid=cls.german_uuid,
+            managing_organization=cls.other_org
+        )
+        cls.english_program_read_report_group = ProgramOrganizationGroupFactory(
+            name='{}_{}_ReadProgramReports'.format(
+                cls.org.key,
+                cls.english_program.key,
+            ),
+            program=cls.english_program,
+            granting_organization=cls.org,
+            role=ProgramReadReportRole.name,
+        )
+        cls.german_program_read_report_group = ProgramOrganizationGroupFactory(
+            name='{}_{}_ReadProgramReports'.format(
+                cls.other_org.key,
+                cls.german_program.key,
+            ),
+            program=cls.german_program,
+            granting_organization=cls.other_org,
+            role=ProgramReadReportRole.name,
+        )
+        cls.english_discovery_program = cls.discovery_program_dict(
+            cls.org.discovery_uuid,
+            cls.english_uuid,
+            'masters-in-english'
+        )
+        cls.german_discovery_program = cls.discovery_program_dict(
+            cls.other_org.discovery_uuid,
+            cls.german_uuid,
+            'masters-in-german'
+        )
+        cls.russian_discovery_program = cls.discovery_program_dict(
+            cls.other_org.discovery_uuid,
+            cls.russian_uuid,
+            'russian-slug'
+        )
+        cls.arabic_discovery_program = cls.discovery_program_dict(
+            cls.org.discovery_uuid,
+            cls.arabic_uuid,
+            'arabic-slug'
+        )
+
+    def assert_program_nonexistant(self, expected_uuid):
+        """ Assert that a progam with the given fields do not exists """
+        with self.assertRaises(Program.DoesNotExist):
+            Program.objects.get(discovery_uuid=expected_uuid)
+
+    def assert_programs(self, programs_to_sync, query_count_expected, programs_expected=None):
+        """
+        Make sure the database state is what is expected.
+        Also ensure the query count of the management command is expected
+        """
+        if not programs_expected:
+            programs_expected = programs_to_sync
+        self.mock_get_organizations_patcher.return_value = []
+        self.mock_get_programs_by_types_patcher.return_value = programs_to_sync
+        with self.assertNumQueries(query_count_expected):
+            call_command(self.command)
+
+        for program in programs_expected:
+            created_program = Program.objects.get(discovery_uuid=program['uuid'])
+            self.assertTrue(created_program)
+            self.assertTrue(
+                ProgramOrganizationGroup.objects.get(
+                    program=created_program,
+                    granting_organization=created_program.managing_organization,
+                    role=ProgramReadReportRole.name,
+                )
+            )
+
+    def test_sync_programs_create_with_different_slugs(self):
+        updated_discovery_program = self.discovery_program_dict(
+            self.german_program.managing_organization.discovery_uuid,
+            self.german_program.discovery_uuid,
+            'updated-marketing-slug',
+        )
+        programs_to_sync = [
+            self.russian_discovery_program,
+            self.arabic_discovery_program,
+            self.english_discovery_program,
+            updated_discovery_program
+        ]
+        self.assert_program_nonexistant(self.russian_discovery_program.get('uuid'))
+        self.assert_program_nonexistant(self.arabic_discovery_program.get('uuid'))
+
+        self.assert_programs(programs_to_sync, 47)
+
+    def test_sync_programs_with_different_slugs(self):
+        updated_discovery_program = self.discovery_program_dict(
+            self.german_program.managing_organization.discovery_uuid,
+            self.german_program.discovery_uuid,
+            'updated-marketing-slug'
+        )
+        programs_to_sync = [
+            self.english_discovery_program,
+            updated_discovery_program
+        ]
+        self.assert_programs(programs_to_sync, 5)
+
+    def test_sync_programs_create_only(self):
+        programs_to_sync = [
+            self.russian_discovery_program,
+            self.arabic_discovery_program,
+            self.english_discovery_program,
+        ]
+        self.assert_program_nonexistant(self.russian_discovery_program.get('uuid'))
+        self.assert_program_nonexistant(self.arabic_discovery_program.get('uuid'))
+
+        self.assert_programs(programs_to_sync, 47)
+
+    def test_sync_programs_no_change(self):
+        programs_to_sync = [
+            self.english_discovery_program,
+            self.german_discovery_program,
+        ]
+        self.assert_programs(programs_to_sync, 5)
+
+    @ddt.data(
+        '44444444-2222-3333-4444-000000000000',
+        None
+    )
+    def test_sync_programs_bad_org(self, org_uuid):
+        no_org_program = self.discovery_program_dict(
+            org_uuid,
+            self.russian_uuid,
+            'no-org-program',
+        )
+        programs_to_sync = [
+            self.english_discovery_program,
+            no_org_program,
+        ]
+        self.assert_program_nonexistant(no_org_program.get('uuid'))
+        self.assert_programs(programs_to_sync, 5, [self.english_discovery_program])
+        self.assert_program_nonexistant(no_org_program.get('uuid'))
+
+    def test_sync_programs_multiple_authoring_orgs(self):
+        new_program_uuid_string = '44444444-2222-3333-4444-555555555555'
+        new_program_to_create = {
+            'authoring_organizations': [
+                {'uuid': str(self.org.discovery_uuid)},
+                {'uuid': str(self.other_org.discovery_uuid)},
+            ],
+            'uuid': new_program_uuid_string,
+            'marketing_slug': 'multi_orgs_program',
+        }
+        programs_to_sync = [
+            new_program_to_create,
+            self.german_discovery_program,
+            self.english_discovery_program,
+        ]
+        self.assert_programs(programs_to_sync, 27)
+        newly_created_program = Program.objects.get(
+            discovery_uuid=new_program_uuid_string
+        )
+        self.assertEqual(
+            newly_created_program.managing_organization.discovery_uuid,
+            self.org.discovery_uuid
+        )

--- a/registrar/apps/core/management/commands/test/test_sync_with_discovery.py
+++ b/registrar/apps/core/management/commands/test/test_sync_with_discovery.py
@@ -94,7 +94,7 @@ class TestSyncOrganizationsWithDiscoveryCommand(TestSyncWithDiscoveryCommandBase
 
     def assert_org_nonexistant(self, expected_uuid):
         """
-        Make sure the passed in org uuids do not exists in the database
+        Make sure the passed in org uuids do not exist in the database
         """
         with self.assertRaises(Organization.DoesNotExist):
             Organization.objects.get(discovery_uuid=expected_uuid)
@@ -338,15 +338,8 @@ class TestSyncProgramsWithDiscoveryCommand(TestSyncWithDiscoveryCommandBase):
             'marketing_slug': 'multi_orgs_program',
         }
         programs_to_sync = [
-            new_program_to_create,
             self.german_discovery_program,
             self.english_discovery_program,
         ]
-        self.assert_programs(programs_to_sync, 27)
-        newly_created_program = Program.objects.get(
-            discovery_uuid=new_program_uuid_string
-        )
-        self.assertEqual(
-            newly_created_program.managing_organization.discovery_uuid,
-            self.org.discovery_uuid
-        )
+        self.assert_programs(programs_to_sync + [new_program_to_create], 5, programs_to_sync)
+        self.assert_program_nonexistant(new_program_uuid_string)

--- a/registrar/apps/core/tests/test_api_client.py
+++ b/registrar/apps/core/tests/test_api_client.py
@@ -1,0 +1,126 @@
+"""
+Test module for api_client.py
+"""
+from posixpath import join as urljoin
+from uuid import UUID
+
+import ddt
+import responses
+from django.conf import settings
+from django.test import TestCase
+
+from ..api_client import DISCOVERY_API_TPL, DiscoveryServiceClient
+from .utils import mock_oauth_login
+
+
+@ddt.ddt
+class DiscoveryServiceClientTestCase(TestCase):
+    """
+    Tests against the DiscoveryServiceClient object
+    """
+    organization_from_discovery = {
+        'key': 'test_org',
+        'name': 'org for testing',
+        'uuid': '00000000-1111-3333-6666-777777777777',
+    }
+    another_organization_from_discovery = {
+        'key': 'test_another_org',
+        'name': 'another org for testing',
+        'uuid': '00000000-1111-3333-6666-777777777788'
+    }
+    master_uuid = UUID("99999999-4444-2222-1111-000000000000")
+    master_from_discovery = {
+        'title': "Master's in CS",
+        'marketing_url': "https://stem.edx.org/masters-in-cs",
+        'type': "Masters",
+        'uuid': str(master_uuid),
+    }
+    mm_program_from_discovery = {
+        'title': "Micromaster tester program",
+        'marketing_url': "https://stem.edx.org/mm-in-test",
+        'type': "Micromasters",
+        'uuid': "99999999-4444-2222-1111-000000000011",
+    }
+    program_types = ['Micromasters', 'Masters']
+
+    def get_multi_response(self, results):
+        """ Return the response that's paginated """
+        return {
+            'count': len(results),
+            'next': None,
+            'prev': None,
+            'results': results
+        }
+
+    @mock_oauth_login
+    @responses.activate
+    @ddt.data(
+        (200, master_from_discovery),
+        (403, {'message': 'Permission Denied'})
+    )
+    @ddt.unpack
+    def test_get_program(self, status, data_json):
+        discovery_program_url = urljoin(
+            settings.DISCOVERY_BASE_URL,
+            DISCOVERY_API_TPL.format('programs', self.master_uuid)
+        )
+        responses.add(
+            responses.GET,
+            discovery_program_url,
+            status=status,
+            json=data_json,
+        )
+        program = DiscoveryServiceClient.get_program(self.master_uuid)
+        if status == 200:
+            self.assertEqual(program, data_json)
+        else:
+            self.assertIsNone(program)
+
+    @mock_oauth_login
+    @responses.activate
+    @ddt.data(
+        (200, [master_from_discovery, mm_program_from_discovery]),
+        (403, [])
+    )
+    @ddt.unpack
+    def test_get_programs_by_types(self, status, results):
+        discovery_url = urljoin(
+            settings.DISCOVERY_BASE_URL,
+            DISCOVERY_API_TPL.format('programs', '')
+        )
+        discovery_url += '?types={}'.format(','.join(self.program_types))
+        responses.add(
+            responses.GET,
+            discovery_url,
+            status=status,
+            json=self.get_multi_response(results),
+        )
+        programs = DiscoveryServiceClient.get_programs_by_types(self.program_types)
+        if status == 200:
+            self.assertEqual(results, programs)
+        else:
+            self.assertEqual([], programs)
+
+    @mock_oauth_login
+    @responses.activate
+    @ddt.data(
+        (200, [organization_from_discovery, another_organization_from_discovery]),
+        (403, [])
+    )
+    @ddt.unpack
+    def test_get_organizations(self, status, results):
+        discovery_url = urljoin(
+            settings.DISCOVERY_BASE_URL,
+            DISCOVERY_API_TPL.format('organizations', '')
+        )
+        responses.add(
+            responses.GET,
+            discovery_url,
+            status=status,
+            json=self.get_multi_response(results),
+        )
+        orgs = DiscoveryServiceClient.get_organizations()
+        if status == 200:
+            self.assertEqual(results, orgs)
+        else:
+            self.assertEqual([], orgs)


### PR DESCRIPTION
Create the management command to sync the organization and programs objects from discovery service
## Description
Create a management command that calls the Discovery service API.
It will populate the Registrar service with new Organizations and new Programs.
For each new organization created, a new OrganizationGroup with ReadOrganizationReports group is also created
For each new program created, a new ProgramOrganizationGroup with ReadOrganizationReports group is also created
@edx/masters-devs-cosmonauts Please review
