### PR TITLE
Revert "Upgrade OS to Ubuntu Focal 20.04"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,8 @@ branches:
   - master
 
 language: python
-dist: focal
 python:
-    - 3.5
+    - 3.5.2
     - 3.8
 env:
 - TOXENV=django22

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal as app
+FROM ubuntu:xenial as app
 
 # System requirements.
 RUN apt-get update && apt-get upgrade -qy


### PR DESCRIPTION
Reverts edx/registrar#365

Failing at docker image push, need to wait until https://github.com/edx/registrar/pull/354 is merged as Python 3.5 is incompatible.