### PR TITLE
Program/Org Group Performance Fix

### DIFF
--- a/registrar/apps/core/apps.py
+++ b/registrar/apps/core/apps.py
@@ -22,14 +22,26 @@ class CoreConfig(AppConfig):
         """
         Perform other one-time initialization steps.
         """
-        from django.db.models.signals import pre_migrate, post_save     # pylint: disable=import-outside-toplevel
-        from registrar.apps.core.models import User     # pylint: disable=import-outside-toplevel
-        from registrar.apps.core.signals import handle_user_post_save       # pylint: disable=import-outside-toplevel
+        from django.db.models.signals import pre_migrate, pre_save, post_save     # pylint: disable=import-outside-toplevel
+        from registrar.apps.core.models import OrganizationGroup, ProgramOrganizationGroup, User     # pylint: disable=import-outside-toplevel
+        from registrar.apps.core.signals import (
+            handle_organization_group_pre_save,
+            handle_program_group_pre_save,
+            handle_user_post_save
+        )       # pylint: disable=import-outside-toplevel
 
         post_save.connect(
             handle_user_post_save,
             sender=User,
             dispatch_uid=self.USER_POST_SAVE_DISPATCH_UID
+        )
+        pre_save.connect(
+            handle_organization_group_pre_save,
+            sender=OrganizationGroup,
+        )
+        pre_save.connect(
+            handle_program_group_pre_save,
+            sender=ProgramOrganizationGroup,
         )
         pre_migrate.connect(self._disconnect_user_post_save_for_migrations)
 

--- a/registrar/apps/core/apps.py
+++ b/registrar/apps/core/apps.py
@@ -22,13 +22,13 @@ class CoreConfig(AppConfig):
         """
         Perform other one-time initialization steps.
         """
-        from django.db.models.signals import pre_migrate, pre_save, post_save     # pylint: disable=import-outside-toplevel
-        from registrar.apps.core.models import OrganizationGroup, ProgramOrganizationGroup, User     # pylint: disable=import-outside-toplevel
+        from django.db.models.signals import pre_migrate, pre_save, post_save
+        from registrar.apps.core.models import OrganizationGroup, ProgramOrganizationGroup, User
         from registrar.apps.core.signals import (
             handle_organization_group_pre_save,
             handle_program_group_pre_save,
             handle_user_post_save
-        )       # pylint: disable=import-outside-toplevel
+        )
 
         post_save.connect(
             handle_user_post_save,
@@ -45,7 +45,6 @@ class CoreConfig(AppConfig):
         )
         pre_migrate.connect(self._disconnect_user_post_save_for_migrations)
 
