### PR TITLE
Update celery autodiscover mechanism for celery 4.

### DIFF
--- a/registrar/celery.py
+++ b/registrar/celery.py
@@ -3,14 +3,13 @@ Defines the Celery application for the registrar project.
 """
 
 from celery import Celery
-from django.conf import settings
 
 
 app = Celery('registrar')
 
 app.conf.task_protocol = 1
 app.config_from_object('django.conf:settings', namespace="CELERY")
-app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
+app.autodiscover_tasks()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Pulling in INSTALLED_APPS and passing it explicitly was more necessary before Celery 4.  In celery 4 and later,
celery introduces an autodiscovery mechanism for django apps.  Update to the Celery 4 way because the other way
introduces a race condition in Celery 4 that can result in not all tasks getting properly discovered.

See https://github.com/edx/edx-platform/pull/25467 for an example of where this had to be fixed in edx-platform.