### PR TITLE
fix: trigger docker push workflow on open release branches

### DIFF
--- a/.github/workflows/push-docker-images.yml
+++ b/.github/workflows/push-docker-images.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches:
       - master
-    tags:
       - open-release/**
+
 jobs:
   push:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Currently, the workflow was not running on pushes to open-release branches so this will fix that 