### PR TITLE
chore: Switch from edx-sphinx-theme to sphinx-book-theme

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,14 +11,13 @@
 # serve to show the default.
 
 import os
-import edx_theme
 
 # If you wish to publish docs to readthedocs.org you'll need to make sure to
 # follow the steps here:
 # https://edx-sphinx-theme.readthedocs.io/en/latest/readme.html#read-the-docs-configuration
 
-html_theme = 'edx_theme'
-html_theme_path = [edx_theme.get_html_theme_path()]
+html_theme = 'sphinx_book_theme'
+# html_theme_path = []
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -32,7 +31,7 @@ html_theme_path = [edx_theme.get_html_theme_path()]
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['edx_theme']
+extensions = []
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -104,7 +103,37 @@ pygments_style = 'sphinx'
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-# html_theme_options = {}
+html_theme_options = {
+ "repository_url": "https://github.com/openedx/registrar",
+ "repository_branch": "master",
+ "path_to_docs": "docs/",
+ "home_page_in_toc": True,
+ "use_repository_button": True,
+ "use_issues_button": True,
+ "use_edit_page_button": True,
+ # Please don't change unless you know what you're doing.
+ "extra_footer": """
+        <a rel="license" href="https://creativecommons.org/licenses/by-sa/4.0/">
+            <img
+                alt="Creative Commons License"
+                style="border-width:0"
+                src="https://i.creativecommons.org/l/by-sa/4.0/80x15.png"/>
+        </a>
+        <br>
+        These works by
+            <a
+                xmlns:cc="https://creativecommons.org/ns#"
+                href="https://openedx.org"
+                property="cc:attributionName"
+                rel="cc:attributionURL"
+            >Axim Collaborative, Inc</a>
+        are licensed under a
+            <a
+                rel="license"
+                href="https://creativecommons.org/licenses/by-sa/4.0/"
+            >Creative Commons Attribution-ShareAlike 4.0 International License</a>.
+    """
+}
 
 # Add any paths that contain custom themes here, relative to this directory.
 # html_theme_path = []
@@ -118,12 +147,12 @@ pygments_style = 'sphinx'
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
-# html_logo = None
+html_logo = "https://logos.openedx.org/open-edx-logo-color.png"
 
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
-html_favicon = os.path.join(html_theme_path[0], 'edx_theme', 'static', 'css', 'favicon.ico')
+html_favicon = "https://logos.openedx.org/open-edx-favicon.ico"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -1,8 +1,4 @@
-# This is a temporary solution to override the real common_constraints.txt
-# In edx-lint, until the pyjwt constraint in edx-lint has been removed.
-# See BOM-2721 for more details.
-# Below is the copied and edited version of common_constraints
-
+# This is a temporary solution to override the real common_constraints.txt\n# In edx-lint, until the pyjwt constraint in edx-lint has been removed.\n# See BOM-2721 for more details.\n# Below is the copied and edited version of common_constraints\n
 # A central location for most common version constraints
 # (across edx repos) for pip-installation.
 #

--- a/requirements/devstack.txt
+++ b/requirements/devstack.txt
@@ -4,6 +4,10 @@
 #
 #    make upgrade
 #
+accessible-pygments==0.0.4
+    # via
+    #   -r requirements/local.txt
+    #   pydata-sphinx-theme
 alabaster==0.7.13
     # via
     #   -r requirements/local.txt
@@ -30,11 +34,16 @@ async-timeout==4.0.2
 babel==2.12.1
     # via
     #   -r requirements/local.txt
+    #   pydata-sphinx-theme
     #   sphinx
 backoff==1.10.0
     # via
     #   -r requirements/local.txt
     #   analytics-python
+beautifulsoup4==4.12.2
+    # via
+    #   -r requirements/local.txt
+    #   pydata-sphinx-theme
 billiard==3.6.4.0
     # via
     #   -r requirements/local.txt
@@ -194,6 +203,7 @@ djangorestframework==3.14.0
 docutils==0.19
     # via
     #   -r requirements/local.txt
+    #   pydata-sphinx-theme
     #   sphinx
 drf-jwt==1.19.2
     # via
