### PR TITLE
Added documentation for job listing and status endpoints

### DIFF
--- a/registrar/apps/api/v1/views.py
+++ b/registrar/apps/api/v1/views.py
@@ -511,9 +511,26 @@ class CourseEnrollmentView(CourseSpecificViewMixin, JobInvokerMixin, EnrollmentM
         return self.handle_enrollments(self.internal_course_key)
 
 
+@schema_for(
+    'get',
+    parameters=[
+        query_parameter('job_id', str, 'ID of asynchronous job, in UUID-4 format'),
+    ],
+    responses={
+        200: JobStatusSerializer,
+        404: "Program key is invalid.",
+        **SCHEMA_COMMON_RESPONSES,
+    },
+)
 class JobStatusRetrieveView(TrackViewMixin, RetrieveAPIView):
     """
     A view for getting the status of a job.
+
+    This endpoint returns the status of jobs created by GET queries to the program and course enrollment endpoints.
+    If a job is complete, a link to the result of the job will be included.
+
+    The only users who can view a job status are the job’s creator and edX staff.
+
 
     Path: /api/[version]/jobs/{job_id}
 
@@ -550,9 +567,22 @@ class JobStatusRetrieveView(TrackViewMixin, RetrieveAPIView):
         return status
 
 
+@schema_for(
+    'get',
+    responses={
+        200: JobStatusSerializer(many=True),
+        401: "User is not logged in.",
+        **SCHEMA_COMMON_RESPONSES,
+    },
+)
 class JobStatusListView(TrackViewMixin, ListAPIView):
     """
     A view for listing currently processing jobs.
+
+    This endpoint returns a list of job status created by GET queries to the program and course enrollment endpoints.
+    If a job is complete, a link to the result of the job will be included.
+
+    The only users who can view a job status are the job’s creator and edX staff.
 
     Path: /api/[version]/jobs/
 


### PR DESCRIPTION
## [MST-205](https://openedx.atlassian.net/browse/MST-205)

Used api-doc-tools to add documentation for the job listing and status endpoints.

Example of endpoint:

![Screen Shot 2020-10-13 at 9 15 54 AM](https://user-images.githubusercontent.com/46360176/95865862-26c7fb00-0d35-11eb-8b6e-bccbead3f53b.png)

