### PR TITLE
Programs Sync Fixes

### DIFF
--- a/registrar/apps/core/api_client.py
+++ b/registrar/apps/core/api_client.py
@@ -44,7 +44,7 @@ class DiscoveryServiceClient:
     @classmethod
     def get_programs_by_types(cls, types):
         """
-        Fetch a JSON representation of programs of specified types from the Discovery service.
+        Fetch a JSON representation of all active programs of specified types from the Discovery service.
 
         Returns empty if not found or other HTTP error.
 
@@ -57,7 +57,7 @@ class DiscoveryServiceClient:
             settings.DISCOVERY_BASE_URL,
             DISCOVERY_API_TPL.format('programs', '')
         )
-        url += '?types={}'.format(','.join(types))
+        url += '?types={}&status=active'.format(','.join(types))
         try:
             return get_all_paginated_results(url)
         except HTTPError:

--- a/registrar/apps/core/management/commands/sync_with_discovery.py
+++ b/registrar/apps/core/management/commands/sync_with_discovery.py
@@ -61,7 +61,7 @@ class Command(BaseCommand):
                     key=discovery_org.get('key'),
                 )
                 orgs_to_create.append(org)
-                logger.info('Creating %s', discovery_org.get('key'))
+                logger.info('Creating %s with uuid %s', discovery_org.get('key'), discovery_org.get('uuid'))
             else:
                 if existing_org.name != discovery_org.get('name') or existing_org.key != discovery_org.get('key'):
                     existing_org.name = discovery_org.get('name')
@@ -129,7 +129,7 @@ class Command(BaseCommand):
                         managing_organization=auth_org,
                         key=discovery_program.get('marketing_slug'),
                     ))
-                    logger.info('Creating %s', discovery_program.get('marketing_slug'))
+                    logger.info('Creating %s with uuid %s', discovery_program.get('marketing_slug'), discovery_authoring_org.get('uuid'))
 
         # Bulk create those new programs
         Program.objects.bulk_create(programs_to_create)

--- a/registrar/apps/core/management/commands/sync_with_discovery.py
+++ b/registrar/apps/core/management/commands/sync_with_discovery.py
@@ -128,7 +128,11 @@ class Command(BaseCommand):
                         managing_organization=auth_org,
                         key=discovery_program.get('marketing_slug'),
                     ))
-                    logger.info('Creating %s with uuid %s', discovery_program.get('marketing_slug'), discovery_authoring_org.get('uuid'))
+                    logger.info(
+                        'Creating %s with uuid %s',
+                        discovery_program.get('marketing_slug'),
+                        discovery_authoring_org.get('uuid')
+                    )
 
         # Bulk create those new programs
         Program.objects.bulk_create(programs_to_create)
@@ -145,9 +149,10 @@ class Command(BaseCommand):
         Then we save each new org group one by one. This is inefficient but necessary
         each new org group save() function includes a lot of logic we cannot bulk create
         """
-        
         read_reports_groups = {}
-        for group in OrganizationGroup.objects.select_related('organization').filter(role=OrganizationReadReportRole.name):
+        for group in OrganizationGroup.objects.select_related('organization').filter(
+            role=OrganizationReadReportRole.name
+        ):
             read_reports_groups[group.organization.key] = group
 
         for org in Organization.objects.all():