@@ -225,8 +235,6 @@ edx-opaque-keys==2.3.0
     #   -r requirements/local.txt
     #   edx-drf-extensions
 edx-rest-api-client==5.5.0
-    # via -r requirements/local.txt
-edx-sphinx-theme==3.1.0
     # via -r requirements/local.txt
 exceptiongroup==1.1.1
     # via
@@ -332,6 +340,7 @@ packaging==23.1
     # via
     #   -r requirements/local.txt
     #   drf-yasg
+    #   pydata-sphinx-theme
     #   pytest
     #   sphinx
     #   tox
@@ -379,9 +388,15 @@ pycryptodomex==3.17
     # via
     #   -r requirements/local.txt
     #   pyjwkest
+pydata-sphinx-theme==0.13.3
+    # via
+    #   -r requirements/local.txt
+    #   sphinx-book-theme
 pygments==2.15.1
     # via
     #   -r requirements/local.txt
+    #   accessible-pygments
+    #   pydata-sphinx-theme
     #   sphinx
 pyjwkest==1.4.2
     # via
@@ -535,7 +550,6 @@ six==1.16.0
     #   edx-django-release-util
     #   edx-drf-extensions
     #   edx-lint
-    #   edx-sphinx-theme
     #   pyjwkest
     #   python-dateutil
     #   python-memcached
@@ -558,11 +572,18 @@ social-auth-core==4.4.2
     #   -r requirements/local.txt
     #   edx-auth-backends
     #   social-auth-app-django
+soupsieve==2.4.1
+    # via
+    #   -r requirements/local.txt
+    #   beautifulsoup4
 sphinx==5.3.0
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/local.txt
-    #   edx-sphinx-theme
+    #   pydata-sphinx-theme
+    #   sphinx-book-theme
+sphinx-book-theme==1.0.1
+    # via -r requirements/local.txt
 sphinxcontrib-applehelp==1.0.4
     # via
     #   -r requirements/local.txt
@@ -621,6 +642,7 @@ typing-extensions==4.5.0
     # via
     #   -r requirements/local.txt
     #   astroid
+    #   pydata-sphinx-theme
     #   pylint
 uritemplate==4.1.1
     # via

--- a/requirements/docs.in
+++ b/requirements/docs.in
@@ -1,4 +1,4 @@
 -c constraints.txt
 
 Sphinx
-edx-sphinx-theme
+sphinx-book-theme

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -4,18 +4,24 @@
 #
 #    make upgrade
 #
+accessible-pygments==0.0.4
+    # via pydata-sphinx-theme
 alabaster==0.7.13
     # via sphinx
 babel==2.12.1
-    # via sphinx
+    # via
+    #   pydata-sphinx-theme
+    #   sphinx
+beautifulsoup4==4.12.2
+    # via pydata-sphinx-theme
 certifi==2022.12.7
     # via requests
 charset-normalizer==3.1.0
     # via requests
 docutils==0.19
-    # via sphinx
-edx-sphinx-theme==3.1.0
-    # via -r requirements/docs.in
+    # via
+    #   pydata-sphinx-theme
+    #   sphinx
 idna==3.4
     # via requests
 imagesize==1.4.1
@@ -27,22 +33,32 @@ jinja2==3.1.2
 markupsafe==2.1.2
     # via jinja2
 packaging==23.1
-    # via sphinx
+    # via
+    #   pydata-sphinx-theme
+    #   sphinx
+pydata-sphinx-theme==0.13.3
+    # via sphinx-book-theme
 pygments==2.15.1
-    # via sphinx
+    # via
+    #   accessible-pygments
+    #   pydata-sphinx-theme
+    #   sphinx
 pytz==2023.3
     # via babel
 requests==2.28.2
     # via sphinx
-six==1.16.0
-    # via edx-sphinx-theme
 snowballstemmer==2.2.0
     # via sphinx
+soupsieve==2.4.1
+    # via beautifulsoup4
 sphinx==5.3.0
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/docs.in
-    #   edx-sphinx-theme
+    #   pydata-sphinx-theme
+    #   sphinx-book-theme
+sphinx-book-theme==1.0.1
+    # via -r requirements/docs.in
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
@@ -55,6 +71,8 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
+typing-extensions==4.5.0
+    # via pydata-sphinx-theme
 urllib3==1.26.15
     # via requests
 zipp==3.15.0

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -4,6 +4,10 @@
 #
 #    make upgrade
 #