-    # pylint: disable=import-outside-toplevel
     def _disconnect_user_post_save_for_migrations(self, sender, **kwargs):  # pylint: disable=unused-argument
         """
         Handle pre_migrate signal - disconnect User post_save handler.

--- a/registrar/apps/core/management/commands/test/test_sync_with_discovery.py
+++ b/registrar/apps/core/management/commands/test/test_sync_with_discovery.py
@@ -140,7 +140,7 @@ class TestSyncOrganizationsWithDiscoveryCommand(TestSyncWithDiscoveryCommandBase
         ]
         self.assert_org_nonexistant(self.new_discovery_org_uuid)
 
-        self.assert_organizations(orgs_to_sync, 53)
+        self.assert_organizations(orgs_to_sync, 49)
 
     def test_sync_organization_create_only(self):
         other_new_org_uuid = '99999999-2222-2222-3333-555555555555'
@@ -158,7 +158,7 @@ class TestSyncOrganizationsWithDiscoveryCommand(TestSyncWithDiscoveryCommandBase
         self.assert_org_nonexistant(self.new_discovery_org_uuid)
         self.assert_org_nonexistant(other_new_org_uuid)
 
-        self.assert_organizations(orgs_to_sync, 52)
+        self.assert_organizations(orgs_to_sync, 42)
 
     def test_sync_organization_update_only(self):
         orgs_to_sync = [
@@ -173,7 +173,7 @@ class TestSyncOrganizationsWithDiscoveryCommand(TestSyncWithDiscoveryCommandBase
             self.discovery_org,
             self.discovery_other_org,
         ]
-        self.assert_organizations(orgs_to_sync, 11)
+        self.assert_organizations(orgs_to_sync, 9)
 
 
 @ddt.ddt
@@ -290,7 +290,7 @@ class TestSyncProgramsWithDiscoveryCommand(TestSyncWithDiscoveryCommandBase):
         self.assert_program_nonexistant(self.russian_discovery_program.get('uuid'))
         self.assert_program_nonexistant(self.arabic_discovery_program.get('uuid'))
 
-        self.assert_programs(programs_to_sync, 54)
+        self.assert_programs(programs_to_sync, 42)
 
     def test_sync_programs_with_different_slugs(self):
         updated_discovery_program = self.discovery_program_dict(
@@ -302,7 +302,7 @@ class TestSyncProgramsWithDiscoveryCommand(TestSyncWithDiscoveryCommandBase):
             self.english_discovery_program,
             updated_discovery_program
         ]
-        self.assert_programs(programs_to_sync, 13)
+        self.assert_programs(programs_to_sync, 9)
 
     def test_sync_programs_create_only(self):
         programs_to_sync = [
@@ -313,7 +313,7 @@ class TestSyncProgramsWithDiscoveryCommand(TestSyncWithDiscoveryCommandBase):
         self.assert_program_nonexistant(self.russian_discovery_program.get('uuid'))
         self.assert_program_nonexistant(self.arabic_discovery_program.get('uuid'))
 
-        self.assert_programs(programs_to_sync, 54)
+        self.assert_programs(programs_to_sync, 42)
 
     def test_sync_programs_missing_role(self):
         """ program already exists but no reporting role has been created """
@@ -331,7 +331,7 @@ class TestSyncProgramsWithDiscoveryCommand(TestSyncWithDiscoveryCommandBase):
         programs_to_sync = [
             spanish_discovery_program
         ]
-        self.assert_programs(programs_to_sync, 33)
+        self.assert_programs(programs_to_sync, 25)
 
     def test_sync_programs_update_role(self):
         """ program already exists but the reporting role has a nonstandard name """
@@ -355,14 +355,14 @@ class TestSyncProgramsWithDiscoveryCommand(TestSyncWithDiscoveryCommandBase):
         programs_to_sync = [
             spanish_discovery_program
         ]
-        self.assert_programs(programs_to_sync, 34)
+        self.assert_programs(programs_to_sync, 31)
 
     def test_sync_programs_no_change(self):
         programs_to_sync = [
             self.english_discovery_program,
             self.german_discovery_program,
         ]
-        self.assert_programs(programs_to_sync, 13)
+        self.assert_programs(programs_to_sync, 9)
 
     @ddt.data(
         '44444444-2222-3333-4444-000000000000',
@@ -379,7 +379,7 @@ class TestSyncProgramsWithDiscoveryCommand(TestSyncWithDiscoveryCommandBase):
             no_org_program,
         ]
         self.assert_program_nonexistant(no_org_program.get('uuid'))
-        self.assert_programs(programs_to_sync, 13, [self.english_discovery_program])
+        self.assert_programs(programs_to_sync, 9, [self.english_discovery_program])
         self.assert_program_nonexistant(no_org_program.get('uuid'))
 
     def test_sync_programs_multiple_authoring_orgs(self):
@@ -396,5 +396,5 @@ class TestSyncProgramsWithDiscoveryCommand(TestSyncWithDiscoveryCommandBase):
             self.german_discovery_program,
             self.english_discovery_program,
         ]
-        self.assert_programs(programs_to_sync + [new_program_to_create], 13, programs_to_sync)
+        self.assert_programs(programs_to_sync + [new_program_to_create], 9, programs_to_sync)
         self.assert_program_nonexistant(new_program_uuid_string)

--- a/registrar/apps/core/models.py
+++ b/registrar/apps/core/models.py
@@ -161,15 +161,6 @@ class OrganizationGroup(Group):
         default=perms.OrganizationReadMetadataRole.name,
     )
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        # Save the value of organization in an attribute, so that when
-        # save() is called, we have access to the old value.
-        try:
-            self._initial_organization = self.organization
-        except Organization.DoesNotExist:   # pragma: no cover
-            self._initial_organization = None
-
     @property
     def role_object(self):
         """
