### PR TITLE
Exclude internal endpoints from new api doc

### DIFF
--- a/registrar/apps/api/internal/views.py
+++ b/registrar/apps/api/internal/views.py
@@ -1,6 +1,7 @@
 """ Internal utility API views """
 from django.http import Http404
 from django.shortcuts import get_object_or_404
+from edx_api_doc_tools import exclude_schema_for_all
 from edx_rest_framework_extensions.auth.jwt.authentication import (
     JwtAuthentication,
 )
@@ -16,10 +17,11 @@ from registrar.apps.core.models import Program
 from ..mixins import TrackViewMixin
 
 
+@exclude_schema_for_all
 class FlushProgramCacheView(TrackViewMixin, APIView):
     """
     A view for clearing the programs cache.
-    Is only accessable to staff users.
+    Is only accessible to staff users.
 
     Paths:
         All programs:      /api/internal/cache/


### PR DESCRIPTION
## [MST-429](https://openedx.atlassian.net/browse/MST-429)

Upon loading, the new api-docs page shows an error for an invalid endpoint. This is caused by the two endpoints defined in internal/urls.py, as they both are delete methods and have the same path (parameters do not make a path unique, according to openapi, which is used by api-doc-tools).

Because we wanted to hide these endpoints on the doc anyway, a decorator has been added that will prevent the docs for these endpoints from being generated.