+accessible-pygments==0.0.4
+    # via
+    #   -r requirements/docs.txt
+    #   pydata-sphinx-theme
 alabaster==0.7.13
     # via
     #   -r requirements/docs.txt
@@ -30,11 +34,16 @@ async-timeout==4.0.2
 babel==2.12.1
     # via
     #   -r requirements/docs.txt
+    #   pydata-sphinx-theme
     #   sphinx
 backoff==1.10.0
     # via
     #   -r requirements/test.txt
     #   analytics-python
+beautifulsoup4==4.12.2
+    # via
+    #   -r requirements/docs.txt
+    #   pydata-sphinx-theme
 billiard==3.6.4.0
     # via
     #   -r requirements/test.txt
@@ -194,6 +203,7 @@ djangorestframework==3.14.0
 docutils==0.19
     # via
     #   -r requirements/docs.txt
+    #   pydata-sphinx-theme
     #   sphinx
 drf-jwt==1.19.2
     # via
@@ -226,8 +236,6 @@ edx-opaque-keys==2.3.0
     #   edx-drf-extensions
 edx-rest-api-client==5.5.0
     # via -r requirements/test.txt
-edx-sphinx-theme==3.1.0
-    # via -r requirements/docs.txt
 exceptiongroup==1.1.1
     # via
     #   -r requirements/test.txt
@@ -332,6 +340,7 @@ packaging==23.1
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   drf-yasg
+    #   pydata-sphinx-theme
     #   pytest
     #   sphinx
     #   tox
@@ -375,9 +384,15 @@ pycryptodomex==3.17
     # via
     #   -r requirements/test.txt
     #   pyjwkest
+pydata-sphinx-theme==0.13.3
+    # via
+    #   -r requirements/docs.txt
+    #   sphinx-book-theme
 pygments==2.15.1
     # via
     #   -r requirements/docs.txt
+    #   accessible-pygments
+    #   pydata-sphinx-theme
     #   sphinx
 pyjwkest==1.4.2
     # via
@@ -518,7 +533,6 @@ semantic-version==2.10.0
     #   edx-drf-extensions
 six==1.16.0
     # via
-    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   analytics-python
     #   configobj
@@ -527,7 +541,6 @@ six==1.16.0
     #   edx-django-release-util
     #   edx-drf-extensions
     #   edx-lint
-    #   edx-sphinx-theme
     #   pyjwkest
     #   python-dateutil
     #   responses
@@ -549,11 +562,18 @@ social-auth-core==4.4.2
     #   -r requirements/test.txt
     #   edx-auth-backends
     #   social-auth-app-django
+soupsieve==2.4.1
+    # via
+    #   -r requirements/docs.txt
+    #   beautifulsoup4
 sphinx==5.3.0
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/docs.txt
-    #   edx-sphinx-theme
+    #   pydata-sphinx-theme
+    #   sphinx-book-theme
+sphinx-book-theme==1.0.1
+    # via -r requirements/docs.txt
 sphinxcontrib-applehelp==1.0.4
     # via
     #   -r requirements/docs.txt
@@ -610,8 +630,10 @@ tox==3.28.0
     #   -r requirements/test.txt
 typing-extensions==4.5.0
     # via
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   astroid
+    #   pydata-sphinx-theme
     #   pylint
 uritemplate==4.1.1
     # via

--- a/requirements/monitoring/requirements.txt
+++ b/requirements/monitoring/requirements.txt
@@ -4,6 +4,11 @@
 #
 #    make upgrade
 #
+accessible-pygments==0.0.4
+    # via
+    #   -r requirements/monitoring/../devstack.txt
+    #   -r requirements/monitoring/../local.txt
+    #   pydata-sphinx-theme
 alabaster==0.7.13
     # via
     #   -r requirements/monitoring/../devstack.txt
@@ -47,6 +52,7 @@ babel==2.12.1
     # via
     #   -r requirements/monitoring/../devstack.txt
     #   -r requirements/monitoring/../local.txt