@@ -229,13 +220,6 @@ class ProgramOrganizationGroup(Group):
         choices=ROLE_CHOICES,
         default=perms.ProgramReadMetadataRole.name,
     )
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        try:
-            self._initial_program = self.program
-        except Program.DoesNotExist:   # pragma: no cover
-            self._initial_program = None
 
     @property
     def role_object(self):

--- a/registrar/apps/core/models.py
+++ b/registrar/apps/core/models.py
@@ -141,6 +141,10 @@ class OrganizationGroup(Group):
     """
     Group subclass to grant select guardian permissions to a group on an organization level.
 
+    signals:
+        - pre-save: sets the _initial_organization attribute so we can remove permissions on
+            the old organization when this model is saved.
+
     .. no_pii::
     """
     objects = models.Manager()
@@ -203,6 +207,10 @@ class OrganizationGroup(Group):
 class ProgramOrganizationGroup(Group):
     """
     Group subclass to grant select guardian permissions to a group on a program level.
+
+    signals:
+        - pre-save: sets the _initial_program attribute so we can remove permissions on
+            the old program when this model is saved.
 
     .. no_pii::
     """

--- a/registrar/apps/core/models.py
+++ b/registrar/apps/core/models.py
@@ -161,6 +161,11 @@ class OrganizationGroup(Group):
         default=perms.OrganizationReadMetadataRole.name,
     )
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # assigned by pre-save signal
+        self._initial_organization = None
+
     @property
     def role_object(self):
         """
@@ -220,6 +225,11 @@ class ProgramOrganizationGroup(Group):
         choices=ROLE_CHOICES,
         default=perms.ProgramReadMetadataRole.name,
     )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # assigned by pre-save signal
+        self._initial_program = None
 
     @property
     def role_object(self):

--- a/registrar/apps/core/signals.py
+++ b/registrar/apps/core/signals.py
@@ -42,7 +42,7 @@ def handle_organization_group_pre_save(sender, instance, **kwargs):   # pylint: 
         existing_org_group = OrganizationGroup.objects.get(pk=instance.id)
         try:
             instance._initial_organization = existing_org_group.organization
-        except Organization.DoesNotExist:
+        except Organization.DoesNotExist:   # pragma: no cover
             instance._initial_organization = None
     else:
         instance._initial_organization = None
@@ -57,7 +57,7 @@ def handle_program_group_pre_save(sender, instance, **kwargs):   # pylint: disab
         existing_program_group = ProgramOrganizationGroup.objects.get(pk=instance.id)
         try:
             instance._initial_program = existing_program_group.program
-        except Program.DoesNotExist:
+        except Program.DoesNotExist:   # pragma: no cover
             instance._initial_program = None
     else:
         instance._initial_program = None

--- a/registrar/apps/core/signals.py
+++ b/registrar/apps/core/signals.py
@@ -31,6 +31,7 @@ def handle_user_post_save(sender, **kwargs):  # pylint: disable=unused-argument
 
     pending_groups.delete()
 
+
 def handle_organization_group_pre_save(sender, instance, **kwargs):
     """
     Save previous organization value so guardian permissions can be cleaned up on save
@@ -43,6 +44,7 @@ def handle_organization_group_pre_save(sender, instance, **kwargs):
             instance._initial_organization = None
     else:
         instance._initial_organization = None
