### PR TITLE
fix: reduce length of program name

### DIFF
--- a/registrar/apps/core/management/commands/sync_with_discovery.py
+++ b/registrar/apps/core/management/commands/sync_with_discovery.py
@@ -128,8 +128,13 @@ class Command(BaseCommand):
                 if discovery_authoring_org:
                     auth_org = existing_org_dictionary.get(discovery_authoring_org.get('uuid'))
                 if auth_org:
-                    # key fromd disco is not guarenteed to be a valid slugfield
-                    program_key = slugify(discovery_program.get('marketing_slug'))
+                    # key from disco is not guaranteed to be a valid slugfield.
+                    # The current key pattern in disco looks something like /masters/program/name-of-the-program,
+                    # so we should only use the piece of the marketing slug that contains the name of the program.
+                    program_key = slugify(
+                        discovery_program.get('marketing_slug').split('/')[-1],
+                        max_length=100,
+                    )
                     programs_to_create.append(Program(
                         discovery_uuid=discovery_program.get('uuid'),
                         managing_organization=auth_org,


### PR DESCRIPTION
## [COSMO-217](https://2u-internal.atlassian.net/browse/COSMO-217)

The `marketing_slug` field from discovery has a maximum length of 255 characters, and the strings being used for that field are following a new pattern that looks something like `/masters/online-masters-in-analytics/online-masters-in-data-analytics/university-of-edx-master-of-science-business-in-data-insights-and-analytics`, as opposed to the old style of slug, which looked more like `university-of-edx-master-of-science-business-in-data-insights-and-analytics`. 

The additional length for these slugs is causing downstream issues in registrar, because the program key is used in the ProgramOrganizationGroup `name` field, which has a maximum character length of `150`. 

By splitting the marketing slug field and only taking the last index, we should be able to reduce the length of the program key, which should prevent any errors from occurring while trying to generate a new ProgramOrganizationGroup name.