+    #   pydata-sphinx-theme
     #   sphinx
 backoff==1.10.0
     # via
@@ -55,6 +61,11 @@ backoff==1.10.0
     #   -r requirements/monitoring/../production.txt
     #   -r requirements/monitoring/../test.txt
     #   analytics-python
+beautifulsoup4==4.12.2
+    # via
+    #   -r requirements/monitoring/../devstack.txt
+    #   -r requirements/monitoring/../local.txt
+    #   pydata-sphinx-theme
 billiard==3.6.4.0
     # via
     #   -r requirements/monitoring/../devstack.txt
@@ -302,6 +313,7 @@ docutils==0.19
     # via
     #   -r requirements/monitoring/../devstack.txt
     #   -r requirements/monitoring/../local.txt
+    #   pydata-sphinx-theme
     #   sphinx
 drf-jwt==1.19.2
     # via
@@ -371,10 +383,6 @@ edx-rest-api-client==5.5.0
     #   -r requirements/monitoring/../local.txt
     #   -r requirements/monitoring/../production.txt
     #   -r requirements/monitoring/../test.txt
-edx-sphinx-theme==3.1.0
-    # via
-    #   -r requirements/monitoring/../devstack.txt
-    #   -r requirements/monitoring/../local.txt
 exceptiongroup==1.1.1
     # via
     #   -r requirements/monitoring/../devstack.txt
@@ -551,6 +559,7 @@ packaging==23.1
     #   -r requirements/monitoring/../production.txt
     #   -r requirements/monitoring/../test.txt
     #   drf-yasg
+    #   pydata-sphinx-theme
     #   pytest
     #   sphinx
     #   tox
@@ -623,10 +632,17 @@ pycryptodomex==3.17
     #   -r requirements/monitoring/../production.txt
     #   -r requirements/monitoring/../test.txt
     #   pyjwkest
+pydata-sphinx-theme==0.13.3
+    # via
+    #   -r requirements/monitoring/../devstack.txt
+    #   -r requirements/monitoring/../local.txt
+    #   sphinx-book-theme
 pygments==2.15.1
     # via
     #   -r requirements/monitoring/../devstack.txt
     #   -r requirements/monitoring/../local.txt
+    #   accessible-pygments
+    #   pydata-sphinx-theme
     #   sphinx
 pyjwkest==1.4.2
     # via
@@ -854,7 +870,6 @@ six==1.16.0
     #   edx-django-release-util
     #   edx-drf-extensions
     #   edx-lint
-    #   edx-sphinx-theme
     #   pyjwkest
     #   python-dateutil
     #   python-memcached
@@ -887,11 +902,21 @@ social-auth-core==4.4.2
     #   -r requirements/monitoring/../test.txt
     #   edx-auth-backends
     #   social-auth-app-django
+soupsieve==2.4.1
+    # via
+    #   -r requirements/monitoring/../devstack.txt
+    #   -r requirements/monitoring/../local.txt
+    #   beautifulsoup4
 sphinx==5.3.0
     # via
     #   -r requirements/monitoring/../devstack.txt
     #   -r requirements/monitoring/../local.txt
-    #   edx-sphinx-theme
+    #   pydata-sphinx-theme
+    #   sphinx-book-theme
+sphinx-book-theme==1.0.1
+    # via
+    #   -r requirements/monitoring/../devstack.txt
+    #   -r requirements/monitoring/../local.txt
 sphinxcontrib-applehelp==1.0.4
     # via
     #   -r requirements/monitoring/../devstack.txt
@@ -971,6 +996,7 @@ typing-extensions==4.5.0
     #   -r requirements/monitoring/../local.txt
     #   -r requirements/monitoring/../test.txt
     #   astroid
+    #   pydata-sphinx-theme
     #   pylint
 uritemplate==4.1.1
     # via


### PR DESCRIPTION
The edx-sphinx theme is being deprecated, and replaced with sphinx-book-theme. This removes references to the deprecated theme and replaces them with the new standard theme for the platform.

**Testing instructions:**
- Run `make docs` and see that the docs are generated properly and use the sphinx-book-theme

See https://github.com/openedx/public-engineering/issues/200