### PR TITLE
Only show v2 endpoints on new api docs

### DIFF
--- a/registrar/urls.py
+++ b/registrar/urls.py
@@ -26,6 +26,7 @@ from edx_api_doc_tools import make_api_info, make_docs_ui_view
 
 from . import api_renderer
 from .apps.api import urls as api_urls
+from .apps.api.v2 import urls as v2_urls
 from .apps.core import views as core_views
 
 
@@ -45,7 +46,8 @@ with open(api_description_path, encoding='utf-8') as api_description_file:
             version="v2",
             email="masters-dev@edx.org",
             description=api_description_file.read(),
-        )
+        ),
+        api_url_patterns=[url(r'^api/v2/', include(v2_urls))],
     )
 
 urlpatterns = oauth2_urlpatterns + [

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -28,7 +28,7 @@ django==2.2.16            # via -c requirements/constraints.txt, -r requirements
 djangorestframework==3.11.1  # via -r requirements/base.in, django-user-tasks, drf-jwt, drf-yasg, edx-api-doc-tools, edx-drf-extensions, rest-condition
 drf-jwt==1.17.2           # via edx-drf-extensions
 drf-yasg==1.17.1          # via edx-api-doc-tools
-edx-api-doc-tools==1.3.1  # via -r requirements/base.in
+edx-api-doc-tools==1.3.2  # via -r requirements/base.in
 edx-auth-backends==3.1.0  # via -r requirements/base.in
 edx-django-release-util==0.4.4  # via -r requirements/base.in
 edx-django-utils==3.8.0   # via edx-drf-extensions

--- a/requirements/devstack.txt
+++ b/requirements/devstack.txt
@@ -53,7 +53,7 @@ docutils==0.15.2          # via -c requirements/constraints.txt, -r requirements
 drf-jwt==1.17.2           # via -r requirements/local.txt, edx-drf-extensions
 drf-yasg==1.17.1          # via -r requirements/local.txt, edx-api-doc-tools
 ecdsa==0.14.1             # via -r requirements/local.txt, python-jose
-edx-api-doc-tools==1.3.1  # via -r requirements/local.txt
+edx-api-doc-tools==1.3.2  # via -r requirements/local.txt
 edx-auth-backends==3.1.0  # via -r requirements/local.txt
 edx-django-release-util==0.4.4  # via -r requirements/local.txt
 edx-django-utils==3.8.0   # via -r requirements/local.txt, edx-drf-extensions

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -53,7 +53,7 @@ docutils==0.15.2          # via -c requirements/constraints.txt, -r requirements
 drf-jwt==1.17.2           # via -r requirements/test.txt, edx-drf-extensions
 drf-yasg==1.17.1          # via -r requirements/test.txt, edx-api-doc-tools
 ecdsa==0.14.1             # via -r requirements/test.txt, python-jose
-edx-api-doc-tools==1.3.1  # via -r requirements/test.txt
+edx-api-doc-tools==1.3.2  # via -r requirements/test.txt
 edx-auth-backends==3.1.0  # via -r requirements/test.txt
 edx-django-release-util==0.4.4  # via -r requirements/test.txt
 edx-django-utils==3.8.0   # via -r requirements/test.txt, edx-drf-extensions

--- a/requirements/monitoring/requirements.txt
+++ b/requirements/monitoring/requirements.txt
@@ -53,7 +53,7 @@ docutils==0.15.2          # via -r requirements/monitoring/../devstack.txt, -r r
 drf-jwt==1.17.2           # via -r requirements/monitoring/../devstack.txt, -r requirements/monitoring/../local.txt, -r requirements/monitoring/../production.txt, -r requirements/monitoring/../test.txt, edx-drf-extensions
 drf-yasg==1.17.1          # via -r requirements/monitoring/../devstack.txt, -r requirements/monitoring/../local.txt, -r requirements/monitoring/../production.txt, -r requirements/monitoring/../test.txt, edx-api-doc-tools
 ecdsa==0.14.1             # via -r requirements/monitoring/../devstack.txt, -r requirements/monitoring/../local.txt, -r requirements/monitoring/../test.txt, python-jose
-edx-api-doc-tools==1.3.1  # via -r requirements/monitoring/../devstack.txt, -r requirements/monitoring/../local.txt, -r requirements/monitoring/../production.txt, -r requirements/monitoring/../test.txt
+edx-api-doc-tools==1.3.2  # via -r requirements/monitoring/../devstack.txt, -r requirements/monitoring/../local.txt, -r requirements/monitoring/../production.txt, -r requirements/monitoring/../test.txt
 edx-auth-backends==3.1.0  # via -r requirements/monitoring/../devstack.txt, -r requirements/monitoring/../local.txt, -r requirements/monitoring/../production.txt, -r requirements/monitoring/../test.txt
 edx-django-release-util==0.4.4  # via -r requirements/monitoring/../devstack.txt, -r requirements/monitoring/../local.txt, -r requirements/monitoring/../production.txt, -r requirements/monitoring/../test.txt
 edx-django-utils==3.8.0   # via -r requirements/monitoring/../devstack.txt, -r requirements/monitoring/../local.txt, -r requirements/monitoring/../production.txt, -r requirements/monitoring/../test.txt, edx-drf-extensions

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -30,7 +30,7 @@ django==2.2.16            # via -c requirements/constraints.txt, -r requirements
 djangorestframework==3.11.1  # via -r requirements/base.txt, django-user-tasks, drf-jwt, drf-yasg, edx-api-doc-tools, edx-drf-extensions, rest-condition
 drf-jwt==1.17.2           # via -r requirements/base.txt, edx-drf-extensions
 drf-yasg==1.17.1          # via -r requirements/base.txt, edx-api-doc-tools
-edx-api-doc-tools==1.3.1  # via -r requirements/base.txt
+edx-api-doc-tools==1.3.2  # via -r requirements/base.txt
 edx-auth-backends==3.1.0  # via -r requirements/base.txt
 edx-django-release-util==0.4.4  # via -r requirements/base.txt
 edx-django-utils==3.8.0   # via -r requirements/base.txt, edx-drf-extensions

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -47,7 +47,7 @@ docopt==0.6.2             # via pipreqs
 drf-jwt==1.17.2           # via -r requirements/base.txt, edx-drf-extensions
 drf-yasg==1.17.1          # via -r requirements/base.txt, edx-api-doc-tools
 ecdsa==0.14.1             # via python-jose
-edx-api-doc-tools==1.3.1  # via -r requirements/base.txt
+edx-api-doc-tools==1.3.2  # via -r requirements/base.txt
 edx-auth-backends==3.1.0  # via -r requirements/base.txt
 edx-django-release-util==0.4.4  # via -r requirements/base.txt
 edx-django-utils==3.8.0   # via -r requirements/base.txt, edx-drf-extensions


### PR DESCRIPTION
## [MST-201](https://openedx.atlassian.net/browse/MST-201)

@edx/masters-devs-cosmonauts 

Updated api-doc-tools library and filtered api doc urls to show only endpoints matching v2 patterns. 

Pictures of api-docs/new page for examples of changes:

![Screen Shot 2020-09-24 at 3 56 11 PM](https://user-images.githubusercontent.com/46360176/94194007-17186d80-fe7f-11ea-8ef1-c341ae0a34d6.png)

Shows updated base url

![Screen Shot 2020-09-24 at 3 56 01 PM](https://user-images.githubusercontent.com/46360176/94193983-0d8f0580-fe7f-11ea-80ea-db92a90fa124.png)

Shows part of endpoint list

