### PR TITLE
fix: import base to docs reqs

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -141,7 +141,7 @@ edx-drf-extensions==10.3.0
     # via -r requirements/base.in
 edx-opaque-keys==2.10.0
     # via edx-drf-extensions
-edx-rest-api-client==5.6.1
+edx-rest-api-client==5.7.0
     # via -r requirements/base.in
 idna==3.7
     # via requests
@@ -200,9 +200,8 @@ pyyaml==6.0.1
     #   edx-django-release-util
 redis==5.0.6
     # via -r requirements/base.in
-requests==2.32.3
+requests==2.31.0
     # via
-    #   -c requirements/constraints.txt
     #   analytics-python
     #   edx-drf-extensions
     #   edx-rest-api-client

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -48,8 +48,3 @@ wrapt < 1.14.0
 
 # At the time of adding this, the moto version 4.1.9 requires urllib3<1.27,>=1.25.4
 urllib3<1.27,>=1.25.4
-
-# Constrain requests upgrade to be the latest version of later.
-# For some reason v2.31.0 and v2.32.3 (which is the latest version as of this writing) were installed at the same time
-# This caused a version error. This constraint may be removed later if this causes issues or is no longer needed. 
-requests>=2.32.3

--- a/requirements/devstack.txt
+++ b/requirements/devstack.txt
@@ -266,7 +266,7 @@ edx-opaque-keys==2.10.0
     # via
     #   -r requirements/local.txt
     #   edx-drf-extensions
-edx-rest-api-client==5.6.1
+edx-rest-api-client==5.7.0
     # via -r requirements/local.txt
 exceptiongroup==1.2.1
     # via
@@ -514,9 +514,8 @@ pyyaml==6.0.1
     #   yamllint
 redis==5.0.6
     # via -r requirements/local.txt
-requests==2.32.3
+requests==2.31.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/local.txt
     #   analytics-python
     #   edx-drf-extensions

--- a/requirements/docs.in
+++ b/requirements/docs.in
@@ -1,4 +1,6 @@
 -c constraints.txt
 
+-r base.txt
+
 Sphinx
 sphinx-book-theme

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -8,36 +8,247 @@ accessible-pygments==0.0.4
     # via pydata-sphinx-theme
 alabaster==0.7.13
     # via sphinx
+amqp==5.2.0
+    # via
+    #   -r requirements/base.txt
+    #   kombu
+analytics-python==1.4.post1
+    # via -r requirements/base.txt
+asgiref==3.8.1
+    # via
+    #   -r requirements/base.txt
+    #   django
+    #   django-cors-headers
+async-timeout==4.0.3
+    # via
+    #   -r requirements/base.txt
+    #   redis
 babel==2.15.0
     # via
     #   pydata-sphinx-theme
     #   sphinx
+backoff==1.10.0
+    # via
+    #   -r requirements/base.txt
+    #   analytics-python
+backports-zoneinfo[tzdata]==0.2.1
+    # via
+    #   -r requirements/base.txt
+    #   celery
+    #   django
+    #   djangorestframework
+    #   kombu
 beautifulsoup4==4.12.3
     # via pydata-sphinx-theme
+billiard==4.2.0
+    # via
+    #   -r requirements/base.txt
+    #   celery
+celery==5.4.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   django-user-tasks
 certifi==2024.6.2
-    # via requests
+    # via
+    #   -r requirements/base.txt
+    #   requests
+cffi==1.16.0
+    # via
+    #   -r requirements/base.txt
+    #   cryptography
+    #   pynacl
 charset-normalizer==3.3.2
