### PR TITLE
fix: log to console for registrar k8s app

### DIFF
--- a/registrar/settings/utils.py
+++ b/registrar/settings/utils.py
@@ -45,10 +45,7 @@ def get_logger_config(log_dir='/var/tmp',
         logging_env=logging_env, hostname=hostname
     )
 
-    if debug:
-        handlers = ['console']
-    else:
-        handlers = ['local']
+    handlers = ['console']
 
     logger_config = {
         'version': 1,


### PR DESCRIPTION
## Issue: [PSRE-1654](https://2u-internal.atlassian.net/browse/PSRE-1654)
## Description

This PR will print application log messages to the console for the registrar app running inside k8s and will fix the issue of the local file handler as default it is trying to send messages to the local file on registrar containers in Kubernetes https://github.com/openedx/registrar/blob/ff703e2a05fa9dc95bd70a0f2706d9df618fb069/registrar/settings/utils.py#L48
