### PR TITLE
update openedx.yaml to use current best practices

### DIFF
--- a/openedx.yaml
+++ b/openedx.yaml
@@ -1,7 +1,6 @@
 # This file describes this Open edX repo, as described in OEP-2:
 # http://open-edx-proposals.readthedocs.io/en/latest/oeps/oep-0002.html#specification
 
-nick: regis
 tags:
     - webservice
     - masters


### PR DESCRIPTION
## Description

Remove deprecated fields from openedx.yaml, per the [OEP](https://open-edx-proposals.readthedocs.io/en/latest/oep-0002-bp-repo-metadata.html). The ownership document should the single source of truth for ownership information.