-    # via requests
+    # via
+    #   -r requirements/base.txt
+    #   requests
+click==8.1.7
+    # via
+    #   -r requirements/base.txt
+    #   celery
+    #   click-didyoumean
+    #   click-plugins
+    #   click-repl
+    #   edx-django-utils
+click-didyoumean==0.3.1
+    # via
+    #   -r requirements/base.txt
+    #   celery
+click-plugins==1.1.1
+    # via
+    #   -r requirements/base.txt
+    #   celery
+click-repl==0.3.0
+    # via
+    #   -r requirements/base.txt
+    #   celery
+cryptography==42.0.8
+    # via
+    #   -r requirements/base.txt
+    #   pyjwt
+    #   social-auth-core
+defusedxml==0.8.0rc2
+    # via
+    #   -r requirements/base.txt
+    #   python3-openid
+    #   social-auth-core
+django==4.2.13
+    # via
+    #   -c requirements/common_constraints.txt
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   django-cors-headers
+    #   django-crum
+    #   django-extensions
+    #   django-guardian
+    #   django-model-utils
+    #   django-mysql
+    #   django-simple-history
+    #   django-storages
+    #   django-user-tasks
+    #   django-waffle
+    #   djangorestframework
+    #   drf-jwt
+    #   drf-yasg
+    #   edx-api-doc-tools
+    #   edx-auth-backends
+    #   edx-django-release-util
+    #   edx-django-utils
+    #   edx-drf-extensions
+    #   social-auth-app-django
+django-cors-headers==4.3.1
+    # via -r requirements/base.txt
+django-crum==0.7.9
+    # via
+    #   -r requirements/base.txt
+    #   edx-django-utils
+django-extensions==3.1.5
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+django-guardian==2.4.0
+    # via -r requirements/base.txt
+django-model-utils==4.5.1
+    # via
+    #   -r requirements/base.txt
+    #   django-user-tasks
+django-mysql==4.13.0
+    # via -r requirements/base.txt
+django-simple-history==3.7.0
+    # via -r requirements/base.txt
+django-storages==1.10.1
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+django-user-tasks==3.2.0
+    # via -r requirements/base.txt
+django-waffle==4.1.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-django-utils
+    #   edx-drf-extensions
+djangorestframework==3.15.1
+    # via
+    #   -r requirements/base.txt
+    #   django-user-tasks
+    #   drf-jwt
+    #   drf-yasg
+    #   edx-api-doc-tools
+    #   edx-drf-extensions
+dnspython==2.6.1
+    # via
+    #   -r requirements/base.txt
+    #   pymongo
 docutils==0.19
     # via
     #   pydata-sphinx-theme
     #   sphinx
+drf-jwt==1.19.2
+    # via
+    #   -r requirements/base.txt
+    #   edx-drf-extensions
+drf-yasg==1.21.7
+    # via
+    #   -r requirements/base.txt
+    #   django-user-tasks
+    #   edx-api-doc-tools
+edx-api-doc-tools==1.8.0
+    # via -r requirements/base.txt
+edx-auth-backends==4.3.0
+    # via -r requirements/base.txt
+edx-django-release-util==1.4.0
+    # via -r requirements/base.txt
+edx-django-utils==5.14.2
+    # via
+    #   -r requirements/base.txt
+    #   edx-drf-extensions
+    #   edx-rest-api-client
+edx-drf-extensions==10.3.0
+    # via -r requirements/base.txt
+edx-opaque-keys==2.10.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-drf-extensions
+edx-rest-api-client==5.7.0
+    # via -r requirements/base.txt
 idna==3.7
-    # via requests
+    # via
+    #   -r requirements/base.txt
+    #   requests
 imagesize==1.4.1
     # via sphinx
 importlib-metadata==6.11.0
     # via
     #   -c requirements/common_constraints.txt
     #   sphinx
+inflection==0.5.1
+    # via
+    #   -r requirements/base.txt
+    #   drf-yasg
 jinja2==3.1.4
     # via sphinx
+kombu==5.3.7
+    # via
+    #   -r requirements/base.txt
+    #   celery
 markupsafe==2.1.5
     # via jinja2
+monotonic==1.6
+    # via
+    #   -r requirements/base.txt
+    #   analytics-python
+newrelic==5.24.0.153
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   edx-django-utils
+oauthlib==3.2.2
+    # via
+    #   -r requirements/base.txt
+    #   requests-oauthlib
+    #   social-auth-core
 packaging==24.1
     # via
+    #   -r requirements/base.txt
+    #   drf-yasg
     #   pydata-sphinx-theme
     #   sphinx
