### PR TITLE
fix: update ubuntu version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial as app
+FROM ubuntu:focal as app
 
 # System requirements.
 RUN apt-get update && apt-get upgrade -qy


### PR DESCRIPTION
## [MST-720](https://openedx.atlassian.net/browse/MST-720)

The docker push step for GHA is broken. Updating the ubuntu version on the dockerfile should fix this issue, as xenial pulls pip at version 8.1.1, but focal uses pip 20.0.2 (as seen here:  https://github.com/edx/course-discovery/runs/2269009288)
