### PR TITLE
chore: remove preload_app setting from docker_gunicorn_configuration.py

### DIFF
--- a/registrar/docker_gunicorn_configuration.py
+++ b/registrar/docker_gunicorn_configuration.py
@@ -4,7 +4,6 @@ gunicorn configuration file: http://docs.gunicorn.org/en/develop/configure.html
 import multiprocessing  # pylint: disable=unused-import
 
 
-preload_app = True
 timeout = 300
 bind = "0.0.0.0:18734"
 workers = 2


### PR DESCRIPTION
## Description

I am working to resolve the Registrar's app latency issue in EKS and I've updated the worker class for Gunicorn to use gevent for registrar containers in EKS ( https://github.com/edx/edx-internal/pull/7230/files ). 
Setting `preload_app = True` is incompatible with worker class `gevent` and breaking the OAuth of the registrar app in EKS.

Registrar service on EC2 instances is running with worker class `gevent` and with preload default option which is false.

Ticket: https://2u-internal.atlassian.net/browse/PSRE-1927


