### PR TITLE
feat: handle nonslug program keys from discovery

### DIFF
--- a/registrar/apps/core/management/commands/manage_programs.py
+++ b/registrar/apps/core/management/commands/manage_programs.py
@@ -3,6 +3,7 @@ import logging
 
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
+from slugify import slugify
 
 from registrar.apps.core.discovery_cache import ProgramDetails
 from registrar.apps.core.models import Organization, Program
@@ -89,7 +90,7 @@ class Command(BaseCommand):
             discovery_uuid=program_uuid,
             defaults={
                 'managing_organization': org,
-                'key': program_key or program_details.get('marketing_slug'),
+                'key': program_key or slugify(program_details.get('marketing_slug')),
             },
         )
         if (not created) and program_key and (program.key != program_key):

--- a/registrar/apps/core/management/commands/sync_with_discovery.py
+++ b/registrar/apps/core/management/commands/sync_with_discovery.py
@@ -3,6 +3,7 @@ import logging
 
 from django.core.management.base import BaseCommand
 from django.db import transaction
+from slugify import slugify
 
 from registrar.apps.core.api_client import DiscoveryServiceClient
 from registrar.apps.core.models import (
@@ -127,14 +128,16 @@ class Command(BaseCommand):
                 if discovery_authoring_org:
                     auth_org = existing_org_dictionary.get(discovery_authoring_org.get('uuid'))
                 if auth_org:
+                    # key fromd disco is not guarenteed to be a valid slugfield
+                    program_key = slugify(discovery_program.get('marketing_slug'))
                     programs_to_create.append(Program(
                         discovery_uuid=discovery_program.get('uuid'),
                         managing_organization=auth_org,
-                        key=discovery_program.get('marketing_slug'),
+                        key=program_key,
                     ))
                     logger.info(
                         'Creating %s with uuid %s',
-                        discovery_program.get('marketing_slug'),
+                        program_key,
                         discovery_authoring_org.get('uuid')
                     )
 

--- a/registrar/apps/core/management/commands/test/test_manage_programs.py
+++ b/registrar/apps/core/management/commands/test/test_manage_programs.py
@@ -86,6 +86,23 @@ class TestManagePrograms(TestCase):
         )
         self.assert_program(self.arabic_uuid, 'masters-in-arabic', self.org)
 
+    def test_create_program_discovery_nonslug_key(self):
+        """
+        Discovery program with a key that is not a valid SlugField
+        should be slugified on create
+        """
+        self.mock_get_discovery_program.return_value = self.discovery_dict(
+            self.org.key,
+            self.arabic_uuid,
+            'nonslug/marketing/key-format',
+        )
+        self.assert_program_nonexistant(self.arabic_uuid)
+        call_command(
+            self.command,
+            self.arabic_uuid,
+        )
+        self.assert_program(self.arabic_uuid, 'nonslug-marketing-key-format', self.org)
+
     def test_create_program_no_key(self):
         self.mock_get_discovery_program.return_value = self.arabic_discovery_program
         self.assert_program_nonexistant(self.arabic_uuid)

--- a/registrar/apps/core/management/commands/test/test_sync_with_discovery.py
+++ b/registrar/apps/core/management/commands/test/test_sync_with_discovery.py
@@ -299,6 +299,20 @@ class TestSyncProgramsWithDiscoveryCommand(TestSyncWithDiscoveryCommandBase):
 
         self.assert_programs(programs_to_sync, 42)
 
+    def test_sync_programs_create_with_non_slug_marketing_slug(self):
+        """ Discovery keys that are not valid slugs should be slugified """
+        discovery_program = self.discovery_program_dict(
+            self.org.discovery_uuid,
+            '77777777-2222-3333-4444-555555555555',
+            'marketing/path/non-slug',
+        )
+        programs_to_sync = [
+            discovery_program,
+        ]
+        self.assert_programs(programs_to_sync, 26)
+        created_program = Program.objects.get(discovery_uuid=discovery_program['uuid'])
+        self.assertEqual(created_program.key, 'marketing-path-non-slug')
+
     def test_sync_programs_with_different_slugs(self):
         updated_discovery_program = self.discovery_program_dict(
             self.german_program.managing_organization.discovery_uuid,


### PR DESCRIPTION
## Description

This [Discovery ADR](https://github.com/openedx/course-discovery/blob/ef5f9dcb3713d99d8ebf081346c29d1b72bb80e7/docs/decisions/0023-url-restructuring-for-seo-improvements.rst) changed the way Program marketing slugs are generated such that they are no longer guaranteed to be a valid SlugField which makes them unsafe to use as url tokens. Because Registrar supports these values deviating from the source in discovery we're able to translate any non-slug values to something that will work with Registrar and any UI's that rely on it (Program Console + Learner Portal).

This change will only impact new programs moving forward since we do not modify a programs key after a record with that UUID has been synced. This is done to support custom external keys for partners that need a specific value and works to our benefit here.

## 2U-Internal Ticket: [COSMO-185](https://2u-internal.atlassian.net/browse/COSMO-185?atlOrigin=eyJpIjoiNWZkNTFjYjFiOTg2NDE1NWIzMmIyMzMwY2I1Yjg4MzMiLCJwIjoiaiJ9)
