### PR TITLE
Updating python to version 3.8 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,9 @@ RUN apt-get update && apt-get upgrade -qy
 RUN apt-get install -qy \
 	git-core \
 	language-pack-en \
-	python3.5 \
+	python3.8 \
 	python3-pip \
-	python3.5-dev \
+	python3.8-dev \
 	libmysqlclient-dev \
 	libssl-dev
 RUN pip3 install --upgrade pip setuptools


### PR DESCRIPTION
## [MST-720](https://openedx.atlassian.net/browse/MST-720)

The push dockerfile step is now erroring because it can't find the python3.5-dev package. I'm upgrading the python version specific packages to 3.8 (mirroring what is done here: https://github.com/edx/course-discovery/blob/master/Dockerfile). 
