### PR TITLE
build: install pip more straightforwardly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ RUN pip3 install --upgrade pip setuptools
 RUN rm -rf /var/lib/apt/lists/*
 
 # Python is Python3.
-RUN ln -s /usr/bin/pip3 /usr/bin/pip
 RUN ln -s /usr/bin/python3 /usr/bin/python
 
 # Use UTF-8.


### PR DESCRIPTION
The version of python-pip installed in ubuntu changed to provide the pip
executable in version 20.0.2-5ubuntu1.4, so this step is no longer
necessary.

Before:
```
% docker run openedx/registrar:a993c2ff0b2257c8066d5ec9f5a9b4ca8cb79f8f pip --version
pip 21.1.1 from /usr/local/lib/python3.8/dist-packages/pip (python 3.8)
```
After:
```
% docker run 10f6417de989cfea59483ae227c5b1ddf5f740b3c531acce89576758905578d4 pip --version
pip 21.1.2 from /usr/local/lib/python3.8/dist-packages/pip (python 3.8)
```