### PR TITLE
Update new docs for program enrollments

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -28,7 +28,7 @@ django==2.2.16            # via -c requirements/constraints.txt, -r requirements
 djangorestframework==3.11.1  # via -r requirements/base.in, django-user-tasks, drf-jwt, drf-yasg, edx-api-doc-tools, edx-drf-extensions, rest-condition
 drf-jwt==1.17.2           # via edx-drf-extensions
 drf-yasg==1.17.1          # via edx-api-doc-tools
-edx-api-doc-tools==1.3.2  # via -r requirements/base.in
+edx-api-doc-tools==1.4.0  # via -r requirements/base.in
 edx-auth-backends==3.1.0  # via -r requirements/base.in
 edx-django-release-util==0.4.4  # via -r requirements/base.in
 edx-django-utils==3.8.0   # via edx-drf-extensions

--- a/requirements/devstack.txt
+++ b/requirements/devstack.txt
@@ -53,7 +53,7 @@ docutils==0.15.2          # via -c requirements/constraints.txt, -r requirements
 drf-jwt==1.17.2           # via -r requirements/local.txt, edx-drf-extensions
 drf-yasg==1.17.1          # via -r requirements/local.txt, edx-api-doc-tools
 ecdsa==0.14.1             # via -r requirements/local.txt, python-jose
-edx-api-doc-tools==1.3.2  # via -r requirements/local.txt
+edx-api-doc-tools==1.4.0  # via -r requirements/local.txt
 edx-auth-backends==3.1.0  # via -r requirements/local.txt
 edx-django-release-util==0.4.4  # via -r requirements/local.txt
 edx-django-utils==3.8.0   # via -r requirements/local.txt, edx-drf-extensions

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -53,7 +53,7 @@ docutils==0.15.2          # via -c requirements/constraints.txt, -r requirements
 drf-jwt==1.17.2           # via -r requirements/test.txt, edx-drf-extensions
 drf-yasg==1.17.1          # via -r requirements/test.txt, edx-api-doc-tools
 ecdsa==0.14.1             # via -r requirements/test.txt, python-jose
-edx-api-doc-tools==1.3.2  # via -r requirements/test.txt
+edx-api-doc-tools==1.4.0  # via -r requirements/test.txt
 edx-auth-backends==3.1.0  # via -r requirements/test.txt
 edx-django-release-util==0.4.4  # via -r requirements/test.txt
 edx-django-utils==3.8.0   # via -r requirements/test.txt, edx-drf-extensions

--- a/requirements/monitoring/requirements.txt
+++ b/requirements/monitoring/requirements.txt
@@ -53,7 +53,7 @@ docutils==0.15.2          # via -r requirements/monitoring/../devstack.txt, -r r
 drf-jwt==1.17.2           # via -r requirements/monitoring/../devstack.txt, -r requirements/monitoring/../local.txt, -r requirements/monitoring/../production.txt, -r requirements/monitoring/../test.txt, edx-drf-extensions
 drf-yasg==1.17.1          # via -r requirements/monitoring/../devstack.txt, -r requirements/monitoring/../local.txt, -r requirements/monitoring/../production.txt, -r requirements/monitoring/../test.txt, edx-api-doc-tools
 ecdsa==0.14.1             # via -r requirements/monitoring/../devstack.txt, -r requirements/monitoring/../local.txt, -r requirements/monitoring/../test.txt, python-jose
-edx-api-doc-tools==1.3.2  # via -r requirements/monitoring/../devstack.txt, -r requirements/monitoring/../local.txt, -r requirements/monitoring/../production.txt, -r requirements/monitoring/../test.txt
+edx-api-doc-tools==1.4.0  # via -r requirements/monitoring/../devstack.txt, -r requirements/monitoring/../local.txt, -r requirements/monitoring/../production.txt, -r requirements/monitoring/../test.txt
 edx-auth-backends==3.1.0  # via -r requirements/monitoring/../devstack.txt, -r requirements/monitoring/../local.txt, -r requirements/monitoring/../production.txt, -r requirements/monitoring/../test.txt
 edx-django-release-util==0.4.4  # via -r requirements/monitoring/../devstack.txt, -r requirements/monitoring/../local.txt, -r requirements/monitoring/../production.txt, -r requirements/monitoring/../test.txt
 edx-django-utils==3.8.0   # via -r requirements/monitoring/../devstack.txt, -r requirements/monitoring/../local.txt, -r requirements/monitoring/../production.txt, -r requirements/monitoring/../test.txt, edx-drf-extensions

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -30,7 +30,7 @@ django==2.2.16            # via -c requirements/constraints.txt, -r requirements
 djangorestframework==3.11.1  # via -r requirements/base.txt, django-user-tasks, drf-jwt, drf-yasg, edx-api-doc-tools, edx-drf-extensions, rest-condition
 drf-jwt==1.17.2           # via -r requirements/base.txt, edx-drf-extensions
 drf-yasg==1.17.1          # via -r requirements/base.txt, edx-api-doc-tools
-edx-api-doc-tools==1.3.2  # via -r requirements/base.txt
+edx-api-doc-tools==1.4.0  # via -r requirements/base.txt
 edx-auth-backends==3.1.0  # via -r requirements/base.txt
 edx-django-release-util==0.4.4  # via -r requirements/base.txt
 edx-django-utils==3.8.0   # via -r requirements/base.txt, edx-drf-extensions

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -47,7 +47,7 @@ docopt==0.6.2             # via pipreqs
 drf-jwt==1.17.2           # via -r requirements/base.txt, edx-drf-extensions
 drf-yasg==1.17.1          # via -r requirements/base.txt, edx-api-doc-tools
 ecdsa==0.14.1             # via python-jose
-edx-api-doc-tools==1.3.2  # via -r requirements/base.txt
+edx-api-doc-tools==1.4.0  # via -r requirements/base.txt
 edx-auth-backends==3.1.0  # via -r requirements/base.txt
 edx-django-release-util==0.4.4  # via -r requirements/base.txt
 edx-django-utils==3.8.0   # via -r requirements/base.txt, edx-drf-extensions

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [pycodestyle]
-ignore=W504
+ignore=W504,E501
 max-line-length = 120
 exclude=.git,settings,migrations,registrar/static,bower_components,registrar/wsgi.py
 


### PR DESCRIPTION
### [MST-203](https://openedx.atlassian.net/browse/MST-203)

Documentation updated for these endpoints using [edx-api-doc-tools](https://github.com/edx/api-doc-tools):

- ​`GET /v2​/programs​/{program_key}​/enrollments​/`
- `POST /v2​/programs​/{program_key}​/enrollments​/`
- `PATCH /v2​/programs​/{program_key}​/enrollments​/`

Example endpoint:

![Screen Shot 2020-10-05 at 2 09 38 PM](https://user-images.githubusercontent.com/10442143/95116083-7ba3ba00-0714-11eb-89eb-fa91caf1ac62.png)
![Screen Shot 2020-10-05 at 2 09 52 PM](https://user-images.githubusercontent.com/10442143/95116087-7e9eaa80-0714-11eb-8f0a-1330a04c6c4e.png)
