### PR TITLE
fix: Don't make image build wait for manual config of tzdata

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:focal as app
 
 # System requirements.
 RUN apt-get update
-RUN apt-get install -qy \
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -qy \
 	git-core \
 	language-pack-en \
 	build-essential \


### PR DESCRIPTION
tzdata seems to get installed now as a dependency of pkg-config, and Debian defaults to interactive configuration. Tell it that ain't gonna happen.