### PR TITLE
feat: enable course role management for Program Console

### DIFF
--- a/registrar/apps/api/v1/views.py
+++ b/registrar/apps/api/v1/views.py
@@ -769,7 +769,6 @@ class CourseRunEnrollmentUploadView(EnrollmentMixin, CourseSpecificViewMixin, En
         """
         Get field names based on waffle flag
         """
-        # MST-190 will remove the waffle and roll out the feature to all partners.
         if waffle.flag_is_active(request, 'enable_course_role_management'):
             return {'student_key', 'course_id', 'status', 'course_staff'}
         else:
@@ -808,9 +807,11 @@ class CourseRunEnrollmentDownloadView(EnrollmentMixin, JobInvokerMixin, APIView)
         """
         Submit a user task that retrieves course run enrollment data for the given program.
         """
+        course_role_management_enabled = waffle.flag_is_active(request, 'enable_course_role_management')
         return self.invoke_download_job(
             list_all_course_run_enrollments,
             self.program.key,
+            course_role_management_enabled,
         )
 
 


### PR DESCRIPTION
## Description

JIRA: [MST-1910](https://2u-internal.atlassian.net/browse/MST-1910)

This commit enables course role management via CSV for use by the Program Console frontend application. Previously, this feature was only enabled for the Registrar REST API, which is used by program partners to manage course and program enrollments.

Now, provided that the appropriate user group is added to the `enable_course_role_management` waffle flag, any user that is a member of said user group can use the Program Console to download course enrollments and see whether enrolled learners in the course are course staff and to upload course enrollments to effect a change in a learner's course staff status.