### PR TITLE
feat: add success log to disco sync

### DIFF
--- a/registrar/apps/core/management/commands/sync_with_discovery.py
+++ b/registrar/apps/core/management/commands/sync_with_discovery.py
@@ -37,6 +37,10 @@ class Command(BaseCommand):
         self.sync_org_groups()
         self.sync_program_org_groups()
 
+        # load bearing log message. edx.org monitors for this log message
+        # to know when the sync has run successfully
+        logger.info('Sync with Discovery Service complete!')
+
     def sync_organizations(self):
         """
         Make API call to discovery service and get latest organizations list

--- a/registrar/apps/core/management/commands/test/test_sync_with_discovery.py
+++ b/registrar/apps/core/management/commands/test/test_sync_with_discovery.py
@@ -176,6 +176,18 @@ class TestSyncOrganizationsWithDiscoveryCommand(TestSyncWithDiscoveryCommandBase
         ]
         self.assert_organizations(orgs_to_sync, 9)
 
+    def test_success_output(self):
+        orgs_to_sync = [
+            self.new_discovery_organization,
+            self.updating_discovery_organization,
+            self.discovery_other_org,
+        ]
+        self.mock_get_organizations_patcher.return_value = orgs_to_sync
+        self.mock_get_programs_by_types_patcher.return_value = []
+        with patch('registrar.apps.core.management.commands.sync_with_discovery.logger') as mock_logger:
+            call_command(self.command)
+            mock_logger.info.assert_called_with('Sync with Discovery Service complete!')
+
 
 @ddt.ddt
 class TestSyncProgramsWithDiscoveryCommand(TestSyncWithDiscoveryCommandBase):


### PR DESCRIPTION
Log a message when this job succeeds. We will use this to keep track of job successes for the purposes of alerting.

Right now we log when each component of this succeeds but not the job as a whole. This is an single point of truth to report on

2U internal alert policy: https://onenr.io/0bRmZ3gJWjy