+pbr==6.0.0
+    # via
+    #   -r requirements/base.txt
+    #   stevedore
+prompt-toolkit==3.0.47
+    # via
+    #   -r requirements/base.txt
+    #   click-repl
+psutil==5.9.8
+    # via
+    #   -r requirements/base.txt
+    #   edx-django-utils
+pycparser==2.22
+    # via
+    #   -r requirements/base.txt
+    #   cffi
 pydata-sphinx-theme==0.14.4
     # via sphinx-book-theme
 pygments==2.18.0
@@ -45,14 +256,87 @@ pygments==2.18.0
     #   accessible-pygments
     #   pydata-sphinx-theme
     #   sphinx
-pytz==2024.1
-    # via babel
-requests==2.32.3
+pyjwt[crypto]==2.8.0
+    # via
+    #   -r requirements/base.txt
+    #   drf-jwt
+    #   edx-auth-backends
+    #   edx-drf-extensions
+    #   edx-rest-api-client
+    #   social-auth-core
+pymongo==4.7.3
+    # via
+    #   -r requirements/base.txt
+    #   edx-opaque-keys
+pynacl==1.5.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-django-utils
+python-dateutil==2.9.0.post0
+    # via
+    #   -r requirements/base.txt
+    #   analytics-python
+    #   celery
+python-slugify==4.0.1
     # via
     #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+python3-openid==3.2.0
+    # via
+    #   -r requirements/base.txt
+    #   social-auth-core
+pytz==2024.1
+    # via
+    #   -r requirements/base.txt
+    #   babel
+    #   drf-yasg
+pyyaml==6.0.1
+    # via
+    #   -r requirements/base.txt
+    #   drf-yasg
+    #   edx-django-release-util
+redis==5.0.6
+    # via -r requirements/base.txt
+requests==2.31.0
+    # via
+    #   -r requirements/base.txt
+    #   analytics-python
+    #   edx-drf-extensions
+    #   edx-rest-api-client
+    #   requests-oauthlib
+    #   slumber
+    #   social-auth-core
     #   sphinx
+requests-oauthlib==2.0.0
+    # via
+    #   -r requirements/base.txt
+    #   social-auth-core
+semantic-version==2.10.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-drf-extensions
+six==1.16.0
+    # via
+    #   -r requirements/base.txt
+    #   analytics-python
+    #   edx-auth-backends
+    #   edx-django-release-util
+    #   python-dateutil
+slumber==0.7.1
+    # via
+    #   -r requirements/base.txt
+    #   edx-rest-api-client
 snowballstemmer==2.2.0
     # via sphinx
+social-auth-app-django==5.4.1
+    # via
+    #   -r requirements/base.txt
+    #   edx-auth-backends
+social-auth-core==4.5.4
+    # via
+    #   -r requirements/base.txt
+    #   edx-auth-backends
+    #   social-auth-app-django
 soupsieve==2.5
     # via beautifulsoup4
 sphinx==6.2.1
@@ -74,11 +358,49 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
+sqlparse==0.5.0
+    # via
+    #   -r requirements/base.txt
+    #   django
+stevedore==5.2.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-django-utils
+    #   edx-opaque-keys
+text-unidecode==1.3
+    # via
+    #   -r requirements/base.txt
+    #   python-slugify
 typing-extensions==4.12.2
-    # via pydata-sphinx-theme
+    # via
+    #   -r requirements/base.txt
+    #   asgiref
+    #   edx-opaque-keys
+    #   kombu
+    #   pydata-sphinx-theme
+tzdata==2024.1
+    # via
+    #   -r requirements/base.txt
+    #   backports-zoneinfo
+    #   celery
+uritemplate==4.1.1
+    # via
+    #   -r requirements/base.txt
+    #   drf-yasg
 urllib3==1.26.18
     # via
     #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
     #   requests
+vine==5.1.0
+    # via
+    #   -r requirements/base.txt
+    #   amqp
+    #   celery
+    #   kombu
+wcwidth==0.2.13
+    # via
+    #   -r requirements/base.txt
+    #   prompt-toolkit
 zipp==3.19.2
     # via importlib-metadata

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -14,12 +14,16 @@ alabaster==0.7.13
     #   sphinx
 amqp==5.2.0
     # via
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   kombu
 analytics-python==1.4.post1
-    # via -r requirements/test.txt
+    # via
+    #   -r requirements/docs.txt
+    #   -r requirements/test.txt
 asgiref==3.8.1
     # via
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   django
     #   django-cors-headers
