### PR TITLE
fix:add default transport so celery will run tasks eagerly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get install -qy \
 	libmysqlclient-dev \
 	libssl-dev
 RUN pip3 install --upgrade pip setuptools
+# delete apt package lists because we do not need them inflating our image
 RUN rm -rf /var/lib/apt/lists/*
 
 # Python is Python3.

--- a/registrar/settings/base.py
+++ b/registrar/settings/base.py
@@ -134,7 +134,7 @@ CELERY_TASK_DEFAULT_QUEUE = os.environ.get('CELERY_DEFAULT_QUEUE', 'registrar.de
 # These settings need not be set if CELERY_TASK_ALWAYS_EAGER == True, like in Standalone.
 # Devstack overrides these in its docker-compose.yml.
 # Production environments can override these to be whatever they want.
-CELERY_BROKER_TRANSPORT = os.environ.get("CELERY_BROKER_TRANSPORT", "")
+CELERY_BROKER_TRANSPORT = os.environ.get("CELERY_BROKER_TRANSPORT", "redis")
 CELERY_BROKER_HOSTNAME = os.environ.get("CELERY_BROKER_HOSTNAME", "")
 CELERY_BROKER_VHOST = os.environ.get("CELERY_BROKER_VHOST", "")
 CELERY_BROKER_USER = os.environ.get("CELERY_BROKER_USER", "")


### PR DESCRIPTION
This makes sure we set a default transport, which is helpful when
we're running with CELERY_TASK_ALWAYS_EAGER. That setting enables us
to move forward without using the URL configured for the transport, so
this default doesn't matter when it's set. In other cases, this
will've needed to've been set explicitly before, so changing the
default should be quite benign.

Also I added a comment earlier to a Dockerfile but didn't get it into
somewhere, so tossing that in this PR.