### PR TITLE
feat: add group users to program and group model admin

### DIFF
--- a/registrar/apps/core/admin.py
+++ b/registrar/apps/core/admin.py
@@ -47,8 +47,22 @@ class OrganizationAdmin(GuardedModelAdmin):
     date_hierarchy = 'modified'
 
 
-class OrganizationGroupAdmin(admin.ModelAdmin):
-    list_display = ('name', 'organization', 'role')
+class GroupAdmin(admin.ModelAdmin):
+    """
+    Custom admin class for OrganizationGroupAdmin and ProgramGroupAdmin
+    """
+    def group_users(self, obj):
+        """Return comma separated list of users in group"""
+        return ", ".join([user.username for user in User.objects.filter(groups__name=obj.name)])
+
+
+class OrganizationGroupAdmin(GroupAdmin):
+    """
+    Admin tool for the OrganizationGroup model
+    """
+    list_display = ('name', 'organization', 'role', 'group_users')
+    fields = ('name', 'organization', 'role', 'group_users')
+    readonly_fields = ('group_users',)
     search_fields = ('name', 'organization__key', 'organization__name', 'role')
     ordering = ('name',)
     exclude = ('permissions',)
@@ -69,8 +83,13 @@ class ProgramAdmin(admin.ModelAdmin):
     ordering = ("managing_organization", "key")
 
 
-class ProgramGroupAdmin(admin.ModelAdmin):
-    list_display = ('name', 'program', 'granting_organization', 'role')
+class ProgramGroupAdmin(GroupAdmin):
+    """
+    Admin tool for the ProgramOrganizationGroup model
+    """
+    list_display = ('name', 'program', 'granting_organization', 'role', 'group_users')
+    fields = ('name', 'program', 'granting_organization', 'role', 'group_users')
+    readonly_fields = ('group_users',)
     search_fields = ('name', 'program__key', 'granting_organization__name', 'role')
     ordering = ('name',)
     exclude = ('permissions', )


### PR DESCRIPTION
## [MST-648](https://openedx.atlassian.net/browse/MST-648)

The list of users within a Program or Organization group is now easily visible within django admin.

![Screen Shot 2021-07-16 at 9 14 29 AM](https://user-images.githubusercontent.com/46360176/125953731-7c40fb3d-faa1-4ee5-876a-b1975bd35cd9.png)

![Screen Shot 2021-07-16 at 9 14 36 AM](https://user-images.githubusercontent.com/46360176/125953738-2dd7e22a-a52b-4e61-a3c2-afc5e698ba48.png)

View will automatically resize if there are many or longer usernames:

![Screen Shot 2021-07-16 at 9 36 56 AM](https://user-images.githubusercontent.com/46360176/125956711-14ef3c98-1919-4d70-9816-7b05f726d5b2.png)

![Screen Shot 2021-07-16 at 9 37 12 AM](https://user-images.githubusercontent.com/46360176/125956723-7f3a5a08-6416-4e73-8096-0da3de50b92c.png)