@@ -185,7 +190,11 @@ class Command(BaseCommand):
         each new program org group save() function includes a lot of logic we cannot bulk create
         """
         read_reports_groups = {}
-        for group in ProgramOrganizationGroup.objects.select_related('program').select_related('granting_organization').filter(role=ProgramReadReportRole.name):
+        groups_query = ProgramOrganizationGroup.objects.select_related(
+            'program'
+        ).select_related('granting_organization').filter(role=ProgramReadReportRole.name)
+
+        for group in groups_query:
             read_reports_groups[(group.granting_organization.key, group.program.key)] = group
 
         for program in Program.objects.select_related('managing_organization'):

--- a/registrar/apps/core/management/commands/sync_with_discovery.py
+++ b/registrar/apps/core/management/commands/sync_with_discovery.py
@@ -84,7 +84,6 @@ class Command(BaseCommand):
         if orgs_to_update:
             # Bulk update those organizations needs updating
             Organization.objects.bulk_update(orgs_to_update, ['name', 'key'])
-            self.update_org_groups(orgs_to_update)
 
         logger.info('Sync Organizations Success!')
 
@@ -138,21 +137,6 @@ class Command(BaseCommand):
             logger.info('Sync programs complete. No changes made to Registrar service')
 
         logger.info('Sync Programs Success!')
-
-    def update_org_groups(self, updated_orgs):
-        """
-        Update the existing OrganizationGroups to match the up to date name of the organization
-        """
-        existing_org_groups = OrganizationGroup.objects.select_related('organization').filter(
-            organization__discovery_uuid__in=[org.discovery_uuid for org in updated_orgs]
-        )
-        org_group_to_update = []
-        for org_group in existing_org_groups:
-            role_name = org_group.name.split("_")[-1]
-            org_group.name = '{name}_{role}'.format(name=org_group.organization.key, role=role_name)
-            org_group_to_update.append(org_group)
-
-        OrganizationGroup.objects.bulk_update(org_group_to_update, ['name'])
 
     def sync_org_groups(self):
         """