+
 
 def handle_program_group_pre_save(sender, instance, **kwargs):
     """

--- a/registrar/apps/core/signals.py
+++ b/registrar/apps/core/signals.py
@@ -33,7 +33,7 @@ def handle_user_post_save(sender, **kwargs):  # pylint: disable=unused-argument
     pending_groups.delete()
 
 
-def handle_organization_group_pre_save(sender, instance):   # pylint: disable=unused-argument
+def handle_organization_group_pre_save(sender, instance, **kwargs):   # pylint: disable=unused-argument
     """
     Save previous organization value so guardian permissions can be cleaned up on save
     """
@@ -48,7 +48,7 @@ def handle_organization_group_pre_save(sender, instance):   # pylint: disable=un
         instance._initial_organization = None
 
 
-def handle_program_group_pre_save(sender, instance):   # pylint: disable=unused-argument
+def handle_program_group_pre_save(sender, instance, **kwargs):   # pylint: disable=unused-argument
     """
     Save previous program value so guardian permissions can be cleaned up on save
     """

--- a/registrar/apps/core/signals.py
+++ b/registrar/apps/core/signals.py
@@ -5,6 +5,7 @@ from logging import getLogger
 
 from .models import (
     Organization,
+    Program,
     OrganizationGroup,
     PendingUserGroup,
     ProgramOrganizationGroup,
@@ -32,10 +33,11 @@ def handle_user_post_save(sender, **kwargs):  # pylint: disable=unused-argument
     pending_groups.delete()
 
 
-def handle_organization_group_pre_save(sender, instance, **kwargs):
+def handle_organization_group_pre_save(sender, instance):   # pylint: disable=unused-argument
     """
     Save previous organization value so guardian permissions can be cleaned up on save
     """
+    # pylint: disable=protected-access
     if instance.id:
         existing_org_group = OrganizationGroup.objects.get(pk=instance.id)
         try:
@@ -46,10 +48,11 @@ def handle_organization_group_pre_save(sender, instance, **kwargs):
         instance._initial_organization = None
 
 
-def handle_program_group_pre_save(sender, instance, **kwargs):
+def handle_program_group_pre_save(sender, instance):   # pylint: disable=unused-argument
     """
     Save previous program value so guardian permissions can be cleaned up on save
     """
+    # pylint: disable=protected-access
     if instance.id:
         existing_program_group = ProgramOrganizationGroup.objects.get(pk=instance.id)
         try:

--- a/registrar/apps/core/signals.py
+++ b/registrar/apps/core/signals.py
@@ -3,7 +3,12 @@ Django signal handlers.
 """
 from logging import getLogger
 
-from .models import PendingUserGroup
+from .models import (
+    Organization,
+    OrganizationGroup,
+    PendingUserGroup,
+    ProgramOrganizationGroup,
+)
 
 
 logger = getLogger(__name__)
@@ -25,3 +30,29 @@ def handle_user_post_save(sender, **kwargs):  # pylint: disable=unused-argument
         user_instance.groups.add(pending_group.group)
 
     pending_groups.delete()
+
+def handle_organization_group_pre_save(sender, instance, **kwargs):
+    """
+    Save previous organization value so guardian permissions can be cleaned up on save
+    """
+    if instance.id:
+        existing_org_group = OrganizationGroup.objects.get(pk=instance.id)
+        try:
+            instance._initial_organization = existing_org_group.organization
+        except Organization.DoesNotExist:
+            instance._initial_organization = None
+    else:
+        instance._initial_organization = None
+
+def handle_program_group_pre_save(sender, instance, **kwargs):
+    """
+    Save previous program value so guardian permissions can be cleaned up on save
+    """
+    if instance.id:
+        existing_program_group = ProgramOrganizationGroup.objects.get(pk=instance.id)
+        try:
+            instance._initial_program = existing_program_group.program
+        except Program.DoesNotExist:
+            instance._initial_program = None
+    else:
+        instance._initial_program = None

--- a/registrar/apps/core/signals.py
+++ b/registrar/apps/core/signals.py
@@ -5,9 +5,9 @@ from logging import getLogger
 
 from .models import (
     Organization,
-    Program,
     OrganizationGroup,
     PendingUserGroup,
+    Program,
     ProgramOrganizationGroup,
 )
 

--- a/registrar/apps/core/tests/test_auth_checks.py
+++ b/registrar/apps/core/tests/test_auth_checks.py
@@ -204,7 +204,7 @@ class GetProgramsByAPIPermissionsTests(TestCase):
         for program in self.programs:
             program_type = (
                 'Masters'
-                if program.key.startswith('masters')  # pylint: disable=no-member
+                if program.key.startswith('masters')
                 else 'MicroMasters'
             )
             cache.set(

--- a/registrar/apps/core/tests/test_models.py
+++ b/registrar/apps/core/tests/test_models.py
@@ -108,7 +108,7 @@ class OrganizationGroupTests(TestCase):
         )
         permissions = get_perms(self.user, self.organization)
         self.assertEqual([], permissions)
