### PR TITLE
fix: fix devstack cache backend options parameter

### DIFF
--- a/registrar/settings/devstack.py
+++ b/registrar/settings/devstack.py
@@ -18,7 +18,7 @@ CACHES = {
     'default': {
         'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
         'LOCATION': os.environ.get('CACHE_LOCATION', 'memcached:11211'),
-        "OPTIONS": {"no_delay": True, "ignore_exec": True, "use_pooling": True},
+        "OPTIONS": {"no_delay": True, "ignore_exc": True, "use_pooling": True},
     }
 }
 


### PR DESCRIPTION
## Description
- Fixed the devstack cache backend options parameter from `ignore_exec` to `ignore_exc`. 