--- a/registrar/apps/core/management/commands/test/test_sync_with_discovery.py
+++ b/registrar/apps/core/management/commands/test/test_sync_with_discovery.py
@@ -132,17 +132,6 @@ class TestSyncOrganizationsWithDiscoveryCommand(TestSyncWithDiscoveryCommandBase
             expected_org_group_name = '{}_ReadOrganizationReports'.format(org['key'])
             self.assertEqual(existing_org_report_group.name, expected_org_group_name)
 
-            # check that read enrollment role exists
-            existing_org_enrollment_group = OrganizationGroup.objects.filter(
-                organization__discovery_uuid=org['uuid'],
-                role=OrganizationReadEnrollmentsRole.name
-            )
-            if existing_org_enrollment_group:
-                self.assertEqual(len(existing_org_enrollment_group), 1)
-                group = existing_org_enrollment_group[0]
-                expected_org_group_name = '{}_ReadEnrollments'.format(org['key'])
-                self.assertEqual(group.name, expected_org_group_name)
-
     def test_sync_organization_create_and_update(self):
         orgs_to_sync = [
             self.new_discovery_organization,
@@ -151,7 +140,7 @@ class TestSyncOrganizationsWithDiscoveryCommand(TestSyncWithDiscoveryCommandBase
         ]
         self.assert_org_nonexistant(self.new_discovery_org_uuid)
 
-        self.assert_organizations(orgs_to_sync, 30)
+        self.assert_organizations(orgs_to_sync, 33)
 
     def test_sync_organization_create_only(self):
         other_new_org_uuid = '99999999-2222-2222-3333-555555555555'
@@ -177,7 +166,7 @@ class TestSyncOrganizationsWithDiscoveryCommand(TestSyncWithDiscoveryCommandBase
             self.discovery_other_org
         ]
 
-        self.assert_organizations(orgs_to_sync, 13)
+        self.assert_organizations(orgs_to_sync, 16)
 
     def test_sync_no_change(self):
         orgs_to_sync = [

--- a/registrar/apps/core/management/commands/test/test_sync_with_discovery.py
+++ b/registrar/apps/core/management/commands/test/test_sync_with_discovery.py
@@ -53,6 +53,11 @@ class TestSyncWithDiscoveryCommandBase(TestCase):
             organization=cls.org,
             role=OrganizationReadEnrollmentsRole.name
         )
+        cls.other_org_read_reports_group = OrganizationGroupFactory(
+            name='{}_ReadOrganizationReports'.format(cls.other_org.key),
+            organization=cls.other_org,
+            role=OrganizationReadReportRole.name
+        )
         cls.other_org_read_enrollments = OrganizationGroupFactory(
             name='{}_ReadEnrollments'.format(cls.other_org.key),
             organization=cls.other_org,
@@ -146,7 +151,7 @@ class TestSyncOrganizationsWithDiscoveryCommand(TestSyncWithDiscoveryCommandBase
         ]
         self.assert_org_nonexistant(self.new_discovery_org_uuid)
 
-        self.assert_organizations(orgs_to_sync, 56)
+        self.assert_organizations(orgs_to_sync, 30)
 
     def test_sync_organization_create_only(self):
         other_new_org_uuid = '99999999-2222-2222-3333-555555555555'
@@ -164,7 +169,7 @@ class TestSyncOrganizationsWithDiscoveryCommand(TestSyncWithDiscoveryCommandBase
         self.assert_org_nonexistant(self.new_discovery_org_uuid)
         self.assert_org_nonexistant(other_new_org_uuid)
 
-        self.assert_organizations(orgs_to_sync, 70)
+        self.assert_organizations(orgs_to_sync, 42)
 
     def test_sync_organization_update_only(self):
         orgs_to_sync = [
@@ -172,14 +177,14 @@ class TestSyncOrganizationsWithDiscoveryCommand(TestSyncWithDiscoveryCommandBase
             self.discovery_other_org
         ]
 
-        self.assert_organizations(orgs_to_sync, 35)
+        self.assert_organizations(orgs_to_sync, 13)
 
     def test_sync_no_change(self):
         orgs_to_sync = [
             self.discovery_org,
             self.discovery_other_org,
         ]
-        self.assert_organizations(orgs_to_sync, 29)
+        self.assert_organizations(orgs_to_sync, 9)
 
 
 @ddt.ddt
@@ -296,7 +301,7 @@ class TestSyncProgramsWithDiscoveryCommand(TestSyncWithDiscoveryCommandBase):
         self.assert_program_nonexistant(self.russian_discovery_program.get('uuid'))
         self.assert_program_nonexistant(self.arabic_discovery_program.get('uuid'))
 
-        self.assert_programs(programs_to_sync, 47)
+        self.assert_programs(programs_to_sync, 42)
 
     def test_sync_programs_with_different_slugs(self):
         updated_discovery_program = self.discovery_program_dict(
@@ -308,7 +313,7 @@ class TestSyncProgramsWithDiscoveryCommand(TestSyncWithDiscoveryCommandBase):
             self.english_discovery_program,
             updated_discovery_program
         ]
-        self.assert_programs(programs_to_sync, 5)
+        self.assert_programs(programs_to_sync, 9)
 
     def test_sync_programs_create_only(self):
         programs_to_sync = [
@@ -319,14 +324,14 @@ class TestSyncProgramsWithDiscoveryCommand(TestSyncWithDiscoveryCommandBase):
         self.assert_program_nonexistant(self.russian_discovery_program.get('uuid'))
         self.assert_program_nonexistant(self.arabic_discovery_program.get('uuid'))
 
-        self.assert_programs(programs_to_sync, 47)
+        self.assert_programs(programs_to_sync, 42)
 
     def test_sync_programs_no_change(self):
         programs_to_sync = [
             self.english_discovery_program,
             self.german_discovery_program,
         ]
-        self.assert_programs(programs_to_sync, 5)
+        self.assert_programs(programs_to_sync, 9)
 
     @ddt.data(
         '44444444-2222-3333-4444-000000000000',
@@ -343,7 +348,7 @@ class TestSyncProgramsWithDiscoveryCommand(TestSyncWithDiscoveryCommandBase):
             no_org_program,
         ]
         self.assert_program_nonexistant(no_org_program.get('uuid'))
-        self.assert_programs(programs_to_sync, 5, [self.english_discovery_program])
+        self.assert_programs(programs_to_sync, 9, [self.english_discovery_program])
         self.assert_program_nonexistant(no_org_program.get('uuid'))
 
     def test_sync_programs_multiple_authoring_orgs(self):
@@ -360,5 +365,5 @@ class TestSyncProgramsWithDiscoveryCommand(TestSyncWithDiscoveryCommandBase):
             self.german_discovery_program,
             self.english_discovery_program,
         ]
-        self.assert_programs(programs_to_sync + [new_program_to_create], 5, programs_to_sync)
+        self.assert_programs(programs_to_sync + [new_program_to_create], 9, programs_to_sync)
         self.assert_program_nonexistant(new_program_uuid_string)

--- a/registrar/apps/core/management/commands/test/test_sync_with_discovery.py
+++ b/registrar/apps/core/management/commands/test/test_sync_with_discovery.py
@@ -326,6 +326,48 @@ class TestSyncProgramsWithDiscoveryCommand(TestSyncWithDiscoveryCommandBase):
 
         self.assert_programs(programs_to_sync, 42)
 
+    def test_sync_programs_missing_role(self):
+        """ program already exists but no reporting role has been created """
+        spanish_program = ProgramFactory(
+            key='masters-in-spanish',
+            discovery_uuid='77777777-2222-3333-4444-555555555555',
+            managing_organization=self.org
+        )
+        spanish_discovery_program = self.discovery_program_dict(
+            self.org.discovery_uuid,
+            spanish_program.discovery_uuid,
+            spanish_program.key, 
+        )
+
+        programs_to_sync = [
+            spanish_discovery_program
+        ]
+        self.assert_programs(programs_to_sync, 25)
+
+    def test_sync_programs_update_role(self):
+        """ program already exists but the reporting role has a nonstandard name """
+        spanish_program = ProgramFactory(
+            key='masters-in-spanish',
+            discovery_uuid='77777777-2222-3333-4444-555555555555',
+            managing_organization=self.org
+        )
+        spanish_discovery_program = self.discovery_program_dict(
+            self.org.discovery_uuid,
+            spanish_program.discovery_uuid,
+            spanish_program.key, 
+        )
+        ProgramOrganizationGroupFactory(
+            name='BadNameReadReports',
+            program=spanish_program,
+            granting_organization=self.org,
+            role=ProgramReadReportRole.name,
+        )
+
+        programs_to_sync = [
+            spanish_discovery_program
+        ]
+        self.assert_programs(programs_to_sync, 15)
+
     def test_sync_programs_no_change(self):
         programs_to_sync = [
             self.english_discovery_program,
@@ -352,7 +394,7 @@ class TestSyncProgramsWithDiscoveryCommand(TestSyncWithDiscoveryCommandBase):
         self.assert_program_nonexistant(no_org_program.get('uuid'))
 
     def test_sync_programs_multiple_authoring_orgs(self):
-        new_program_uuid_string = '44444444-2222-3333-4444-555555555555'
+        new_program_uuid_string = '77777777-2222-3333-4444-555555555555'
         new_program_to_create = {
             'authoring_organizations': [
                 {'uuid': str(self.org.discovery_uuid)},

--- a/registrar/apps/core/management/commands/test/test_sync_with_discovery.py
+++ b/registrar/apps/core/management/commands/test/test_sync_with_discovery.py
@@ -140,7 +140,7 @@ class TestSyncOrganizationsWithDiscoveryCommand(TestSyncWithDiscoveryCommandBase
         ]
         self.assert_org_nonexistant(self.new_discovery_org_uuid)
 
-        self.assert_organizations(orgs_to_sync, 33)
+        self.assert_organizations(orgs_to_sync, 53)
 
     def test_sync_organization_create_only(self):
         other_new_org_uuid = '99999999-2222-2222-3333-555555555555'
@@ -158,7 +158,7 @@ class TestSyncOrganizationsWithDiscoveryCommand(TestSyncWithDiscoveryCommandBase
         self.assert_org_nonexistant(self.new_discovery_org_uuid)
         self.assert_org_nonexistant(other_new_org_uuid)
 
-        self.assert_organizations(orgs_to_sync, 42)
+        self.assert_organizations(orgs_to_sync, 52)
 
     def test_sync_organization_update_only(self):
         orgs_to_sync = [
@@ -166,14 +166,14 @@ class TestSyncOrganizationsWithDiscoveryCommand(TestSyncWithDiscoveryCommandBase
             self.discovery_other_org
         ]
 
-        self.assert_organizations(orgs_to_sync, 16)
+        self.assert_organizations(orgs_to_sync, 32)
 
     def test_sync_no_change(self):
         orgs_to_sync = [
             self.discovery_org,
             self.discovery_other_org,
         ]
-        self.assert_organizations(orgs_to_sync, 9)
+        self.assert_organizations(orgs_to_sync, 11)
 
 
 @ddt.ddt
@@ -290,7 +290,7 @@ class TestSyncProgramsWithDiscoveryCommand(TestSyncWithDiscoveryCommandBase):
         self.assert_program_nonexistant(self.russian_discovery_program.get('uuid'))
         self.assert_program_nonexistant(self.arabic_discovery_program.get('uuid'))
 
-        self.assert_programs(programs_to_sync, 42)
+        self.assert_programs(programs_to_sync, 54)
 
     def test_sync_programs_with_different_slugs(self):
         updated_discovery_program = self.discovery_program_dict(
@@ -302,7 +302,7 @@ class TestSyncProgramsWithDiscoveryCommand(TestSyncWithDiscoveryCommandBase):
             self.english_discovery_program,
             updated_discovery_program
         ]
-        self.assert_programs(programs_to_sync, 9)
+        self.assert_programs(programs_to_sync, 13)
 
     def test_sync_programs_create_only(self):
         programs_to_sync = [
@@ -313,7 +313,7 @@ class TestSyncProgramsWithDiscoveryCommand(TestSyncWithDiscoveryCommandBase):
         self.assert_program_nonexistant(self.russian_discovery_program.get('uuid'))
         self.assert_program_nonexistant(self.arabic_discovery_program.get('uuid'))
 
-        self.assert_programs(programs_to_sync, 42)
+        self.assert_programs(programs_to_sync, 54)
 
     def test_sync_programs_missing_role(self):
         """ program already exists but no reporting role has been created """
@@ -325,13 +325,13 @@ class TestSyncProgramsWithDiscoveryCommand(TestSyncWithDiscoveryCommandBase):
         spanish_discovery_program = self.discovery_program_dict(
             self.org.discovery_uuid,
             spanish_program.discovery_uuid,
-            spanish_program.key, 
+            spanish_program.key,
         )
 
         programs_to_sync = [
             spanish_discovery_program
         ]
-        self.assert_programs(programs_to_sync, 25)
+        self.assert_programs(programs_to_sync, 33)
 
     def test_sync_programs_update_role(self):
         """ program already exists but the reporting role has a nonstandard name """
@@ -343,7 +343,7 @@ class TestSyncProgramsWithDiscoveryCommand(TestSyncWithDiscoveryCommandBase):
         spanish_discovery_program = self.discovery_program_dict(
             self.org.discovery_uuid,
             spanish_program.discovery_uuid,
-            spanish_program.key, 
+            spanish_program.key,
         )
         ProgramOrganizationGroupFactory(
             name='BadNameReadReports',
@@ -355,14 +355,14 @@ class TestSyncProgramsWithDiscoveryCommand(TestSyncWithDiscoveryCommandBase):
         programs_to_sync = [
             spanish_discovery_program
         ]
-        self.assert_programs(programs_to_sync, 15)
+        self.assert_programs(programs_to_sync, 34)
 
     def test_sync_programs_no_change(self):
         programs_to_sync = [
             self.english_discovery_program,
             self.german_discovery_program,
         ]
-        self.assert_programs(programs_to_sync, 9)
+        self.assert_programs(programs_to_sync, 13)
 
     @ddt.data(
         '44444444-2222-3333-4444-000000000000',
@@ -379,7 +379,7 @@ class TestSyncProgramsWithDiscoveryCommand(TestSyncWithDiscoveryCommandBase):
             no_org_program,
         ]
         self.assert_program_nonexistant(no_org_program.get('uuid'))
-        self.assert_programs(programs_to_sync, 9, [self.english_discovery_program])
+        self.assert_programs(programs_to_sync, 13, [self.english_discovery_program])
         self.assert_program_nonexistant(no_org_program.get('uuid'))
 
     def test_sync_programs_multiple_authoring_orgs(self):
@@ -396,5 +396,5 @@ class TestSyncProgramsWithDiscoveryCommand(TestSyncWithDiscoveryCommandBase):
             self.german_discovery_program,
             self.english_discovery_program,
         ]
-        self.assert_programs(programs_to_sync + [new_program_to_create], 9, programs_to_sync)
+        self.assert_programs(programs_to_sync + [new_program_to_create], 13, programs_to_sync)
         self.assert_program_nonexistant(new_program_uuid_string)

--- a/registrar/apps/core/models.py
+++ b/registrar/apps/core/models.py
@@ -165,10 +165,10 @@ class OrganizationGroup(Group):
         super().__init__(*args, **kwargs)
         # Save the value of organization in an attribute, so that when
         # save() is called, we have access to the old value.
-        try:
-            self._initial_organization = self.organization
-        except Organization.DoesNotExist:   # pragma: no cover
-            self._initial_organization = None
+        # try:
+        #     self._initial_organization = self.organization
+        # except Organization.DoesNotExist:   # pragma: no cover
+        self._initial_organization = None
 
     @property
     def role_object(self):
@@ -232,10 +232,10 @@ class ProgramOrganizationGroup(Group):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        try:
-            self._initial_program = self.program
-        except Program.DoesNotExist:   # pragma: no cover
-            self._initial_program = None
+        # try:
+        #     self._initial_program = self.program
+        # except Program.DoesNotExist:   # pragma: no cover
+        self._initial_program = None
 
     @property
     def role_object(self):

--- a/registrar/apps/core/models.py
+++ b/registrar/apps/core/models.py
@@ -165,10 +165,10 @@ class OrganizationGroup(Group):
         super().__init__(*args, **kwargs)
         # Save the value of organization in an attribute, so that when
         # save() is called, we have access to the old value.
-        # try:
-        #     self._initial_organization = self.organization
-        # except Organization.DoesNotExist:   # pragma: no cover
-        self._initial_organization = None
+        try:
+            self._initial_organization = self.organization
+        except Organization.DoesNotExist:   # pragma: no cover
+            self._initial_organization = None
 
     @property
     def role_object(self):
@@ -232,10 +232,10 @@ class ProgramOrganizationGroup(Group):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        # try:
-        #     self._initial_program = self.program
-        # except Program.DoesNotExist:   # pragma: no cover
-        self._initial_program = None
+        try:
+            self._initial_program = self.program
+        except Program.DoesNotExist:   # pragma: no cover
+            self._initial_program = None
 
     @property
     def role_object(self):

--- a/registrar/apps/core/tests/test_api_client.py
+++ b/registrar/apps/core/tests/test_api_client.py
@@ -88,7 +88,7 @@ class DiscoveryServiceClientTestCase(TestCase):
             settings.DISCOVERY_BASE_URL,
             DISCOVERY_API_TPL.format('programs', '')
         )
-        discovery_url += '?types={}'.format(','.join(self.program_types))
+        discovery_url += '?types={}&status=active'.format(','.join(self.program_types))
         responses.add(
             responses.GET,
             discovery_url,


### PR DESCRIPTION
@edx/masters-devs-cosmonauts 

## [MST-484](https://openedx.atlassian.net/browse/MST-484)

The main change here is that the sync of programs and orgs have been decoupled from the sync of the corresponding groups.  This should simplify the logic needed to deal with states caused by manually creating/modifying these models (which have caused the job to fail).

Added a bit more logging to help track down any other issues that may come up.

One change in here I'm putting up for discussion (https://github.com/edx/registrar/commit/2ef090985c938537824ab46f9d08f62d4eebcdf5) I limited the sync to only the reporting groups. Previously this would alter the name of enrollment groups if and only if the organization name changed. If we're going to enforce rules on naming enrollment groups we should do it holistically and not as a side effect IMO.