### PR TITLE
style: fix string formatting due to pylint errors

### DIFF
--- a/registrar/apps/api/segment.py
+++ b/registrar/apps/api/segment.py
@@ -29,7 +29,10 @@ def track(
     if settings.SEGMENT_KEY:
         analytics.track(user_id, event, properties, context, timestamp, anonymous_id, integrations)
     else:
-        logger.debug("{{{}, {}}} not tracked because SEGMENT_KEY not set".format(user_id, event))
+        logger.debug(
+            "{%(user_id)s, %(event)r} not tracked because SEGMENT_KEY not set",
+            {'user_id': user_id, 'event': event}
+        )
 
 
 def get_tracking_properties(user, **kwargs):

--- a/registrar/apps/api/tests/test_segment.py
+++ b/registrar/apps/api/tests/test_segment.py
@@ -22,9 +22,10 @@ class SegmentTrackTests(TestCase):
         )
 
     @mock.patch.object(settings, 'SEGMENT_KEY', new=None)
-    @mock.patch.object(segment.logger, 'debug', autospec=True)
-    def test_track_no_segment_key(self, mock_logger_debug):
-        segment.track(user_id=1, event=self.EVENT_DATA)
-        mock_logger_debug.assert_called_once_with(
+    def test_track_no_segment_key(self):
+        with self.assertLogs(level='DEBUG') as log:
+            segment.track(user_id=1, event=self.EVENT_DATA)
+        self.assertEqual(
+            log.records[0].getMessage(),
             r"{1, {'key': 'value'}} not tracked because SEGMENT_KEY not set"
         )

--- a/registrar/apps/api/v1/mixins.py
+++ b/registrar/apps/api/v1/mixins.py
@@ -156,7 +156,7 @@ class JobInvokerMixin:
         job_id, user_id, and file_format.
         """
         job_id = str(uuid.uuid4())
-        file_path = '{}.{}'.format(job_id, 'json')
+        file_path = f'{job_id}.json'
         upload_filestore.store(file_path, upload_content)
         return self._invoke_job(task_fn, file_path, job_id=job_id, *args, **kwargs)
 

--- a/registrar/apps/api/v1/tests/test_views.py
+++ b/registrar/apps/api/v1/tests/test_views.py
@@ -2473,10 +2473,7 @@ class EnrollmentUploadMixin:
         self.assertEqual(job_response.data['state'], 'Succeeded')
 
         filestore = get_enrollment_uploads_filestore()
-        retrieved = filestore.retrieve('/{}/{}.json'.format(
-            'uploads',
-            upload_response.data['job_id'],
-        ))
+        retrieved = filestore.retrieve(f'/uploads/{upload_response.data["job_id"]}.json')
         self.assertEqual(json.loads(retrieved), enrollments)
 
     def test_enrollment_upload_conflict(self):
@@ -2612,10 +2609,7 @@ class CourseEnrollmentUploadTest(EnrollmentUploadMixin, S3MockMixin, RegistrarAP
         self.assertEqual(job_response.data['state'], 'Succeeded')
 
         filestore = get_enrollment_uploads_filestore()
-        retrieved = filestore.retrieve('/{}/{}.json'.format(
-            'uploads',
-            upload_response.data['job_id'],
-        ))
+        retrieved = filestore.retrieve(f'/uploads/{upload_response.data["job_id"]}.json')
         self.assertEqual(json.loads(retrieved), enrollments)
 
     @mock.patch.object(CourseRunEnrollmentUploadView, 'task_fn', _succeeding_job)
@@ -2643,10 +2637,7 @@ class CourseEnrollmentUploadTest(EnrollmentUploadMixin, S3MockMixin, RegistrarAP
         self.assertEqual(job_response.data['state'], 'Succeeded')
 
         filestore = get_enrollment_uploads_filestore()
-        retrieved = filestore.retrieve('/{}/{}.json'.format(
-            'uploads',
-            upload_response.data['job_id'],
-        ))
+        retrieved = filestore.retrieve(f'/uploads/{upload_response.data["job_id"]}.json')
         self.assertEqual(json.loads(retrieved), expected_enrollments)
 
     @mock.patch.object(CourseRunEnrollmentUploadView, 'task_fn', _succeeding_job)
@@ -2672,10 +2663,7 @@ class CourseEnrollmentUploadTest(EnrollmentUploadMixin, S3MockMixin, RegistrarAP
         self.assertEqual(job_response.data['state'], 'Succeeded')
 
         filestore = get_enrollment_uploads_filestore()
-        retrieved = filestore.retrieve('/{}/{}.json'.format(
-            'uploads',
-            upload_response.data['job_id'],
-        ))
+        retrieved = filestore.retrieve(f'/uploads/{upload_response.data["job_id"]}.json')
         self.assertEqual(json.loads(retrieved), enrollments)
 
 
@@ -3045,7 +3033,7 @@ class ReportsListViewTest(S3MockMixin, RegistrarAPITestCase, AuthRequestMixin):
         filestore = get_program_reports_filestore()
         for file in files:
             filestore.store(
-                '{}/{}'.format(file_prefix, file['name']),
+                f'{file_prefix}/{file["name"]}',
                 'data'
             )
 
@@ -3053,7 +3041,7 @@ class ReportsListViewTest(S3MockMixin, RegistrarAPITestCase, AuthRequestMixin):
             {
                 'name': file['name'],
                 'created_date': file['created_date'],
-                'download_url': filestore.get_url('{}/{}'.format(file_prefix, file['name'])),
+                'download_url': filestore.get_url(f'{file_prefix}/{file["name"]}'),
             } for file in files
         ]
         response = self.get(self.path, self.hum_admin)
@@ -3083,7 +3071,7 @@ class ReportsListViewTest(S3MockMixin, RegistrarAPITestCase, AuthRequestMixin):
         filestore = get_program_reports_filestore()
         for file in files:
             filestore.store(
-                '{}/{}'.format(file_prefix, file['name']),
+                f'{file_prefix}/{file["name"]}',
                 'data',
             )
 
@@ -3091,12 +3079,12 @@ class ReportsListViewTest(S3MockMixin, RegistrarAPITestCase, AuthRequestMixin):
             {
                 'name': 'aggregate_report__2019-12-18',
                 'created_date': '2019-12-18',
-                'download_url': filestore.get_url('{}/{}'.format(file_prefix, 'aggregate_report__2019-12-18')),
+                'download_url': filestore.get_url(f'{file_prefix}/aggregate_report__2019-12-18'),
             },
             {
                 'name': 'individual_report__2019-12-18',
                 'created_date': '2019-12-18',
-                'download_url': filestore.get_url('{}/{}'.format(file_prefix, 'individual_report__2019-12-18')),
+                'download_url': filestore.get_url(f'{file_prefix}/individual_report__2019-12-18'),
             },
         ]
 
@@ -3135,11 +3123,7 @@ class ReportsListViewTest(S3MockMixin, RegistrarAPITestCase, AuthRequestMixin):
             {
                 'name': 'individual_report__2019-12-18',
                 'created_date': '2019-12-18',
-                'download_url': filestore.get_url(
-                    '{file_prefix}/individual_report__2019-12-18'.format(
-                        file_prefix=file_prefix
-                    ),
-                ),
+                'download_url': filestore.get_url(f'{file_prefix}/individual_report__2019-12-18'),
             }
         ]
         response = self.get(self.path, self.hum_admin)

--- a/registrar/apps/api/v1/views.py
+++ b/registrar/apps/api/v1/views.py
@@ -982,7 +982,7 @@ class ReportsListView(ProgramSpecificViewMixin, APIView):
         # wait to generate the download url until after we've done any filtering
         # to avoid generating unnecessary urls
         for report in reports_metadata:
-            report['download_url'] = filestore.get_url('{}/{}'.format(file_prefix, report['name']))
+            report['download_url'] = filestore.get_url(f'{file_prefix}/{report["name"]}')
 
         serializer = ProgramReportMetadataSerializer(reports_metadata, many=True)
         return Response(serializer.data)

--- a/registrar/apps/core/api_client.py
+++ b/registrar/apps/core/api_client.py
@@ -57,7 +57,7 @@ class DiscoveryServiceClient:
             settings.DISCOVERY_BASE_URL,
             DISCOVERY_API_TPL.format('programs', '')
         )
-        url += '?types={}&status=active'.format(','.join(types))
+        url += f'?types={",".join(types)}&status=active'
         try:
             return get_all_paginated_results(url)
         except HTTPError:

--- a/registrar/apps/core/constants.py
+++ b/registrar/apps/core/constants.py
@@ -13,10 +13,7 @@ INTERNAL_COURSE_KEY_PATTERN = r'([^/+]+(/|\+)[^/+]+(/|\+)[^/?]+)'
 
 EXTERNAL_COURSE_KEY_PATTERN = r'([A-Za-z0-9-_:]+)'
 
-COURSE_ID_PATTERN = r'(?P<course_id>({}|{}))'.format(
-    INTERNAL_COURSE_KEY_PATTERN,
-    EXTERNAL_COURSE_KEY_PATTERN
-)
+COURSE_ID_PATTERN = rf'(?P<course_id>({INTERNAL_COURSE_KEY_PATTERN}|{EXTERNAL_COURSE_KEY_PATTERN}))'
 
 # Captures strings composed of alphanumeric characters, dashes, and underscores.
 PROGRAM_KEY_PATTERN = r'(?P<program_key>[A-Za-z0-9-_]+)'

--- a/registrar/apps/core/csv_utils.py
+++ b/registrar/apps/core/csv_utils.py
@@ -84,15 +84,13 @@ def load_records_from_csv(csv_string, field_names, optional_fields=frozenset()):
 
     if missing_fields:
         raise ValidationError(
-            "CSV is missing headers [{}]".format(", ".join(missing_fields))
+            f"CSV is missing headers [{', '.join(missing_fields)}]"
         )
     records = []
     for n, row in enumerate(reader, 1):
         if None in row or not all(row[field] for field in required_fields):
             raise ValidationError(
-                "CSV is missing data at row #{}. Required fields are [{}].".format(
-                    n, ", ".join(field_names)
-                )
+                f"CSV is missing data at row #{n}. Required fields are [{', '.join(field_names)}]."
             )
         stripped_row = {
             field: val.strip()

--- a/registrar/apps/core/filestore.py
+++ b/registrar/apps/core/filestore.py
@@ -58,9 +58,8 @@ class FilestoreBase:
                 return content if isinstance(content, str) else content.decode('utf-8')
         except OSError as e:
             logger.exception(
-                "Could not read file stored at path {!r} in bucket {!r}: {}".format(
-                    full_path, self.bucket, e
-                )
+                "Could not read file stored at path %(path)r in bucket %(bucket)r: %(e)s",
+                {'path': full_path, 'bucket': self.bucket, 'e': e}
             )
             return None
 
@@ -133,9 +132,8 @@ class FilestoreBase:
             return operation(full_path)
         except ClientError:
             logger.error(
-                "Error while {} {!r} in bucket {!r}.".format(
-                    operation_description, full_path, self.bucket
-                )
+                "Error while %(description)s %(path)r in bucket %(bucket)r.",
+                {'description': operation_description, 'path': full_path, 'bucket': self.bucket}
             )
             raise
 

--- a/registrar/apps/core/management/commands/create_organization.py
+++ b/registrar/apps/core/management/commands/create_organization.py
@@ -63,7 +63,7 @@ class Command(BaseCommand):
             )
         except Exception as e:
             raise CommandError(f'Unable to create Organization. cause: {e}') from e
-        logger.info('Created Organization {}'.format(org.key))
+        logger.info('Created Organization %(org_key)s', {'org_key': org.key})
         return org
 
     def create_org_group(self, org, group_role, group_name):  # pylint: disable=missing-function-docstring
@@ -77,4 +77,6 @@ class Command(BaseCommand):
             )
         except Exception as e:
             raise CommandError(f'Unable to create OrganizationGroup {group_name}. cause: {e}') from e
-        logger.info('Created OrganizationGroup {} with role {}'.format(group_name, group_role))
+        logger.info(
+            'Created OrganizationGroup %(name)s with role %(role)s', {'name': group_name, 'role': group_role}
+        )

--- a/registrar/apps/core/management/commands/create_user.py
+++ b/registrar/apps/core/management/commands/create_user.py
@@ -46,7 +46,7 @@ class Command(BaseCommand):
             raise CommandError(f'Unable to create User {username}. Cause: {ex}') from ex
         if not created:
             raise CommandError(f'User {user} already exists')
-        logger.info("Created user: {}".format(user))
+        logger.info("Created user: %(user)r", {'user': user})
         return user
 
     def get_groups(self, group_names):  # pylint: disable=missing-function-docstring
@@ -69,4 +69,4 @@ class Command(BaseCommand):
             user.groups.add(*groups)
         except Exception as ex:  # pragma: no cover
             raise CommandError(f'Unable to add user to groups. Cause: {ex}') from ex
-        logger.info('Added user {} to groups {}'.format(user, groups))
+        logger.info('Added user %(user)r to groups %(groups)r', {'user': user, 'groups': groups})

--- a/registrar/apps/core/management/commands/manage_programs.py
+++ b/registrar/apps/core/management/commands/manage_programs.py
@@ -43,8 +43,10 @@ class Command(BaseCommand):
             elif len(split_args) == 2:
                 result.append((split_args[0], split_args[1]))
             else:
-                message = ('incorrectly formatted argument {}, '
-                           'must be in form <program uuid>:<program key> or <program_uuid>').format(uuidkey)
+                message = (
+                    f'incorrectly formatted argument {uuidkey}, '
+                    'must be in form <program uuid>:<program key> or <program_uuid>'
+                )
                 raise CommandError(message)
         return result
 
@@ -58,10 +60,8 @@ class Command(BaseCommand):
             if 'key' in authoring_org:
                 org_keys.append(authoring_org['key'])
         if not org_keys:
-            raise CommandError('No authoring org keys found for program {}'.format(
-                program_details.get('uuid'))
-            )
-        logger.info('Authoring Organizations are {}'.format(org_keys))
+            raise CommandError(f'No authoring org keys found for program {program_details.get("uuid")}')
+        logger.info('Authoring Organizations are %(org_keys)r', {'org_keys': org_keys})
         return org_keys
 
     def get_org(self, org_keys):
@@ -72,10 +72,10 @@ class Command(BaseCommand):
         for org_key in org_keys:
             try:
                 org = Organization.objects.get(key=org_key)
-                logger.info('Using {} as program organization'.format(org))
+                logger.info('Using %(org)r as program organization', {'org': org})
                 return org
             except Organization.DoesNotExist:
-                logger.info('Org {} not found in registrar'.format(org_key))
+                logger.info('Org %(org_key)s not found in registrar', {'org_key': org_key})
         raise CommandError(f'None of the authoring organizations {org_keys} were found in Registrar')
 
     # pylint: disable=missing-function-docstring
@@ -91,4 +91,7 @@ class Command(BaseCommand):
             program.key = program_key
             program.save()
         verb = 'Created' if created else 'Modified existing'
-        logger.info('{} program (key={} uuid={} managing_org={})'.format(verb, program_key, program_uuid, org.key))
+        logger.info(
+            '%(verb)s program (key=%(program_key)s uuid=%(uuid)s managing_org=%(org_key)s)',
+            {'verb': verb, 'program_key': program_key, 'uuid': program_uuid, 'org_key': org.key}
+        )

--- a/registrar/apps/core/management/commands/sync_with_discovery.py
+++ b/registrar/apps/core/management/commands/sync_with_discovery.py
@@ -198,10 +198,7 @@ class Command(BaseCommand):
             read_reports_groups[(group.granting_organization.key, group.program.key)] = group
 
         for program in Program.objects.select_related('managing_organization'):
-            name = '{}_{}_ReadProgramReports'.format(
-                program.managing_organization.key,
-                program.key,
-            )
+            name = f'{program.managing_organization.key}_{program.key}_ReadProgramReports'
 
             created, updated = (False, False)
             program_org_group = read_reports_groups.get((program.managing_organization.key, program.key))

--- a/registrar/apps/core/management/commands/test/test_sync_with_discovery.py
+++ b/registrar/apps/core/management/commands/test/test_sync_with_discovery.py
@@ -130,7 +130,7 @@ class TestSyncOrganizationsWithDiscoveryCommand(TestSyncWithDiscoveryCommandBase
                 role=OrganizationReadReportRole.name
             )
             self.assertTrue(existing_org_report_group)
-            expected_org_group_name = '{}_ReadOrganizationReports'.format(org['key'])
+            expected_org_group_name = f'{org["key"]}_ReadOrganizationReports'
             self.assertEqual(existing_org_report_group.name, expected_org_group_name)
 
     def test_sync_organization_create_and_update(self):
@@ -210,19 +210,13 @@ class TestSyncProgramsWithDiscoveryCommand(TestSyncWithDiscoveryCommandBase):
             managing_organization=cls.other_org
         )
         cls.english_program_read_report_group = ProgramOrganizationGroupFactory(
-            name='{}_{}_ReadProgramReports'.format(
-                cls.org.key,
-                cls.english_program.key,
-            ),
+            name=f'{cls.org.key}_{cls.english_program.key}_ReadProgramReports',
             program=cls.english_program,
             granting_organization=cls.org,
             role=ProgramReadReportRole.name,
         )
         cls.german_program_read_report_group = ProgramOrganizationGroupFactory(
-            name='{}_{}_ReadProgramReports'.format(
-                cls.other_org.key,
-                cls.german_program.key,
-            ),
+            name=f'{cls.other_org.key}_{cls.german_program.key}_ReadProgramReports',
             program=cls.german_program,
             granting_organization=cls.other_org,
             role=ProgramReadReportRole.name,

--- a/registrar/apps/core/models.py
+++ b/registrar/apps/core/models.py
@@ -88,8 +88,9 @@ class Organization(TimeStampedModel):
         """
         Developer-friendly string representation of this Organization.
         """
-        return "<{}: key={} discovery_uuid={} name={!r}>".format(
-            type(self).__name__, self.key, self.discovery_uuid, self.name
+        return (
+            f"<{type(self).__name__}: key={self.key} "
+            f"discovery_uuid={self.discovery_uuid} name={repr(self.name)}>"
         )
 
 
@@ -121,8 +122,9 @@ class Program(TimeStampedModel):
         """
         Developer-friendly string representation of this Program.
         """
-        return "<{}: key={} discovery_uuid={} managing_organization={}>".format(
-            type(self).__name__, self.key, self.discovery_uuid, self.managing_organization.key
+        return (
+            f"<{type(self).__name__}: key={self.key} discovery_uuid={self.discovery_uuid} "
+            f"managing_organization={self.managing_organization.key}>"
         )
 
     @cached_property
@@ -198,8 +200,9 @@ class OrganizationGroup(Group):
         """
         Developer-friendly representation of this OrganizationGroup.
         """
-        return '<{}: name={!r} organization={} role={}>'.format(
-            type(self).__name__, self.name, self.organization.key, self.role
+        return (
+            f'<{type(self).__name__}: name={repr(self.name)} '
+            f'organization={self.organization.key} role={self.role}>'
         )
 
 
@@ -267,13 +270,8 @@ class ProgramOrganizationGroup(Group):
         Developer-friendly representation of this ProgramOrganizationGroup.
         """
         return (
-            "<{}: name={!r} program={} granting_organization={} role={}>".format(
-                type(self).__name__,
-                self.name,
-                self.program.key,
-                self.granting_organization.key,
-                self.role,
-            )
+            f"<{type(self).__name__}: name={repr(self.name)} program={self.program.key} "
+            f"granting_organization={self.granting_organization.key} role={self.role}>"
         )
 
 
@@ -297,9 +295,7 @@ class PendingUserGroup(TimeStampedModel):
         """
         Return human-readable string representation of this PendingUserGroup.
         """
-        return "<{}: user_email={!r} group={!r}>".format(
-            type(self).__name__, self.user_email, self.group
-        )
+        return f"<{type(self).__name__}: user_email={repr(self.user_email)} group={repr(self.group)}>"
 
     def __str__(self):
         """

--- a/registrar/apps/core/signals.py
+++ b/registrar/apps/core/signals.py
@@ -24,9 +24,8 @@ def handle_user_post_save(sender, **kwargs):  # pylint: disable=unused-argument
     pending_groups = PendingUserGroup.objects.filter(user_email=user_instance.email)
     for pending_group in pending_groups:
         logger.info(
-            'add user {} to group {}'.format(
-                user_instance.email, pending_group.group
-            )
+            'add user %(email)s to group %(group)s',
+            {'email': user_instance.email, 'group': pending_group.group}
         )
         user_instance.groups.add(pending_group.group)
 

--- a/registrar/apps/core/tasks.py
+++ b/registrar/apps/core/tasks.py
@@ -20,7 +20,7 @@ def debug_task(self, *args, **kwargs):
     A task for debugging.  Will dump the context of the task request
     to the log as a DEBUG message.
     """
-    log.debug('Request: {0!r}'.format(self.request))
+    log.debug('Request: %(request)r', {'request': self.request})
 
 
 # pylint: disable=unused-argument

--- a/registrar/apps/core/tests/factories.py
+++ b/registrar/apps/core/tests/factories.py
@@ -34,7 +34,7 @@ class GroupFactory(factory.django.DjangoModelFactory):
         model = Group
         django_get_or_create = ('name',)
 
-    name = factory.Sequence('group{}'.format)
+    name = factory.Sequence(lambda n: f'group{n}')
 
     @factory.post_generation
     def permissions(self, create, extracted, **kwargs):  # pylint: disable=unused-argument
@@ -49,7 +49,7 @@ class UserFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = User
 
-    username = factory.Sequence(lambda n: 'user_%d' % n)
+    username = factory.Sequence(lambda n: f'user_{n}')
     password = factory.PostGenerationMethodCall('set_password', USER_PASSWORD)
     is_active = True
     is_superuser = False

--- a/registrar/apps/core/tests/test_api_client.py
+++ b/registrar/apps/core/tests/test_api_client.py
@@ -88,7 +88,7 @@ class DiscoveryServiceClientTestCase(TestCase):
             settings.DISCOVERY_BASE_URL,
             DISCOVERY_API_TPL.format('programs', '')
         )