@@ -30,6 +34,7 @@ astroid==3.2.2
     #   pylint-celery
 async-timeout==4.0.3
     # via
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   redis
 babel==2.15.0
@@ -39,10 +44,12 @@ babel==2.15.0
     #   sphinx
 backoff==1.10.0
     # via
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   analytics-python
 backports-zoneinfo[tzdata]==0.2.1
     # via
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   celery
     #   django
@@ -54,6 +61,7 @@ beautifulsoup4==4.12.3
     #   pydata-sphinx-theme
 billiard==4.2.0
     # via
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   celery
 boto3==1.34.126
@@ -74,6 +82,7 @@ cachetools==5.3.3
 celery==5.4.0
     # via
     #   -c requirements/constraints.txt
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   django-user-tasks
 certifi==2024.6.2
@@ -83,6 +92,7 @@ certifi==2024.6.2
     #   requests
 cffi==1.16.0
     # via
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   cryptography
     #   pynacl
@@ -97,6 +107,7 @@ charset-normalizer==3.3.2
     #   requests
 click==8.1.7
     # via
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   celery
     #   click-didyoumean
@@ -108,6 +119,7 @@ click==8.1.7
     #   edx-lint
 click-didyoumean==0.3.1
     # via
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   celery
 click-log==0.4.0
@@ -116,10 +128,12 @@ click-log==0.4.0
     #   edx-lint
 click-plugins==1.1.1
     # via
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   celery
 click-repl==0.3.0
     # via
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   celery
 code-annotations==1.8.0
@@ -139,6 +153,7 @@ coverage[toml]==7.5.3
     #   pytest-cov
 cryptography==42.0.8
     # via
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   moto
     #   pyjwt
@@ -147,6 +162,7 @@ ddt==1.7.2
     # via -r requirements/test.txt
 defusedxml==0.8.0rc2
     # via
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   python3-openid
     #   social-auth-core
@@ -162,6 +178,7 @@ django==4.2.13
     # via
     #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   django-cors-headers
     #   django-crum
@@ -185,9 +202,12 @@ django==4.2.13
     #   edx-i18n-tools
     #   social-auth-app-django
 django-cors-headers==4.3.1
-    # via -r requirements/test.txt
+    # via
+    #   -r requirements/docs.txt
+    #   -r requirements/test.txt
 django-crum==0.7.9
     # via
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   edx-django-utils
 django-debug-toolbar==4.4.2
@@ -197,30 +217,43 @@ django-dynamic-fixture==4.0.1
 django-extensions==3.1.5
     # via
     #   -c requirements/constraints.txt
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
 django-guardian==2.4.0
-    # via -r requirements/test.txt
+    # via
+    #   -r requirements/docs.txt
+    #   -r requirements/test.txt
 django-model-utils==4.5.1
     # via
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   django-user-tasks
 django-mysql==4.13.0
-    # via -r requirements/test.txt
+    # via
+    #   -r requirements/docs.txt
+    #   -r requirements/test.txt
 django-simple-history==3.7.0
-    # via -r requirements/test.txt
+    # via
+    #   -r requirements/docs.txt
+    #   -r requirements/test.txt
 django-storages==1.10.1
     # via
     #   -c requirements/constraints.txt
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
 django-user-tasks==3.2.0
-    # via -r requirements/test.txt
+    # via
+    #   -r requirements/docs.txt
+    #   -r requirements/test.txt
 django-waffle==4.1.0
     # via
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   edx-django-utils
     #   edx-drf-extensions
 djangorestframework==3.15.1
     # via
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   django-user-tasks
     #   drf-jwt
@@ -229,6 +262,7 @@ djangorestframework==3.15.1
     #   edx-drf-extensions
 dnspython==2.6.1
     # via
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   pymongo
 docutils==0.19
@@ -238,36 +272,50 @@ docutils==0.19
     #   sphinx
 drf-jwt==1.19.2
     # via
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   edx-drf-extensions
 drf-yasg==1.21.7
     # via
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   django-user-tasks
     #   edx-api-doc-tools
 edx-api-doc-tools==1.8.0
