### PR TITLE
build: migrate devstack cache backend to pymemcache

### DIFF
--- a/registrar/settings/devstack.py
+++ b/registrar/settings/devstack.py
@@ -16,8 +16,9 @@ CELERY_TASK_ALWAYS_EAGER = (
 
 CACHES = {
     'default': {
-        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+        'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
         'LOCATION': os.environ.get('CACHE_LOCATION', 'memcached:11211'),
+        "OPTIONS": {"no_delay": True, "ignore_exec": True, "use_pooling": True},
     }
 }
 


### PR DESCRIPTION
## Description
- Under the issue https://github.com/edx/edx-arch-experiments/issues/434, migrating the devstack cache backend from `MemcachedCache` to `PyMemcacheCache`