-        discovery_url += '?types={}&status=active'.format(','.join(self.program_types))
+        discovery_url += f'?types={",".join(self.program_types)}&status=active'
         responses.add(
             responses.GET,
             discovery_url,

--- a/registrar/apps/core/tests/test_tasks.py
+++ b/registrar/apps/core/tests/test_tasks.py
@@ -1,8 +1,6 @@
 """
 Tests for common tasks
 """
-from unittest import mock
-
 from django.test import TestCase
 from user_tasks.models import UserTaskArtifact, UserTaskStatus
 
@@ -13,15 +11,14 @@ from .factories import UserFactory
 class DebugTaskTests(TestCase):
     """ Tests for validating that tasks are working properly. """
 
-    @mock.patch.object(tasks, 'log', autospec=True)
-    def test_debug_task_happy_path(self, mock_logger):
-        task = tasks.debug_task.apply_async([1, 2], kwargs={'foo': 'bar'})
-        task.wait()
+    def test_debug_task_happy_path(self):
+        with self.assertLogs(level='DEBUG') as log:
+            task = tasks.debug_task.apply_async([1, 2], kwargs={'foo': 'bar'})
+            task.wait()
 
-        self.assertEqual(mock_logger.debug.call_count, 1)
-        debug_call_argument = mock_logger.debug.call_args_list[0][0][0]
-        self.assertIn("'args': [1, 2]", debug_call_argument)
-        self.assertIn("'kwargs': {'foo': 'bar'}", debug_call_argument)
+        log_message = log.records[0].getMessage()
+        self.assertIn("'args': [1, 2]", log_message)
+        self.assertIn("'kwargs': {'foo': 'bar'}", log_message)
 
     def test_debug_user_task_happy_path(self):
         TEST_TEXT = "lorem ipsum"

--- a/registrar/apps/enrollments/lms_interop.py
+++ b/registrar/apps/enrollments/lms_interop.py
@@ -196,9 +196,8 @@ def _write_enrollments(method, url, enrollments, client=None):
             if isinstance(response_data, dict):
                 results.update(response_data)
         logger.info(
-            "LMS responded to {} {} with status {} and body {}".format(
-                method, url, response.status_code, response.text
-            )
+            "LMS responded to %(method)s %(url)s with status %(status_code)s and body %(text)s",
+            {'method': method, 'url': url, 'status_code': response.status_code, 'text': response.text}
         )
     return good, bad, results
 

--- a/registrar/apps/enrollments/tasks.py
+++ b/registrar/apps/enrollments/tasks.py
@@ -66,9 +66,7 @@ def list_program_enrollments(self, job_id, user_id, file_format, program_key, in
     except HTTPError as err:
         post_job_failure(
             job_id,
-            "HTTP error {} when getting enrollments at {}".format(
-                err.response.status_code, err.request.url
-            ),
+            f"HTTP error {err.response.status_code} when getting enrollments at {err.request.url}"
         )
         return
     except ValidationError as err:
@@ -115,9 +113,7 @@ def list_course_run_enrollments(
     except HTTPError as err:
         post_job_failure(
             job_id,
-            "HTTP error {} when getting enrollments at {}".format(
-                err.response.status_code, err.request.url
-            ),
+            f"HTTP error {err.response.status_code} when getting enrollments at {err.request.url}"
         )
         return
     except ValidationError as err:
@@ -158,9 +154,7 @@ def list_all_course_run_enrollments(self, job_id, user_id, file_format, program_
         except HTTPError as err:
             post_job_failure(
                 job_id,
-                "HTTP error {} when getting enrollments at {}".format(
-                    err.response.status_code, err.request.url
-                ),
+                f"HTTP error {err.response.status_code} when getting enrollments at {err.request.url}"
             )
             return
         except ValidationError as err:
@@ -334,9 +328,7 @@ def _load_enrollment_requests(job_id, program_key, json_filepath):
     if not json_text:
         post_job_failure(
             job_id,
-            "Enrollment file for program_key={} not found at {}".format(
-                program_key, json_filepath
-            )
+            f"Enrollment file for program_key={program_key} not found at {json_filepath}"
         )
         return None
     try:
@@ -344,8 +336,6 @@ def _load_enrollment_requests(job_id, program_key, json_filepath):
     except json.decoder.JSONDecodeError:
         post_job_failure(
             job_id,
-            "Enrollment file for program_key={} at {} is not valid JSON".format(
-                program_key, json_filepath
-            )
+            f"Enrollment file for program_key={program_key} at {json_filepath} is not valid JSON"
         )
         return None

--- a/registrar/apps/enrollments/tests/test_lms_interop.py
+++ b/registrar/apps/enrollments/tests/test_lms_interop.py
@@ -28,9 +28,6 @@ from ..lms_interop import (
     LMS_PROGRAM_ENROLLMENTS_API_TPL,
     get_course_run_enrollments,
     get_program_enrollments,
-)
-from ..lms_interop import logger as data_logger
-from ..lms_interop import (
     write_course_run_enrollments,
     write_program_enrollments,
 )
@@ -313,28 +310,28 @@ class WriteEnrollmentsTestMixin:
 
     @mock_oauth_login
     @responses.activate
-    @mock.patch.object(data_logger, 'info', autospec=True)
-    def test_backend_errors(self, mock_data_logger):
-        self._add_echo_callback(200)
-        self._add_echo_callback(422)
-        string_422 = "this a string error from lms"
-        dict_400 = {
-            "developer_message": "this is a dict error from lms"
-        }
-        responses.add(responses.POST, self.url, status=422, body=string_422)
-        responses.add(responses.POST, self.url, status=400, json=dict_400)
-        with mock.patch(self.max_write_const, new=2):
-            good, bad, output = self.write_enrollments(self.enrollments)
+    def test_backend_errors(self):
+        with self.assertLogs(level='INFO') as log:
+            self._add_echo_callback(200)
+            self._add_echo_callback(422)
+            string_422 = "this a string error from lms"
+            dict_400 = {
+                "developer_message": "this is a dict error from lms"
+            }
+            responses.add(responses.POST, self.url, status=422, body=string_422)
+            responses.add(responses.POST, self.url, status=400, json=dict_400)
+            with mock.patch(self.max_write_const, new=2):
+                good, bad, output = self.write_enrollments(self.enrollments)
 
-        self.assertDictEqual(output, self.expected_err_output)
-        self.assertEqual(good, True)
-        self.assertEqual(bad, True)
+            self.assertDictEqual(output, self.expected_err_output)
+            self.assertEqual(good, True)
+            self.assertEqual(bad, True)
 
-        for i, status in enumerate([200, 422, 422, 400]):
-            log_str = mock_data_logger.call_args_list[i].args[0]
-            self.assertIn('POST', log_str)
-            self.assertIn(self.url, log_str)
-            self.assertIn(str(status), log_str)
+            for i, status in enumerate([200, 422, 422, 400]):
+                log_str = log.records[i].getMessage()
+                self.assertIn('POST', log_str)
+                self.assertIn(self.url, log_str)
+                self.assertIn(str(status), log_str)
 
     def write_enrollments(self, enrollments):
         """ Overridden in child classes """

--- a/registrar/apps/enrollments/tests/test_tasks.py
+++ b/registrar/apps/enrollments/tests/test_tasks.py
@@ -239,18 +239,14 @@ class WriteEnrollmentTaskTestMixin(BaseTaskTestMixin, S3MockEnvVarsMixin):
     def test_no_such_file(self):
         self.spawn_task().wait()
         self.assert_failed(
-            "Enrollment file for program_key={} not found at {}".format(
-                self.program.key, self.json_filepath
-            )
+            f"Enrollment file for program_key={self.program.key} not found at {self.json_filepath}"
         )
 
     def test_file_not_json(self):
         uploads_filestore.store(self.json_filepath, "this is not valid json")
         self.spawn_task().wait()
         self.assert_failed(
-            "Enrollment file for program_key={} at {} is not valid JSON".format(
-                self.program.key, self.json_filepath
-            )
+            f"Enrollment file for program_key={self.program.key} at {self.json_filepath} is not valid JSON"
         )
 
 

--- a/registrar/apps/grades/tasks.py
+++ b/registrar/apps/grades/tasks.py
@@ -32,9 +32,7 @@ def get_course_run_grades(self, job_id, user_id, file_format, program_key, inter
     except HTTPError as err:
         post_job_failure(
             job_id,
-            "HTTP error {} when getting grades at {}".format(
-                err.response.status_code, err.request.url
-            ),
+            f"HTTP error {err.response.status_code} when getting grades at {err.request.url}"
         )
         return
     except ValidationError as err:

--- a/registrar/apps/grades/tests/test_tasks.py
+++ b/registrar/apps/grades/tests/test_tasks.py
@@ -64,9 +64,7 @@ class GetCourseRunGradesTest(BaseTaskTestMixin, TestCase):
             )
             mock_load_data.side_effect = error
             self.spawn_task().wait()
-        expected_msg = "HTTP error {} when getting grades at registrar.edx.org".format(
-            status_code,
-        )
+        expected_msg = f"HTTP error {status_code} when getting grades at registrar.edx.org"
         self.assert_failed(expected_msg)
 
     def test_invalid_data(self):

--- a/requirements/devstack.txt
+++ b/requirements/devstack.txt
@@ -18,7 +18,7 @@ asgiref==3.4.1
     # via
     #   -r requirements/local.txt
     #   django
-astroid==2.7.3
+astroid==2.8.2
     # via
     #   -r requirements/local.txt
     #   pylint
@@ -399,7 +399,7 @@ pbr==5.6.0
     # via
     #   -r requirements/local.txt
     #   stevedore
-platformdirs==2.3.0
+platformdirs==2.4.0
     # via
     #   -r requirements/local.txt
     #   pylint
@@ -427,7 +427,7 @@ pyasn1==0.4.8
     #   -r requirements/local.txt
     #   python-jose
     #   rsa
-pycodestyle==2.7.0
+pycodestyle==2.8.0
     # via -r requirements/local.txt
 pycparser==2.20
     # via
@@ -453,7 +453,7 @@ pyjwt[crypto]==2.1.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.10.2
+pylint==2.11.1
     # via
     #   -r requirements/local.txt
     #   edx-lint
@@ -707,7 +707,9 @@ transifex-client==0.14.3
 typing-extensions==3.10.0.2
     # via
     #   -r requirements/local.txt
+    #   astroid
     #   gitpython
+    #   pylint
 uritemplate==3.0.1
     # via
     #   -r requirements/local.txt

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -18,7 +18,7 @@ asgiref==3.4.1
     # via
     #   -r requirements/test.txt
     #   django
-astroid==2.7.3
+astroid==2.8.2
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -395,7 +395,7 @@ pbr==5.6.0
     # via
     #   -r requirements/test.txt
     #   stevedore
-platformdirs==2.3.0
+platformdirs==2.4.0
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -421,7 +421,7 @@ pyasn1==0.4.8
     #   -r requirements/test.txt
     #   python-jose
     #   rsa
-pycodestyle==2.7.0
+pycodestyle==2.8.0
     # via -r requirements/test.txt
 pycparser==2.20
     # via
@@ -447,7 +447,7 @@ pyjwt[crypto]==2.1.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.10.2
+pylint==2.11.1
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -693,7 +693,11 @@ tox==3.24.3
 transifex-client==0.14.3
     # via -r requirements/local.in
 typing-extensions==3.10.0.2
-    # via gitpython
+    # via
+    #   -r requirements/test.txt
+    #   astroid
+    #   gitpython
+    #   pylint
 uritemplate==3.0.1
     # via
     #   -r requirements/test.txt

--- a/requirements/monitoring/requirements.txt
+++ b/requirements/monitoring/requirements.txt
@@ -29,7 +29,7 @@ asgiref==3.4.1
     #   -r requirements/monitoring/../production.txt
     #   -r requirements/monitoring/../test.txt
     #   django
-astroid==2.7.3
+astroid==2.8.2
     # via
     #   -r requirements/monitoring/../devstack.txt
     #   -r requirements/monitoring/../local.txt
@@ -646,7 +646,7 @@ pbr==5.6.0
     #   -r requirements/monitoring/../production.txt
     #   -r requirements/monitoring/../test.txt
     #   stevedore
-platformdirs==2.3.0
+platformdirs==2.4.0
     # via
     #   -r requirements/monitoring/../devstack.txt
     #   -r requirements/monitoring/../local.txt
@@ -686,7 +686,7 @@ pyasn1==0.4.8
     #   -r requirements/monitoring/../test.txt
     #   python-jose
     #   rsa
-pycodestyle==2.7.0
+pycodestyle==2.8.0
     # via
     #   -r requirements/monitoring/../devstack.txt
     #   -r requirements/monitoring/../local.txt
@@ -728,7 +728,7 @@ pyjwt[crypto]==2.1.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.10.2
+pylint==2.11.1
     # via
     #   -r requirements/monitoring/../devstack.txt
     #   -r requirements/monitoring/../local.txt
@@ -1093,7 +1093,10 @@ typing-extensions==3.10.0.2
     # via
     #   -r requirements/monitoring/../devstack.txt
     #   -r requirements/monitoring/../local.txt
+    #   -r requirements/monitoring/../test.txt
+    #   astroid
     #   gitpython
+    #   pylint
 uritemplate==3.0.1
     # via
     #   -r requirements/monitoring/../devstack.txt

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,7 +8,7 @@ click==8.0.1
     # via pip-tools
 pep517==0.11.0
     # via pip-tools
-pip-tools==6.2.0
+pip-tools==6.4.0
     # via -r requirements/pip-tools.in
 tomli==1.2.1
     # via pep517

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -14,7 +14,7 @@ asgiref==3.4.1
     # via
     #   -r requirements/base.txt
     #   django
-astroid==2.7.3
+astroid==2.8.2
     # via
     #   pylint
     #   pylint-celery
@@ -308,7 +308,7 @@ pbr==5.6.0
     # via
     #   -r requirements/base.txt
     #   stevedore
-platformdirs==2.3.0
+platformdirs==2.4.0
     # via
     #   pylint
     #   virtualenv
@@ -328,7 +328,7 @@ pyasn1==0.4.8
     # via
     #   python-jose
     #   rsa
-pycodestyle==2.7.0
+pycodestyle==2.8.0
     # via -r requirements/test.in
 pycparser==2.20
     # via
@@ -350,7 +350,7 @@ pyjwt[crypto]==2.1.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.10.2
+pylint==2.11.1
     # via
     #   edx-lint
     #   pylint-celery
@@ -517,6 +517,10 @@ toml==0.10.2
     #   tox
 tox==3.24.3
     # via -r requirements/test.in
+typing-extensions==3.10.0.2
+    # via
+    #   astroid
+    #   pylint
 uritemplate==3.0.1
     # via
     #   -r requirements/base.txt


### PR DESCRIPTION
## Description

Converted all `.format()` strings, and upgraded pylint + related packages. This should resolve the pylint errors found in https://github.com/edx/registrar/pull/443