### PR TITLE
fix: Update the link of the confluence document detailing enrollment integration architecture

### DIFF
--- a/docs/decisions/0002-program-enrollment-storage.rst
+++ b/docs/decisions/0002-program-enrollment-storage.rst
@@ -72,4 +72,4 @@ Consequences
 Notes
 -----
 
-For a deeper delve into the process that lead to this decision, see: https://openedx.atlassian.net/wiki/spaces/MS/pages/952762735/Master+s+Architectural+Review
+For a deeper delve into the process that lead to this decision, see: https://openedx.atlassian.net/wiki/spaces/AC/pages/3345121583/Master+s+Enrollment+Integration+Architectural+Review


### PR DESCRIPTION
## Description

The link associated with the architecture decision of program enrollment storage to the confluence page should be updated to a confluence space which is visible to the public.