-    # via -r requirements/test.txt
+    # via
+    #   -r requirements/docs.txt
+    #   -r requirements/test.txt
 edx-auth-backends==4.3.0
-    # via -r requirements/test.txt
+    # via
+    #   -r requirements/docs.txt
+    #   -r requirements/test.txt
 edx-django-release-util==1.4.0
-    # via -r requirements/test.txt
+    # via
+    #   -r requirements/docs.txt
+    #   -r requirements/test.txt
 edx-django-utils==5.14.2
     # via
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   edx-drf-extensions
     #   edx-rest-api-client
 edx-drf-extensions==10.3.0
-    # via -r requirements/test.txt
+    # via
+    #   -r requirements/docs.txt
+    #   -r requirements/test.txt
 edx-i18n-tools==1.6.0
     # via -r requirements/local.in
 edx-lint==5.3.6
     # via -r requirements/test.txt
 edx-opaque-keys==2.10.0
     # via
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   edx-drf-extensions
-edx-rest-api-client==5.6.1
-    # via -r requirements/test.txt
+edx-rest-api-client==5.7.0
+    # via
+    #   -r requirements/docs.txt
+    #   -r requirements/test.txt
 exceptiongroup==1.2.1
     # via
     #   -r requirements/test.txt
@@ -301,6 +349,7 @@ importlib-metadata==6.11.0
     #   sphinx
 inflection==0.5.1
     # via
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   drf-yasg
 iniconfig==2.0.0
@@ -325,6 +374,7 @@ jmespath==1.0.1
     #   botocore
 kombu==5.3.7
     # via
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   celery
 lxml[html-clean,html_clean]==5.2.2
@@ -347,6 +397,7 @@ mccabe==0.7.0
     #   pylint
 monotonic==1.6
     # via
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   analytics-python
 moto==5.0.9
@@ -354,10 +405,12 @@ moto==5.0.9
 newrelic==5.24.0.153
     # via
     #   -c requirements/constraints.txt
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   edx-django-utils
 oauthlib==3.2.2
     # via
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   requests-oauthlib
     #   social-auth-core
@@ -379,6 +432,7 @@ pathspec==0.12.1
     #   yamllint
 pbr==6.0.0
     # via
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   stevedore
 platformdirs==4.2.2
@@ -396,16 +450,19 @@ polib==1.2.0
     # via edx-i18n-tools
 prompt-toolkit==3.0.47
     # via
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   click-repl
 psutil==5.9.8
     # via
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   edx-django-utils
 pycodestyle==2.11.1
     # via -r requirements/test.txt
 pycparser==2.22
     # via
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   cffi
 pydata-sphinx-theme==0.14.4
@@ -420,6 +477,7 @@ pygments==2.18.0
     #   sphinx
 pyjwt[crypto]==2.8.0
     # via
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   drf-jwt
     #   edx-auth-backends
@@ -448,10 +506,12 @@ pylint-plugin-utils==0.8.2
     #   pylint-django
 pymongo==4.7.3
     # via
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   edx-opaque-keys
 pynacl==1.5.0
     # via
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   edx-django-utils
 pyproject-api==1.6.1
@@ -469,6 +529,7 @@ pytest-django==4.8.0
     # via -r requirements/test.txt
 python-dateutil==2.9.0.post0
     # via
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   analytics-python
     #   botocore
@@ -480,10 +541,12 @@ python-dateutil==2.9.0.post0
 python-slugify==4.0.1
     # via
     #   -c requirements/constraints.txt
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   code-annotations
 python3-openid==3.2.0
     # via
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   social-auth-core
 pytz==2024.1
@@ -496,6 +559,7 @@ pywatchman==2.0.0
     # via -r requirements/local.in
 pyyaml==6.0.1
     # via
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   code-annotations
     #   drf-yasg
@@ -503,10 +567,11 @@ pyyaml==6.0.1
     #   edx-i18n-tools
     #   yamllint
 redis==5.0.6
-    # via -r requirements/test.txt
-requests==2.32.3
     # via
-    #   -c requirements/constraints.txt
+    #   -r requirements/docs.txt
+    #   -r requirements/test.txt
+requests==2.31.0
+    # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   analytics-python
@@ -520,6 +585,7 @@ requests==2.32.3
     #   sphinx
 requests-oauthlib==2.0.0
     # via
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   social-auth-core
 responses==0.17.0
