### PR TITLE
fix: remove newrelic from make file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,17 +174,13 @@ validate_translations: fake_translations detect_changed_source_translations ## i
 
 docker_build:
 	docker build . --target app -t "openedx/registrar:latest"
-	docker build . --target newrelic -t "openedx/registrar:latest-newrelic"
 
 docker_auth:
 	echo "$$DOCKERHUB_PASSWORD" | docker login -u "$$DOCKERHUB_USERNAME" --password-stdin
 
 docker_tag: docker_build
 	docker build . --target app -t "openedx/registrar:${GITHUB_SHA}"
-	docker build . --target newrelic -t "openedx/registrar:${GITHUB_SHA}-newrelic"
 
 docker_push: docker_tag docker_auth ## push to docker hub
 	docker push "openedx/registrar:latest"
 	docker push "openedx/registrar:${GITHUB_SHA}"
-	docker push "openedx/registrar:latest-newrelic"
-	docker push "openedx/registrar:${GITHUB_SHA}-newrelic"


### PR DESCRIPTION
## Description
I noticed that this [github action failed](https://github.com/openedx/registrar/runs/5819036781?check_suite_focus=true) and I presume that because the new relic portion was removed in https://github.com/openedx/registrar/pull/458, then the references to new relic have to be removed in the make file as well. 

TODO: Include a detailed description of the changes in the body of the PR