-        self.user.groups.add(org_group)  # pylint: disable=no-member
+        self.user.groups.add(org_group)
         permissions = get_perms(self.user, self.organization)
         self.assertEqual(len(role.permissions), len(permissions))
         for permission in Organization._meta.permissions:
@@ -122,7 +122,7 @@ class OrganizationGroupTests(TestCase):
             role=perm.OrganizationReadMetadataRole.name,
             organization=self.organization,
         )
-        self.user.groups.add(org_group)  # pylint: disable=no-member
+        self.user.groups.add(org_group)
         permission = perm.OrganizationReadMetadataRole.permissions[0]
         self.assertTrue(self.user.has_perm(permission, self.organization))
         self.assertFalse(self.user.has_perm(permission))
@@ -136,7 +136,7 @@ class OrganizationGroupTests(TestCase):
             role=perm.OrganizationReadMetadataRole.name,
             organization=self.organization,
         )
-        self.user.groups.add(org_group)  # pylint: disable=no-member
+        self.user.groups.add(org_group)
         self.assertTrue(self.user.has_perm(permission, self.organization))
         self.assertFalse(self.user.has_perm(permission, organization2))
 
@@ -151,7 +151,7 @@ class OrganizationGroupTests(TestCase):
             role=perm.OrganizationReadWriteEnrollmentsRole.name,
             organization=org1,
         )
-        self.user.groups.add(org_group)  # pylint: disable=no-member
+        self.user.groups.add(org_group)
         self.assertTrue(self.user.has_perm(metdata_permission, org1))
         self.assertTrue(self.user.has_perm(write_permission, org1))
         self.assertFalse(self.user.has_perm(metdata_permission, org2))
@@ -204,7 +204,7 @@ class ProgramOrganizationGroupTests(TestCase):
         )
         permissions = get_perms(self.user, self.program)
         self.assertEqual([], permissions)
-        self.user.groups.add(program_group)  # pylint: disable=no-member
+        self.user.groups.add(program_group)
         permissions = get_perms(self.user, self.program)
         self.assertEqual(len(role.permissions), len(permissions))
         for permission in Program._meta.permissions:
@@ -219,7 +219,7 @@ class ProgramOrganizationGroupTests(TestCase):
             program=self.program,
             granting_organization=self.program.managing_organization,
         )
-        self.user.groups.add(program_group)  # pylint: disable=no-member
+        self.user.groups.add(program_group)
         permission = perm.ProgramReadMetadataRole.permissions[0]
         self.assertTrue(self.user.has_perm(permission, self.program))
         self.assertFalse(self.user.has_perm(permission))
@@ -234,7 +234,7 @@ class ProgramOrganizationGroupTests(TestCase):
             program=self.program,
             granting_organization=self.program.managing_organization,
         )
-        self.user.groups.add(program_group)  # pylint: disable=no-member
+        self.user.groups.add(program_group)
         self.assertTrue(self.user.has_perm(permission, self.program))
         self.assertFalse(self.user.has_perm(permission, program2))
 
@@ -250,7 +250,7 @@ class ProgramOrganizationGroupTests(TestCase):
             program=program1,
             granting_organization=program1.managing_organization,
         )
-        self.user.groups.add(program_group)  # pylint: disable=no-member
+        self.user.groups.add(program_group)
         self.assertTrue(self.user.has_perm(metdata_permission, program1))
         self.assertTrue(self.user.has_perm(write_permission, program1))
         self.assertFalse(self.user.has_perm(metdata_permission, program2))


### PR DESCRIPTION
@edx/masters-devs-cosmonauts 

This fixes an n+1 query caused by referencing a model attribute (via FK) in the `__init__` method.  What happens is any query on that model (e.g. .all() or .filter()) will produce an extra SQL query for that mode attribute on every object returned by your original query.

I've moved this logic to a presave hook so it's only hit on save and not every time the Python object is created.