@@ -546,10 +612,12 @@ s3transfer==0.10.1
     #   boto3
 semantic-version==2.10.0
     # via
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   edx-drf-extensions
 six==1.16.0
     # via
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   analytics-python
     #   configobj
@@ -560,6 +628,7 @@ six==1.16.0
     #   responses
 slumber==0.7.1
     # via
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   edx-rest-api-client
 snowballstemmer==2.2.0
@@ -568,10 +637,12 @@ snowballstemmer==2.2.0
     #   sphinx
 social-auth-app-django==5.4.1
     # via
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   edx-auth-backends
 social-auth-core==4.5.4
     # via
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   edx-auth-backends
     #   social-auth-app-django
@@ -612,17 +683,20 @@ sphinxcontrib-serializinghtml==1.1.5
     #   sphinx
 sqlparse==0.5.0
     # via
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   django
     #   django-debug-toolbar
 stevedore==5.2.0
     # via
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
 text-unidecode==1.3
     # via
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   python-slugify
 tomli==2.0.1
@@ -651,11 +725,13 @@ typing-extensions==4.12.2
     #   pylint
 tzdata==2024.1
     # via
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   backports-zoneinfo
     #   celery
 uritemplate==4.1.1
     # via
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   drf-yasg
 urllib3==1.26.18
@@ -668,6 +744,7 @@ urllib3==1.26.18
     #   responses
 vine==5.1.0
     # via
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   amqp
     #   celery
@@ -678,6 +755,7 @@ virtualenv==20.26.2
     #   tox
 wcwidth==0.2.13
     # via
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   prompt-toolkit
 werkzeug==3.0.3

--- a/requirements/monitoring/requirements.txt
+++ b/requirements/monitoring/requirements.txt
@@ -426,7 +426,7 @@ edx-opaque-keys==2.10.0
     #   -r requirements/monitoring/../production.txt
     #   -r requirements/monitoring/../test.txt
     #   edx-drf-extensions
-edx-rest-api-client==5.6.1
+edx-rest-api-client==5.7.0
     # via
     #   -r requirements/monitoring/../devstack.txt
     #   -r requirements/monitoring/../local.txt
@@ -817,7 +817,7 @@ redis==5.0.6
     #   -r requirements/monitoring/../local.txt
     #   -r requirements/monitoring/../production.txt
     #   -r requirements/monitoring/../test.txt
-requests==2.32.3
+requests==2.31.0
     # via
     #   -r requirements/monitoring/../devstack.txt
     #   -r requirements/monitoring/../local.txt

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -183,7 +183,7 @@ edx-opaque-keys==2.10.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-edx-rest-api-client==5.6.1
+edx-rest-api-client==5.7.0
     # via -r requirements/base.txt
 gevent==24.2.1
     # via -r requirements/production.in
@@ -292,9 +292,8 @@ pyyaml==6.0.1
     #   edx-django-release-util
 redis==5.0.6
     # via -r requirements/base.txt
-requests==2.32.3
+requests==2.31.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   analytics-python
     #   edx-drf-extensions

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -218,7 +218,7 @@ edx-opaque-keys==2.10.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-edx-rest-api-client==5.6.1
+edx-rest-api-client==5.7.0
     # via -r requirements/base.txt
 exceptiongroup==1.2.1
     # via pytest
@@ -390,9 +390,8 @@ pyyaml==6.0.1
     #   yamllint
 redis==5.0.6
     # via -r requirements/base.txt
-requests==2.32.3
+requests==2.31.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   analytics-python
     #   edx-drf-extensions


### PR DESCRIPTION
An improvement on this PR: https://github.com/openedx/registrar/pull/622

Previously, a version conflict between v2.31.0 and v2.32.3 of the `requests` package occurred when attempting to do python requirement upgrades. The above PR implemented a hotfix by pinning the requests version >=2.32.3, though we decided that this isn't sustainable.

The real problem seemed to be that `docs.in` never inherited requirements from `base.in`, causing the docs requirements to not account for what version of requests was being downloaded by other requirement files. This PR fixes that. 